### PR TITLE
feat(portfolio): 주식 매수 이력 관리 기능 추가

### DIFF
--- a/.claude/designs/portfolio/stock-purchase-history/examples/application-service-example.md
+++ b/.claude/designs/portfolio/stock-purchase-history/examples/application-service-example.md
@@ -1,0 +1,176 @@
+# 애플리케이션 서비스 예시
+
+## PortfolioService 변경 부분
+
+```java
+// 기존 필드에 추가
+private final StockPurchaseHistoryRepository purchaseHistoryRepository;
+
+/**
+ * 주식 항목 등록 - 최초 매수이력 자동 생성
+ */
+@Transactional
+public PortfolioItemResponse addStockItem(Long userId, String itemName,
+                                           String region, String memo,
+                                           String subType, String stockCode, String market,
+                                           String exchangeCode, String country,
+                                           Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield) {
+    // ... 기존 로직 유지 ...
+    PortfolioItem saved = portfolioItemRepository.save(item);
+
+    // 최초 매수이력 생성
+    StockPurchaseHistory history = StockPurchaseHistory.create(
+            saved.getId(), quantity, purchasePrice, LocalDate.now(), null);
+    purchaseHistoryRepository.save(history);
+
+    return PortfolioItemResponse.from(saved);
+}
+
+/**
+ * 주식 추가 매수 - 이력 저장 후 재계산
+ */
+@Transactional
+public PortfolioItemResponse addStockPurchase(Long userId, Long itemId,
+                                               Integer quantity, BigDecimal purchasePrice) {
+    PortfolioItem item = findUserItem(userId, itemId);
+
+    // 매수이력 저장
+    StockPurchaseHistory history = StockPurchaseHistory.create(
+            itemId, quantity, purchasePrice, LocalDate.now(), null);
+    purchaseHistoryRepository.save(history);
+
+    // 전체 이력 기반 재계산
+    List<StockPurchaseHistory> histories = purchaseHistoryRepository.findByPortfolioItemId(itemId);
+    item.recalculateFromPurchaseHistories(histories);
+
+    PortfolioItem saved = portfolioItemRepository.save(item);
+    return PortfolioItemResponse.from(saved);
+}
+
+/**
+ * 매수이력 조회
+ */
+public List<StockPurchaseHistoryResponse> getPurchaseHistories(Long userId, Long itemId) {
+    findUserItem(userId, itemId); // 권한 검증
+    return purchaseHistoryRepository.findByPortfolioItemId(itemId).stream()
+            .map(StockPurchaseHistoryResponse::from)
+            .collect(Collectors.toList());
+}
+
+/**
+ * 매수이력 수정 + 재계산
+ */
+@Transactional
+public PortfolioItemResponse updatePurchaseHistory(Long userId, Long itemId, Long historyId,
+                                                    Integer quantity, BigDecimal purchasePrice,
+                                                    LocalDate purchasedAt, String memo) {
+    PortfolioItem item = findUserItem(userId, itemId);
+
+    StockPurchaseHistory history = purchaseHistoryRepository.findById(historyId)
+            .orElseThrow(() -> new IllegalArgumentException("매수 이력을 찾을 수 없습니다."));
+    if (!history.getPortfolioItemId().equals(itemId)) {
+        throw new IllegalArgumentException("해당 항목의 매수 이력이 아닙니다.");
+    }
+
+    history.update(quantity, purchasePrice, purchasedAt, memo);
+    purchaseHistoryRepository.save(history);
+
+    // 전체 이력 기반 재계산
+    List<StockPurchaseHistory> histories = purchaseHistoryRepository.findByPortfolioItemId(itemId);
+    item.recalculateFromPurchaseHistories(histories);
+
+    PortfolioItem saved = portfolioItemRepository.save(item);
+    return PortfolioItemResponse.from(saved);
+}
+
+/**
+ * 매수이력 삭제 + 재계산
+ */
+@Transactional
+public PortfolioItemResponse deletePurchaseHistory(Long userId, Long itemId, Long historyId) {
+    PortfolioItem item = findUserItem(userId, itemId);
+
+    StockPurchaseHistory history = purchaseHistoryRepository.findById(historyId)
+            .orElseThrow(() -> new IllegalArgumentException("매수 이력을 찾을 수 없습니다."));
+    if (!history.getPortfolioItemId().equals(itemId)) {
+        throw new IllegalArgumentException("해당 항목의 매수 이력이 아닙니다.");
+    }
+
+    // 최소 1건 검증
+    List<StockPurchaseHistory> histories = purchaseHistoryRepository.findByPortfolioItemId(itemId);
+    if (histories.size() <= 1) {
+        throw new IllegalArgumentException("매수 이력은 최소 1건 이상이어야 합니다.");
+    }
+
+    purchaseHistoryRepository.delete(history);
+
+    // 삭제 후 남은 이력으로 재계산
+    histories.removeIf(h -> h.getId().equals(historyId));
+    item.recalculateFromPurchaseHistories(histories);
+
+    PortfolioItem saved = portfolioItemRepository.save(item);
+    return PortfolioItemResponse.from(saved);
+}
+
+/**
+ * 항목 삭제 시 매수이력도 함께 삭제 (기존 deleteItem 수정)
+ */
+@Transactional
+public void deleteItem(Long userId, Long itemId) {
+    PortfolioItem item = findUserItem(userId, itemId);
+    purchaseHistoryRepository.deleteByPortfolioItemId(itemId); // 추가
+    newsCleanupService.deleteSourceAndCleanOrphans(NewsPurpose.PORTFOLIO, item.getId());
+    portfolioItemRepository.delete(item);
+}
+```
+
+## StockPurchaseHistoryResponse
+
+```java
+package com.thlee.stock.market.stockmarket.portfolio.application.dto;
+
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.StockPurchaseHistory;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class StockPurchaseHistoryResponse {
+    private final Long id;
+    private final Long portfolioItemId;
+    private final int quantity;
+    private final BigDecimal purchasePrice;
+    private final BigDecimal totalCost;
+    private final LocalDate purchasedAt;
+    private final String memo;
+    private final LocalDateTime createdAt;
+
+    private StockPurchaseHistoryResponse(Long id, Long portfolioItemId, int quantity,
+                                          BigDecimal purchasePrice, BigDecimal totalCost,
+                                          LocalDate purchasedAt, String memo, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioItemId = portfolioItemId;
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        this.totalCost = totalCost;
+        this.purchasedAt = purchasedAt;
+        this.memo = memo;
+        this.createdAt = createdAt;
+    }
+
+    public static StockPurchaseHistoryResponse from(StockPurchaseHistory history) {
+        return new StockPurchaseHistoryResponse(
+                history.getId(),
+                history.getPortfolioItemId(),
+                history.getQuantity(),
+                history.getPurchasePrice(),
+                history.getTotalCost(),
+                history.getPurchasedAt(),
+                history.getMemo(),
+                history.getCreatedAt()
+        );
+    }
+}
+```

--- a/.claude/designs/portfolio/stock-purchase-history/examples/domain-model-example.md
+++ b/.claude/designs/portfolio/stock-purchase-history/examples/domain-model-example.md
@@ -1,0 +1,122 @@
+# 도메인 모델 예시
+
+## StockPurchaseHistory
+
+```java
+package com.thlee.stock.market.stockmarket.portfolio.domain.model;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class StockPurchaseHistory {
+    private Long id;
+    private Long portfolioItemId;
+    private int quantity;
+    private BigDecimal purchasePrice;
+    private LocalDate purchasedAt;
+    private String memo;
+    private LocalDateTime createdAt;
+
+    /**
+     * 재구성용 생성자 (Repository 조회 시)
+     */
+    public StockPurchaseHistory(Long id, Long portfolioItemId, int quantity,
+                                 BigDecimal purchasePrice, LocalDate purchasedAt,
+                                 String memo, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioItemId = portfolioItemId;
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        this.purchasedAt = purchasedAt;
+        this.memo = memo;
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * 새 매수이력 생성
+     */
+    public static StockPurchaseHistory create(Long portfolioItemId, int quantity,
+                                               BigDecimal purchasePrice, LocalDate purchasedAt,
+                                               String memo) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("매수 수량은 0보다 커야 합니다.");
+        }
+        if (purchasePrice == null || purchasePrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("매수가는 0보다 커야 합니다.");
+        }
+        return new StockPurchaseHistory(null, portfolioItemId, quantity, purchasePrice,
+                purchasedAt != null ? purchasedAt : LocalDate.now(), memo, LocalDateTime.now());
+    }
+
+    /**
+     * 매수이력 수정
+     */
+    public void update(int quantity, BigDecimal purchasePrice, LocalDate purchasedAt, String memo) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("매수 수량은 0보다 커야 합니다.");
+        }
+        if (purchasePrice == null || purchasePrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("매수가는 0보다 커야 합니다.");
+        }
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        if (purchasedAt != null) {
+            this.purchasedAt = purchasedAt;
+        }
+        this.memo = memo;
+    }
+
+    /**
+     * 이 매수건의 총 투자금액
+     */
+    public BigDecimal getTotalCost() {
+        return purchasePrice.multiply(BigDecimal.valueOf(quantity));
+    }
+}
+```
+
+## PortfolioItem 추가 메서드
+
+```java
+// PortfolioItem.java에 추가
+
+/**
+ * 매수이력 기반 수량/평균단가/투자금 재계산
+ * 이력 수정/삭제 후 호출
+ */
+public void recalculateFromPurchaseHistories(List<StockPurchaseHistory> histories) {
+    if (this.assetType != AssetType.STOCK) {
+        throw new IllegalArgumentException("주식 항목이 아닙니다.");
+    }
+    validateDetail(this.stockDetail, "stockDetail");
+    if (histories.isEmpty()) {
+        throw new IllegalArgumentException("매수 이력이 최소 1건 이상 있어야 합니다.");
+    }
+
+    int totalQuantity = 0;
+    BigDecimal totalCost = BigDecimal.ZERO;
+    for (StockPurchaseHistory h : histories) {
+        totalQuantity += h.getQuantity();
+        totalCost = totalCost.add(h.getTotalCost());
+    }
+
+    BigDecimal newAvgBuyPrice = totalCost.divide(BigDecimal.valueOf(totalQuantity), 2, RoundingMode.HALF_UP);
+
+    this.stockDetail = new StockDetail(
+            this.stockDetail.getSubType(),
+            this.stockDetail.getStockCode(),
+            this.stockDetail.getMarket(),
+            this.stockDetail.getExchangeCode(),
+            this.stockDetail.getCountry(),
+            totalQuantity,
+            newAvgBuyPrice,
+            this.stockDetail.getDividendYield()
+    );
+    this.investedAmount = calcInvestedAmount(newAvgBuyPrice, totalQuantity);
+    this.updatedAt = LocalDateTime.now();
+}
+```

--- a/.claude/designs/portfolio/stock-purchase-history/examples/frontend-example.md
+++ b/.claude/designs/portfolio/stock-purchase-history/examples/frontend-example.md
@@ -1,0 +1,181 @@
+# 프론트엔드 예시
+
+## API 클라이언트 추가 (api.js)
+
+```javascript
+// 매수이력 조회
+getPurchaseHistories(userId, itemId) {
+    return this.request('GET', `/api/portfolio/items/stock/${itemId}/purchases?userId=${userId}`);
+},
+
+// 매수이력 수정
+updatePurchaseHistory(userId, itemId, historyId, body) {
+    return this.request('PUT', `/api/portfolio/items/stock/${itemId}/purchases/${historyId}?userId=${userId}`, body);
+},
+
+// 매수이력 삭제
+deletePurchaseHistory(userId, itemId, historyId) {
+    return this.request('DELETE', `/api/portfolio/items/stock/${itemId}/purchases/${historyId}?userId=${userId}`);
+},
+```
+
+## Alpine.js 상태 추가 (app.js)
+
+```javascript
+// portfolio 객체에 추가
+purchaseHistories: [],
+editingHistory: null,
+editHistoryForm: { quantity: '', purchasePrice: '', purchasedAt: '', memo: '' },
+```
+
+## 매수이력 관련 메서드 (app.js)
+
+```javascript
+// 추가매수 모달 열 때 이력도 함께 로드
+async openPurchaseModal(item) {
+    this.portfolio.purchaseItem = item;
+    this.portfolio.purchaseForm = { quantity: '', purchasePrice: '' };
+    this.portfolio.purchaseHistories = [];
+    this.portfolio.editingHistory = null;
+    this.portfolio.showPurchaseModal = true;
+    await this.loadPurchaseHistories(item.id);
+},
+
+async loadPurchaseHistories(itemId) {
+    try {
+        this.portfolio.purchaseHistories = await API.getPurchaseHistories(this.auth.userId, itemId) || [];
+    } catch (e) {
+        console.error('매수이력 조회 실패:', e);
+        this.portfolio.purchaseHistories = [];
+    }
+},
+
+startEditHistory(history) {
+    this.portfolio.editingHistory = history.id;
+    this.portfolio.editHistoryForm = {
+        quantity: history.quantity,
+        purchasePrice: history.purchasePrice,
+        purchasedAt: history.purchasedAt || '',
+        memo: history.memo || ''
+    };
+},
+
+cancelEditHistory() {
+    this.portfolio.editingHistory = null;
+},
+
+async submitEditHistory(historyId) {
+    var form = this.portfolio.editHistoryForm;
+    var item = this.portfolio.purchaseItem;
+
+    if (!form.quantity || Number(form.quantity) <= 0) {
+        alert('수량을 입력해주세요.');
+        return;
+    }
+    if (!form.purchasePrice || Number(form.purchasePrice) <= 0) {
+        alert('매수 단가를 입력해주세요.');
+        return;
+    }
+
+    try {
+        await API.updatePurchaseHistory(this.auth.userId, item.id, historyId, {
+            quantity: Number(form.quantity),
+            purchasePrice: Number(form.purchasePrice),
+            purchasedAt: form.purchasedAt || null,
+            memo: form.memo || null
+        });
+        this.portfolio.editingHistory = null;
+        await this.loadPurchaseHistories(item.id);
+        await this.loadPortfolio();
+    } catch (e) {
+        console.error('매수이력 수정 실패:', e);
+        alert('매수이력 수정에 실패했습니다.');
+    }
+},
+
+async deleteHistory(historyId) {
+    if (!confirm('이 매수 이력을 삭제하시겠습니까?\n삭제 후 수량과 평균단가가 재계산됩니다.')) return;
+    var item = this.portfolio.purchaseItem;
+
+    try {
+        await API.deletePurchaseHistory(this.auth.userId, item.id, historyId);
+        await this.loadPurchaseHistories(item.id);
+        await this.loadPortfolio();
+    } catch (e) {
+        console.error('매수이력 삭제 실패:', e);
+        alert(e.message || '매수이력 삭제에 실패했습니다.');
+    }
+},
+```
+
+## 추가매수 모달 HTML 변경 (index.html)
+
+기존 추가매수 모달에 매수이력 목록 섹션 추가:
+
+```html
+<!-- 매수 이력 목록 (추가매수 모달 내, 현재 보유 정보 아래에 배치) -->
+<template x-if="portfolio.purchaseHistories.length > 0">
+    <div class="mt-4">
+        <h4 class="text-sm font-semibold text-gray-700 mb-2">매수 이력</h4>
+        <div class="space-y-2 max-h-48 overflow-y-auto">
+            <template x-for="h in portfolio.purchaseHistories" :key="h.id">
+                <div class="bg-gray-50 rounded-lg p-3 text-sm">
+                    <!-- 보기 모드 -->
+                    <template x-if="portfolio.editingHistory !== h.id">
+                        <div>
+                            <div class="flex justify-between items-center">
+                                <div>
+                                    <span class="font-medium text-gray-800"
+                                        x-text="Format.number(h.quantity, 0) + '주'"></span>
+                                    <span class="text-gray-500 mx-1">×</span>
+                                    <span class="text-gray-800"
+                                        x-text="Format.number(h.purchasePrice, 0) + '원'"></span>
+                                    <span class="text-gray-400 ml-2"
+                                        x-text="'= ' + Format.number(h.totalCost, 0) + '원'"></span>
+                                </div>
+                                <div class="flex gap-2">
+                                    <button @click.stop="startEditHistory(h)"
+                                        class="text-xs text-blue-600 hover:text-blue-800">수정</button>
+                                    <button x-show="portfolio.purchaseHistories.length > 1"
+                                        @click.stop="deleteHistory(h.id)"
+                                        class="text-xs text-red-500 hover:text-red-700">삭제</button>
+                                </div>
+                            </div>
+                            <div class="flex gap-3 mt-1 text-xs text-gray-400">
+                                <span x-show="h.purchasedAt" x-text="h.purchasedAt"></span>
+                                <span x-show="h.memo" x-text="h.memo"></span>
+                            </div>
+                        </div>
+                    </template>
+                    <!-- 수정 모드 -->
+                    <template x-if="portfolio.editingHistory === h.id">
+                        <div class="space-y-2">
+                            <div class="flex gap-2">
+                                <input type="number" x-model="portfolio.editHistoryForm.quantity"
+                                    placeholder="수량" min="1"
+                                    class="w-1/3 border border-gray-300 rounded px-2 py-1 text-sm">
+                                <input type="number" x-model="portfolio.editHistoryForm.purchasePrice"
+                                    placeholder="단가" min="1"
+                                    class="w-2/3 border border-gray-300 rounded px-2 py-1 text-sm">
+                            </div>
+                            <div class="flex gap-2">
+                                <input type="date" x-model="portfolio.editHistoryForm.purchasedAt"
+                                    class="w-1/2 border border-gray-300 rounded px-2 py-1 text-sm">
+                                <input type="text" x-model="portfolio.editHistoryForm.memo"
+                                    placeholder="메모" maxlength="200"
+                                    class="w-1/2 border border-gray-300 rounded px-2 py-1 text-sm">
+                            </div>
+                            <div class="flex justify-end gap-2">
+                                <button @click.stop="cancelEditHistory()"
+                                    class="text-xs text-gray-500 hover:text-gray-700">취소</button>
+                                <button @click.stop="submitEditHistory(h.id)"
+                                    class="text-xs text-blue-600 hover:text-blue-800 font-medium">저장</button>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </div>
+</template>
+```

--- a/.claude/designs/portfolio/stock-purchase-history/examples/infrastructure-example.md
+++ b/.claude/designs/portfolio/stock-purchase-history/examples/infrastructure-example.md
@@ -1,0 +1,143 @@
+# 인프라 계층 예시
+
+## StockPurchaseHistoryEntity
+
+```java
+package com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "stock_purchase_history",
+    indexes = {
+        @Index(name = "idx_purchase_history_item_id", columnList = "portfolio_item_id")
+    }
+)
+@Getter
+public class StockPurchaseHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "portfolio_item_id", nullable = false)
+    private Long portfolioItemId;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    @Column(name = "purchase_price", nullable = false, precision = 18, scale = 2)
+    private BigDecimal purchasePrice;
+
+    @Column(name = "purchased_at", nullable = false)
+    private LocalDate purchasedAt;
+
+    @Column(name = "memo", length = 200)
+    private String memo;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected StockPurchaseHistoryEntity() {
+    }
+
+    public StockPurchaseHistoryEntity(Long id, Long portfolioItemId, int quantity,
+                                       BigDecimal purchasePrice, LocalDate purchasedAt,
+                                       String memo, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioItemId = portfolioItemId;
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        this.purchasedAt = purchasedAt;
+        this.memo = memo;
+        this.createdAt = createdAt;
+    }
+}
+```
+
+## StockPurchaseHistoryJpaRepository
+
+```java
+package com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StockPurchaseHistoryJpaRepository extends JpaRepository<StockPurchaseHistoryEntity, Long> {
+    List<StockPurchaseHistoryEntity> findByPortfolioItemIdOrderByPurchasedAtAsc(Long portfolioItemId);
+    void deleteByPortfolioItemId(Long portfolioItemId);
+}
+```
+
+## StockPurchaseHistoryRepositoryImpl
+
+```java
+package com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence;
+
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.StockPurchaseHistory;
+import com.thlee.stock.market.stockmarket.portfolio.domain.repository.StockPurchaseHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class StockPurchaseHistoryRepositoryImpl implements StockPurchaseHistoryRepository {
+
+    private final StockPurchaseHistoryJpaRepository jpaRepository;
+
+    @Override
+    public StockPurchaseHistory save(StockPurchaseHistory history) {
+        StockPurchaseHistoryEntity entity = toEntity(history);
+        StockPurchaseHistoryEntity saved = jpaRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<StockPurchaseHistory> findById(Long id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public List<StockPurchaseHistory> findByPortfolioItemId(Long portfolioItemId) {
+        return jpaRepository.findByPortfolioItemIdOrderByPurchasedAtAsc(portfolioItemId)
+                .stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void delete(StockPurchaseHistory history) {
+        jpaRepository.deleteById(history.getId());
+    }
+
+    @Override
+    public void deleteByPortfolioItemId(Long portfolioItemId) {
+        jpaRepository.deleteByPortfolioItemId(portfolioItemId);
+    }
+
+    private StockPurchaseHistoryEntity toEntity(StockPurchaseHistory h) {
+        return new StockPurchaseHistoryEntity(
+                h.getId(), h.getPortfolioItemId(), h.getQuantity(),
+                h.getPurchasePrice(), h.getPurchasedAt(), h.getMemo(), h.getCreatedAt()
+        );
+    }
+
+    private StockPurchaseHistory toDomain(StockPurchaseHistoryEntity e) {
+        return new StockPurchaseHistory(
+                e.getId(), e.getPortfolioItemId(), e.getQuantity(),
+                e.getPurchasePrice(), e.getPurchasedAt(), e.getMemo(), e.getCreatedAt()
+        );
+    }
+}
+```

--- a/.claude/designs/portfolio/stock-purchase-history/examples/presentation-example.md
+++ b/.claude/designs/portfolio/stock-purchase-history/examples/presentation-example.md
@@ -1,0 +1,65 @@
+# 프레젠테이션 계층 예시
+
+## PortfolioController 추가 API
+
+```java
+// PortfolioController.java에 추가
+
+/**
+ * 매수이력 조회
+ */
+@GetMapping("/items/stock/{itemId}/purchases")
+public ResponseEntity<List<StockPurchaseHistoryResponse>> getPurchaseHistories(
+        @RequestParam Long userId,
+        @PathVariable Long itemId) {
+    List<StockPurchaseHistoryResponse> responses = portfolioService.getPurchaseHistories(userId, itemId);
+    return ResponseEntity.ok(responses);
+}
+
+/**
+ * 매수이력 수정
+ */
+@PutMapping("/items/stock/{itemId}/purchases/{historyId}")
+public ResponseEntity<PortfolioItemResponse> updatePurchaseHistory(
+        @RequestParam Long userId,
+        @PathVariable Long itemId,
+        @PathVariable Long historyId,
+        @RequestBody StockPurchaseHistoryUpdateRequest request) {
+    PortfolioItemResponse response = portfolioService.updatePurchaseHistory(
+            userId, itemId, historyId,
+            request.getQuantity(), request.getPurchasePrice(),
+            request.getPurchasedAt(), request.getMemo());
+    return ResponseEntity.ok(response);
+}
+
+/**
+ * 매수이력 삭제
+ */
+@DeleteMapping("/items/stock/{itemId}/purchases/{historyId}")
+public ResponseEntity<Void> deletePurchaseHistory(
+        @RequestParam Long userId,
+        @PathVariable Long itemId,
+        @PathVariable Long historyId) {
+    portfolioService.deletePurchaseHistory(userId, itemId, historyId);
+    return ResponseEntity.noContent().build();
+}
+```
+
+## StockPurchaseHistoryUpdateRequest
+
+```java
+package com.thlee.stock.market.stockmarket.portfolio.presentation.dto;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+public class StockPurchaseHistoryUpdateRequest {
+    private Integer quantity;
+    private BigDecimal purchasePrice;
+    private LocalDate purchasedAt;
+    private String memo;
+}
+```

--- a/.claude/designs/portfolio/stock-purchase-history/stock-purchase-history.md
+++ b/.claude/designs/portfolio/stock-purchase-history/stock-purchase-history.md
@@ -1,0 +1,99 @@
+# 주식 매수 이력 관리 설계
+
+## 작업 리스트
+
+### 백엔드
+- [x] StockPurchaseHistory 도메인 모델 생성
+- [x] StockPurchaseHistoryEntity JPA Entity 생성
+- [x] StockPurchaseHistoryRepository 인터페이스 + 구현체 생성
+- [x] PortfolioItem 도메인 모델에 매수이력 기반 재계산 메서드 추가
+- [x] PortfolioService에 매수이력 CRUD 메서드 추가 (조회, 수정, 삭제)
+- [x] PortfolioService의 addStockPurchase 변경 (이력 저장 연동)
+- [x] PortfolioService의 addStockItem 변경 (최초 등록 시 이력 생성)
+- [x] StockPurchaseHistoryResponse DTO 생성
+- [x] PortfolioController에 매수이력 API 추가 (조회, 수정, 삭제)
+
+### 프론트엔드
+- [x] API 클라이언트에 매수이력 API 메서드 추가
+- [x] 매수이력 조회/수정/삭제 UI 구현 (추가매수 모달 내 이력 섹션)
+
+## 배경
+
+현재 추가 매수 시 가중평균으로 합산만 하고 개별 매수 이력이 남지 않아, 잘못 입력한 매수를 수정/삭제할 수 없음.
+
+## 핵심 결정
+
+- **별도 테이블**: `stock_purchase_history` 테이블로 매수 건별 이력 관리
+- **stock_detail은 파생 데이터**: 매수이력의 합산 결과를 stock_detail의 quantity/avgBuyPrice에 반영 (이력이 원본, stock_detail은 캐시)
+- **이력 수정/삭제 시 재계산**: 이력 변경 시 전체 이력을 기반으로 quantity/avgBuyPrice 재계산
+- **최초 등록도 이력**: addStockItem 시 첫 번째 매수 이력 자동 생성
+
+## 구현
+
+### StockPurchaseHistory 도메인 모델
+위치: `portfolio/domain/model/StockPurchaseHistory.java`
+
+[예시 코드](./examples/domain-model-example.md)
+
+### StockPurchaseHistoryEntity
+위치: `portfolio/infrastructure/persistence/StockPurchaseHistoryEntity.java`
+
+- `stock_purchase_history` 테이블
+- FK: `portfolio_item_id` → `portfolio_item.id`
+- 컬럼: id, portfolio_item_id, quantity, purchase_price, purchased_at, memo, created_at
+
+[예시 코드](./examples/infrastructure-example.md)
+
+### StockPurchaseHistoryRepository
+위치: `portfolio/domain/repository/StockPurchaseHistoryRepository.java`
+
+- `findByPortfolioItemId(Long itemId)`: 특정 종목의 매수이력 조회
+- `save(StockPurchaseHistory history)`: 저장
+- `findById(Long id)`: 단건 조회
+- `delete(StockPurchaseHistory history)`: 삭제
+
+### PortfolioItem 도메인 변경
+위치: `portfolio/domain/model/PortfolioItem.java`
+
+- `recalculateFromPurchaseHistories(List<StockPurchaseHistory>)`: 이력 기반 재계산
+  - 전체 수량 합산, 가중평균단가 계산, investedAmount 갱신
+
+[예시 코드](./examples/domain-model-example.md)
+
+### PortfolioService 변경
+위치: `portfolio/application/PortfolioService.java`
+
+- `addStockItem` 변경: 최초 등록 시 매수이력 자동 생성
+- `addStockPurchase` 변경: 이력 저장 후 재계산
+- `getPurchaseHistories(userId, itemId)`: 매수이력 조회
+- `updatePurchaseHistory(userId, itemId, historyId, quantity, purchasePrice)`: 이력 수정 + 재계산
+- `deletePurchaseHistory(userId, itemId, historyId)`: 이력 삭제 + 재계산
+
+[예시 코드](./examples/application-service-example.md)
+
+### PortfolioController API 추가
+위치: `portfolio/presentation/PortfolioController.java`
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/api/portfolio/items/stock/{itemId}/purchases?userId=` | 매수이력 조회 |
+| PUT | `/api/portfolio/items/stock/{itemId}/purchases/{historyId}?userId=` | 매수이력 수정 |
+| DELETE | `/api/portfolio/items/stock/{itemId}/purchases/{historyId}?userId=` | 매수이력 삭제 |
+
+[예시 코드](./examples/presentation-example.md)
+
+### 프론트엔드
+위치: `static/js/app.js`, `static/js/api.js`, `static/index.html`
+
+- 추가매수 모달에 매수이력 목록 표시
+- 각 이력에 수정/삭제 버튼
+- 이력 수정 시 인라인 편집
+- 이력 삭제 시 confirm 후 삭제 + 재계산된 결과 반영
+
+[예시 코드](./examples/frontend-example.md)
+
+## 주의사항
+
+- 매수이력이 0건이 되면 안 됨 (최소 1건 유지, 마지막 이력 삭제 시 경고)
+- 기존 데이터(이력 없는 기존 종목)는 이력 조회 시 빈 배열 반환, 수정 버튼으로 직접 수정 가능 (기존 방식 유지)
+- StockPurchaseHistoryEntity는 PortfolioItemEntity와 연관관계 없이 ID 참조만 사용 (CLAUDE.md Entity 규칙 준수)

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
@@ -4,6 +4,7 @@ import com.thlee.stock.market.stockmarket.news.application.NewsCleanupService;
 import com.thlee.stock.market.stockmarket.news.domain.model.NewsPurpose;
 import com.thlee.stock.market.stockmarket.news.domain.model.Region;
 import com.thlee.stock.market.stockmarket.portfolio.application.dto.PortfolioItemResponse;
+import com.thlee.stock.market.stockmarket.portfolio.application.dto.StockPurchaseHistoryResponse;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.*;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.AssetType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.BondSubType;
@@ -11,6 +12,7 @@ import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.FundSubTy
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.RealEstateSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.StockSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.repository.PortfolioItemRepository;
+import com.thlee.stock.market.stockmarket.portfolio.domain.repository.StockPurchaseHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,7 @@ import java.util.stream.Collectors;
 public class PortfolioService {
 
     private final PortfolioItemRepository portfolioItemRepository;
+    private final StockPurchaseHistoryRepository purchaseHistoryRepository;
     private final NewsCleanupService newsCleanupService;
 
     /**
@@ -51,6 +54,12 @@ public class PortfolioService {
         }
         validateDuplicate(userId, item);
         PortfolioItem saved = portfolioItemRepository.save(item);
+
+        // 최초 매수이력 생성
+        StockPurchaseHistory history = StockPurchaseHistory.create(
+                saved.getId(), quantity, purchasePrice, LocalDate.now(), null);
+        purchaseHistoryRepository.save(history);
+
         return PortfolioItemResponse.from(saved);
     }
 
@@ -165,13 +174,22 @@ public class PortfolioService {
     }
 
     /**
-     * 주식 추가 매수 (가중평균 계산, investedAmount 자동 갱신)
+     * 주식 추가 매수 - 이력 저장 후 재계산
      */
     @Transactional
     public PortfolioItemResponse addStockPurchase(Long userId, Long itemId,
                                                    Integer quantity, BigDecimal purchasePrice) {
         PortfolioItem item = findUserItem(userId, itemId);
-        item.addStockPurchase(quantity, purchasePrice);
+
+        // 매수이력 저장
+        StockPurchaseHistory history = StockPurchaseHistory.create(
+                itemId, quantity, purchasePrice, LocalDate.now(), null);
+        purchaseHistoryRepository.save(history);
+
+        // 전체 이력 기반 재계산
+        List<StockPurchaseHistory> histories = purchaseHistoryRepository.findByPortfolioItemId(itemId);
+        item.recalculateFromPurchaseHistories(histories);
+
         PortfolioItem saved = portfolioItemRepository.save(item);
         return PortfolioItemResponse.from(saved);
     }
@@ -266,11 +284,77 @@ public class PortfolioService {
     }
 
     /**
-     * 항목 삭제 + 관련 뉴스 출처 매핑 삭제 + orphan 뉴스 정리
+     * 매수이력 조회
+     */
+    public List<StockPurchaseHistoryResponse> getPurchaseHistories(Long userId, Long itemId) {
+        findUserItem(userId, itemId); // 권한 검증
+        return purchaseHistoryRepository.findByPortfolioItemId(itemId).stream()
+                .map(StockPurchaseHistoryResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 매수이력 수정 + 재계산
+     */
+    @Transactional
+    public PortfolioItemResponse updatePurchaseHistory(Long userId, Long itemId, Long historyId,
+                                                        Integer quantity, BigDecimal purchasePrice,
+                                                        LocalDate purchasedAt, String memo) {
+        PortfolioItem item = findUserItem(userId, itemId);
+
+        StockPurchaseHistory history = purchaseHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new IllegalArgumentException("매수 이력을 찾을 수 없습니다."));
+        if (!history.getPortfolioItemId().equals(itemId)) {
+            throw new IllegalArgumentException("해당 항목의 매수 이력이 아닙니다.");
+        }
+
+        history.update(quantity, purchasePrice, purchasedAt, memo);
+        purchaseHistoryRepository.save(history);
+
+        // 전체 이력 기반 재계산
+        List<StockPurchaseHistory> histories = purchaseHistoryRepository.findByPortfolioItemId(itemId);
+        item.recalculateFromPurchaseHistories(histories);
+
+        PortfolioItem saved = portfolioItemRepository.save(item);
+        return PortfolioItemResponse.from(saved);
+    }
+
+    /**
+     * 매수이력 삭제 + 재계산
+     */
+    @Transactional
+    public PortfolioItemResponse deletePurchaseHistory(Long userId, Long itemId, Long historyId) {
+        PortfolioItem item = findUserItem(userId, itemId);
+
+        StockPurchaseHistory history = purchaseHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new IllegalArgumentException("매수 이력을 찾을 수 없습니다."));
+        if (!history.getPortfolioItemId().equals(itemId)) {
+            throw new IllegalArgumentException("해당 항목의 매수 이력이 아닙니다.");
+        }
+
+        // 최소 1건 검증
+        List<StockPurchaseHistory> histories = purchaseHistoryRepository.findByPortfolioItemId(itemId);
+        if (histories.size() <= 1) {
+            throw new IllegalArgumentException("매수 이력은 최소 1건 이상이어야 합니다.");
+        }
+
+        purchaseHistoryRepository.delete(history);
+
+        // 삭제 후 남은 이력으로 재계산
+        histories.removeIf(h -> h.getId().equals(historyId));
+        item.recalculateFromPurchaseHistories(histories);
+
+        PortfolioItem saved = portfolioItemRepository.save(item);
+        return PortfolioItemResponse.from(saved);
+    }
+
+    /**
+     * 항목 삭제 + 매수이력 삭제 + 관련 뉴스 출처 매핑 삭제 + orphan 뉴스 정리
      */
     @Transactional
     public void deleteItem(Long userId, Long itemId) {
         PortfolioItem item = findUserItem(userId, itemId);
+        purchaseHistoryRepository.deleteByPortfolioItemId(itemId);
         newsCleanupService.deleteSourceAndCleanOrphans(NewsPurpose.PORTFOLIO, item.getId());
         portfolioItemRepository.delete(item);
     }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/StockPurchaseHistoryResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/StockPurchaseHistoryResponse.java
@@ -1,0 +1,46 @@
+package com.thlee.stock.market.stockmarket.portfolio.application.dto;
+
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.StockPurchaseHistory;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class StockPurchaseHistoryResponse {
+    private final Long id;
+    private final Long portfolioItemId;
+    private final int quantity;
+    private final BigDecimal purchasePrice;
+    private final BigDecimal totalCost;
+    private final LocalDate purchasedAt;
+    private final String memo;
+    private final LocalDateTime createdAt;
+
+    private StockPurchaseHistoryResponse(Long id, Long portfolioItemId, int quantity,
+                                          BigDecimal purchasePrice, BigDecimal totalCost,
+                                          LocalDate purchasedAt, String memo, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioItemId = portfolioItemId;
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        this.totalCost = totalCost;
+        this.purchasedAt = purchasedAt;
+        this.memo = memo;
+        this.createdAt = createdAt;
+    }
+
+    public static StockPurchaseHistoryResponse from(StockPurchaseHistory history) {
+        return new StockPurchaseHistoryResponse(
+                history.getId(),
+                history.getPortfolioItemId(),
+                history.getQuantity(),
+                history.getPurchasePrice(),
+                history.getTotalCost(),
+                history.getPurchasedAt(),
+                history.getMemo(),
+                history.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/PortfolioItem.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/PortfolioItem.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class PortfolioItem {
@@ -208,6 +209,42 @@ public class PortfolioItem {
                 this.stockDetail.getDividendYield()
         );
         this.investedAmount = calcInvestedAmount(newAvgBuyPrice, newQuantity);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 매수이력 기반 수량/평균단가/투자금 재계산
+     * 이력 수정/삭제 후 호출
+     */
+    public void recalculateFromPurchaseHistories(List<StockPurchaseHistory> histories) {
+        if (this.assetType != AssetType.STOCK) {
+            throw new IllegalArgumentException("주식 항목이 아닙니다.");
+        }
+        validateDetail(this.stockDetail, "stockDetail");
+        if (histories.isEmpty()) {
+            throw new IllegalArgumentException("매수 이력이 최소 1건 이상 있어야 합니다.");
+        }
+
+        int totalQuantity = 0;
+        BigDecimal totalCost = BigDecimal.ZERO;
+        for (StockPurchaseHistory h : histories) {
+            totalQuantity += h.getQuantity();
+            totalCost = totalCost.add(h.getTotalCost());
+        }
+
+        BigDecimal newAvgBuyPrice = totalCost.divide(BigDecimal.valueOf(totalQuantity), 2, RoundingMode.HALF_UP);
+
+        this.stockDetail = new StockDetail(
+                this.stockDetail.getSubType(),
+                this.stockDetail.getStockCode(),
+                this.stockDetail.getMarket(),
+                this.stockDetail.getExchangeCode(),
+                this.stockDetail.getCountry(),
+                totalQuantity,
+                newAvgBuyPrice,
+                this.stockDetail.getDividendYield()
+        );
+        this.investedAmount = calcInvestedAmount(newAvgBuyPrice, totalQuantity);
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/StockPurchaseHistory.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/StockPurchaseHistory.java
@@ -1,0 +1,74 @@
+package com.thlee.stock.market.stockmarket.portfolio.domain.model;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class StockPurchaseHistory {
+    private Long id;
+    private Long portfolioItemId;
+    private int quantity;
+    private BigDecimal purchasePrice;
+    private LocalDate purchasedAt;
+    private String memo;
+    private LocalDateTime createdAt;
+
+    /**
+     * 재구성용 생성자 (Repository 조회 시)
+     */
+    public StockPurchaseHistory(Long id, Long portfolioItemId, int quantity,
+                                 BigDecimal purchasePrice, LocalDate purchasedAt,
+                                 String memo, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioItemId = portfolioItemId;
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        this.purchasedAt = purchasedAt;
+        this.memo = memo;
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * 새 매수이력 생성
+     */
+    public static StockPurchaseHistory create(Long portfolioItemId, int quantity,
+                                               BigDecimal purchasePrice, LocalDate purchasedAt,
+                                               String memo) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("매수 수량은 0보다 커야 합니다.");
+        }
+        if (purchasePrice == null || purchasePrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("매수가는 0보다 커야 합니다.");
+        }
+        return new StockPurchaseHistory(null, portfolioItemId, quantity, purchasePrice,
+                purchasedAt != null ? purchasedAt : LocalDate.now(), memo, LocalDateTime.now());
+    }
+
+    /**
+     * 매수이력 수정
+     */
+    public void update(int quantity, BigDecimal purchasePrice, LocalDate purchasedAt, String memo) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("매수 수량은 0보다 커야 합니다.");
+        }
+        if (purchasePrice == null || purchasePrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("매수가는 0보다 커야 합니다.");
+        }
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        if (purchasedAt != null) {
+            this.purchasedAt = purchasedAt;
+        }
+        this.memo = memo;
+    }
+
+    /**
+     * 이 매수건의 총 투자금액
+     */
+    public BigDecimal getTotalCost() {
+        return purchasePrice.multiply(BigDecimal.valueOf(quantity));
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/repository/StockPurchaseHistoryRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/repository/StockPurchaseHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.thlee.stock.market.stockmarket.portfolio.domain.repository;
+
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.StockPurchaseHistory;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockPurchaseHistoryRepository {
+    StockPurchaseHistory save(StockPurchaseHistory history);
+    Optional<StockPurchaseHistory> findById(Long id);
+    List<StockPurchaseHistory> findByPortfolioItemId(Long portfolioItemId);
+    void delete(StockPurchaseHistory history);
+    void deleteByPortfolioItemId(Long portfolioItemId);
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockPurchaseHistoryEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockPurchaseHistoryEntity.java
@@ -1,0 +1,56 @@
+package com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "stock_purchase_history",
+    indexes = {
+        @Index(name = "idx_purchase_history_item_id", columnList = "portfolio_item_id")
+    }
+)
+@Getter
+public class StockPurchaseHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "portfolio_item_id", nullable = false)
+    private Long portfolioItemId;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    @Column(name = "purchase_price", nullable = false, precision = 18, scale = 2)
+    private BigDecimal purchasePrice;
+
+    @Column(name = "purchased_at", nullable = false)
+    private LocalDate purchasedAt;
+
+    @Column(name = "memo", length = 200)
+    private String memo;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected StockPurchaseHistoryEntity() {
+    }
+
+    public StockPurchaseHistoryEntity(Long id, Long portfolioItemId, int quantity,
+                                       BigDecimal purchasePrice, LocalDate purchasedAt,
+                                       String memo, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioItemId = portfolioItemId;
+        this.quantity = quantity;
+        this.purchasePrice = purchasePrice;
+        this.purchasedAt = purchasedAt;
+        this.memo = memo;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockPurchaseHistoryJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockPurchaseHistoryJpaRepository.java
@@ -1,0 +1,10 @@
+package com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StockPurchaseHistoryJpaRepository extends JpaRepository<StockPurchaseHistoryEntity, Long> {
+    List<StockPurchaseHistoryEntity> findByPortfolioItemIdOrderByPurchasedAtAsc(Long portfolioItemId);
+    void deleteByPortfolioItemId(Long portfolioItemId);
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockPurchaseHistoryRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockPurchaseHistoryRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence;
+
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.StockPurchaseHistory;
+import com.thlee.stock.market.stockmarket.portfolio.domain.repository.StockPurchaseHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class StockPurchaseHistoryRepositoryImpl implements StockPurchaseHistoryRepository {
+
+    private final StockPurchaseHistoryJpaRepository jpaRepository;
+
+    @Override
+    public StockPurchaseHistory save(StockPurchaseHistory history) {
+        StockPurchaseHistoryEntity entity = toEntity(history);
+        StockPurchaseHistoryEntity saved = jpaRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<StockPurchaseHistory> findById(Long id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public List<StockPurchaseHistory> findByPortfolioItemId(Long portfolioItemId) {
+        return jpaRepository.findByPortfolioItemIdOrderByPurchasedAtAsc(portfolioItemId)
+                .stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void delete(StockPurchaseHistory history) {
+        jpaRepository.deleteById(history.getId());
+    }
+
+    @Override
+    public void deleteByPortfolioItemId(Long portfolioItemId) {
+        jpaRepository.deleteByPortfolioItemId(portfolioItemId);
+    }
+
+    private StockPurchaseHistoryEntity toEntity(StockPurchaseHistory h) {
+        return new StockPurchaseHistoryEntity(
+                h.getId(), h.getPortfolioItemId(), h.getQuantity(),
+                h.getPurchasePrice(), h.getPurchasedAt(), h.getMemo(), h.getCreatedAt()
+        );
+    }
+
+    private StockPurchaseHistory toDomain(StockPurchaseHistoryEntity e) {
+        return new StockPurchaseHistory(
+                e.getId(), e.getPortfolioItemId(), e.getQuantity(),
+                e.getPurchasePrice(), e.getPurchasedAt(), e.getMemo(), e.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
@@ -4,6 +4,7 @@ import com.thlee.stock.market.stockmarket.portfolio.application.PortfolioAllocat
 import com.thlee.stock.market.stockmarket.portfolio.application.PortfolioService;
 import com.thlee.stock.market.stockmarket.portfolio.application.dto.AllocationResponse;
 import com.thlee.stock.market.stockmarket.portfolio.application.dto.PortfolioItemResponse;
+import com.thlee.stock.market.stockmarket.portfolio.application.dto.StockPurchaseHistoryResponse;
 import com.thlee.stock.market.stockmarket.portfolio.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -191,6 +192,45 @@ public class PortfolioController {
         PortfolioItemResponse response = portfolioService.addStockPurchase(
                 userId, itemId, request.getQuantity(), request.getPurchasePrice());
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 매수이력 조회
+     */
+    @GetMapping("/items/stock/{itemId}/purchases")
+    public ResponseEntity<List<StockPurchaseHistoryResponse>> getPurchaseHistories(
+            @RequestParam Long userId,
+            @PathVariable Long itemId) {
+        List<StockPurchaseHistoryResponse> responses = portfolioService.getPurchaseHistories(userId, itemId);
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 매수이력 수정
+     */
+    @PutMapping("/items/stock/{itemId}/purchases/{historyId}")
+    public ResponseEntity<PortfolioItemResponse> updatePurchaseHistory(
+            @RequestParam Long userId,
+            @PathVariable Long itemId,
+            @PathVariable Long historyId,
+            @RequestBody StockPurchaseHistoryUpdateRequest request) {
+        PortfolioItemResponse response = portfolioService.updatePurchaseHistory(
+                userId, itemId, historyId,
+                request.getQuantity(), request.getPurchasePrice(),
+                request.getPurchasedAt(), request.getMemo());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 매수이력 삭제
+     */
+    @DeleteMapping("/items/stock/{itemId}/purchases/{historyId}")
+    public ResponseEntity<Void> deletePurchaseHistory(
+            @RequestParam Long userId,
+            @PathVariable Long itemId,
+            @PathVariable Long historyId) {
+        portfolioService.deletePurchaseHistory(userId, itemId, historyId);
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockPurchaseHistoryUpdateRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockPurchaseHistoryUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.thlee.stock.market.stockmarket.portfolio.presentation.dto;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+public class StockPurchaseHistoryUpdateRequest {
+    private Integer quantity;
+    private BigDecimal purchasePrice;
+    private LocalDate purchasedAt;
+    private String memo;
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -567,6 +567,9 @@
                                                                         x-text="Format.number(getEvalAmount(item), 0) + '원'"></span>
                                                                 </div>
                                                                 <p class="text-xs text-gray-400 mt-0.5" x-text="getItemSummary(item)"></p>
+                                                                <p x-show="getStockPriceSummary(item)" class="text-xs mt-0.5"
+                                                                    :class="getProfitAmount(item) > 0 ? 'text-red-500' : getProfitAmount(item) < 0 ? 'text-blue-500' : 'text-gray-400'"
+                                                                    x-text="getStockPriceSummary(item)"></p>
                                                             </div>
                                                             <div class="flex items-center gap-2">
                                                                 <!-- 뉴스 토글 -->
@@ -1262,6 +1265,72 @@
                             <div class="flex justify-between">
                                 <span>예상 투자 금액</span>
                                 <span class="font-medium" x-text="Format.number(Math.round((portfolio.purchaseItem.stockDetail.quantity + Number(portfolio.purchaseForm.quantity)) * Math.round((portfolio.purchaseItem.stockDetail.quantity * portfolio.purchaseItem.stockDetail.avgBuyPrice + Number(portfolio.purchaseForm.quantity) * Number(portfolio.purchaseForm.purchasePrice)) / (portfolio.purchaseItem.stockDetail.quantity + Number(portfolio.purchaseForm.quantity)))), 0) + '원'"></span>
+                            </div>
+                        </div>
+                    </template>
+
+                    <!-- 매수 이력 목록 -->
+                    <template x-if="portfolio.purchaseHistories.length > 0">
+                        <div class="mt-4">
+                            <h4 class="text-sm font-semibold text-gray-700 mb-2">매수 이력</h4>
+                            <div class="space-y-2 max-h-48 overflow-y-auto">
+                                <template x-for="h in portfolio.purchaseHistories" :key="h.id">
+                                    <div class="bg-gray-50 rounded-lg p-3 text-sm">
+                                        <!-- 보기 모드 -->
+                                        <template x-if="portfolio.editingHistory !== h.id">
+                                            <div>
+                                                <div class="flex justify-between items-center">
+                                                    <div>
+                                                        <span class="font-medium text-gray-800"
+                                                            x-text="Format.number(h.quantity, 0) + '주'"></span>
+                                                        <span class="text-gray-500 mx-1">&times;</span>
+                                                        <span class="text-gray-800"
+                                                            x-text="Format.number(h.purchasePrice, 0) + '원'"></span>
+                                                        <span class="text-gray-400 ml-2"
+                                                            x-text="'= ' + Format.number(h.totalCost, 0) + '원'"></span>
+                                                    </div>
+                                                    <div class="flex gap-2">
+                                                        <button @click.stop="startEditHistory(h)"
+                                                            class="text-xs text-blue-600 hover:text-blue-800">수정</button>
+                                                        <button x-show="portfolio.purchaseHistories.length > 1"
+                                                            @click.stop="deleteHistory(h.id)"
+                                                            class="text-xs text-red-500 hover:text-red-700">삭제</button>
+                                                    </div>
+                                                </div>
+                                                <div class="flex gap-3 mt-1 text-xs text-gray-400">
+                                                    <span x-show="h.purchasedAt" x-text="h.purchasedAt"></span>
+                                                    <span x-show="h.memo" x-text="h.memo"></span>
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <!-- 수정 모드 -->
+                                        <template x-if="portfolio.editingHistory === h.id">
+                                            <div class="space-y-2">
+                                                <div class="flex gap-2">
+                                                    <input type="number" x-model="portfolio.editHistoryForm.quantity"
+                                                        placeholder="수량" min="1"
+                                                        class="w-1/3 border border-gray-300 rounded px-2 py-1 text-sm">
+                                                    <input type="number" x-model="portfolio.editHistoryForm.purchasePrice"
+                                                        placeholder="단가" min="1"
+                                                        class="w-2/3 border border-gray-300 rounded px-2 py-1 text-sm">
+                                                </div>
+                                                <div class="flex gap-2">
+                                                    <input type="date" x-model="portfolio.editHistoryForm.purchasedAt"
+                                                        class="w-1/2 border border-gray-300 rounded px-2 py-1 text-sm">
+                                                    <input type="text" x-model="portfolio.editHistoryForm.memo"
+                                                        placeholder="메모" maxlength="200"
+                                                        class="w-1/2 border border-gray-300 rounded px-2 py-1 text-sm">
+                                                </div>
+                                                <div class="flex justify-end gap-2">
+                                                    <button @click.stop="cancelEditHistory()"
+                                                        class="text-xs text-gray-500 hover:text-gray-700">취소</button>
+                                                    <button @click.stop="submitEditHistory(h.id)"
+                                                        class="text-xs text-blue-600 hover:text-blue-800 font-medium">저장</button>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
                             </div>
                         </div>
                     </template>

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -147,6 +147,19 @@ const API = {
         return this.request('POST', `/api/portfolio/items/stock/${itemId}/purchase?userId=${userId}`, body);
     },
 
+    // 매수이력
+    getPurchaseHistories(userId, itemId) {
+        return this.request('GET', `/api/portfolio/items/stock/${itemId}/purchases?userId=${userId}`);
+    },
+
+    updatePurchaseHistory(userId, itemId, historyId, body) {
+        return this.request('PUT', `/api/portfolio/items/stock/${itemId}/purchases/${historyId}?userId=${userId}`, body);
+    },
+
+    deletePurchaseHistory(userId, itemId, historyId) {
+        return this.request('DELETE', `/api/portfolio/items/stock/${itemId}/purchases/${historyId}?userId=${userId}`);
+    },
+
     // 수정 (타입별)
     updateStockItem(userId, itemId, body) {
         return this.request('PUT', `/api/portfolio/items/stock/${itemId}?userId=${userId}`, body);

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -95,6 +95,9 @@ function dashboard() {
             showPurchaseModal: false,
             purchaseItem: null,
             purchaseForm: { quantity: '', purchasePrice: '' },
+            purchaseHistories: [],
+            editingHistory: null,
+            editHistoryForm: { quantity: '', purchasePrice: '', purchasedAt: '', memo: '' },
             selectedNewsItemId: null,
             news: { list: [], page: 0, size: 20, totalPages: 0, totalElements: 0, loading: false },
             collectingItemId: null,
@@ -571,6 +574,20 @@ function dashboard() {
             this.portfolio.expandedSections[assetType] = !this.portfolio.expandedSections[assetType];
         },
 
+        getStockPriceSummary(item) {
+            if (item.assetType !== 'STOCK' || !item.stockDetail) return '';
+            var priceData = this.portfolio.stockPrices[item.stockDetail.stockCode];
+            if (!priceData || !priceData.currentPrice) return '';
+            var parts = ['현재가 ' + Format.number(priceData.currentPrice) + '원'];
+            var rate = this.getProfitRate(item);
+            if (rate !== null) {
+                var sign = rate >= 0 ? '+' : '';
+                parts.push(sign + rate.toFixed(2) + '%');
+            }
+            parts.push('총 ' + Format.number(this.getEvalAmount(item), 0) + '원');
+            return parts.join(' · ');
+        },
+
         getItemSummary(item) {
             switch (item.assetType) {
                 case 'STOCK':
@@ -579,15 +596,6 @@ function dashboard() {
                     if (item.stockDetail.subType === 'ETF') parts.push('ETF');
                     if (item.stockDetail.quantity) parts.push(item.stockDetail.quantity + '주');
                     if (item.stockDetail.avgBuyPrice) parts.push('평균 ' + Format.number(item.stockDetail.avgBuyPrice) + '원');
-                    var priceData = this.portfolio.stockPrices[item.stockDetail.stockCode];
-                    if (priceData && priceData.currentPrice) {
-                        parts.push('평가 ' + Format.number(priceData.currentPrice) + '원');
-                        var rate = this.getProfitRate(item);
-                        if (rate !== null) {
-                            var sign = rate >= 0 ? '+' : '';
-                            parts.push('(' + sign + rate.toFixed(2) + '%)');
-                        }
-                    }
                     return parts.join(' · ');
                 case 'BOND':
                     if (!item.bondDetail) return '';
@@ -833,10 +841,13 @@ function dashboard() {
 
         // ==================== 추가 매수 모달 ====================
 
-        openPurchaseModal(item) {
+        async openPurchaseModal(item) {
             this.portfolio.purchaseItem = item;
             this.portfolio.purchaseForm = { quantity: '', purchasePrice: '' };
+            this.portfolio.purchaseHistories = [];
+            this.portfolio.editingHistory = null;
             this.portfolio.showPurchaseModal = true;
+            await this.loadPurchaseHistories(item.id);
         },
 
         async submitPurchase() {
@@ -863,6 +874,74 @@ function dashboard() {
             } catch (e) {
                 console.error('추가 매수 실패:', e);
                 alert('추가 매수에 실패했습니다.');
+            }
+        },
+
+        // ==================== 매수이력 ====================
+
+        async loadPurchaseHistories(itemId) {
+            try {
+                this.portfolio.purchaseHistories = await API.getPurchaseHistories(this.auth.userId, itemId) || [];
+            } catch (e) {
+                console.error('매수이력 조회 실패:', e);
+                this.portfolio.purchaseHistories = [];
+            }
+        },
+
+        startEditHistory(history) {
+            this.portfolio.editingHistory = history.id;
+            this.portfolio.editHistoryForm = {
+                quantity: history.quantity,
+                purchasePrice: history.purchasePrice,
+                purchasedAt: history.purchasedAt || '',
+                memo: history.memo || ''
+            };
+        },
+
+        cancelEditHistory() {
+            this.portfolio.editingHistory = null;
+        },
+
+        async submitEditHistory(historyId) {
+            var form = this.portfolio.editHistoryForm;
+            var item = this.portfolio.purchaseItem;
+
+            if (!form.quantity || Number(form.quantity) <= 0) {
+                alert('수량을 입력해주세요.');
+                return;
+            }
+            if (!form.purchasePrice || Number(form.purchasePrice) <= 0) {
+                alert('매수 단가를 입력해주세요.');
+                return;
+            }
+
+            try {
+                await API.updatePurchaseHistory(this.auth.userId, item.id, historyId, {
+                    quantity: Number(form.quantity),
+                    purchasePrice: Number(form.purchasePrice),
+                    purchasedAt: form.purchasedAt || null,
+                    memo: form.memo || null
+                });
+                this.portfolio.editingHistory = null;
+                await this.loadPurchaseHistories(item.id);
+                await this.loadPortfolio();
+            } catch (e) {
+                console.error('매수이력 수정 실패:', e);
+                alert('매수이력 수정에 실패했습니다.');
+            }
+        },
+
+        async deleteHistory(historyId) {
+            if (!confirm('이 매수 이력을 삭제하시겠습니까?\n삭제 후 수량과 평균단가가 재계산됩니다.')) return;
+            var item = this.portfolio.purchaseItem;
+
+            try {
+                await API.deletePurchaseHistory(this.auth.userId, item.id, historyId);
+                await this.loadPurchaseHistories(item.id);
+                await this.loadPortfolio();
+            } catch (e) {
+                console.error('매수이력 삭제 실패:', e);
+                alert(e.message || '매수이력 삭제에 실패했습니다.');
             }
         },
 


### PR DESCRIPTION
## Summary
- 개별 매수 건별 이력을 추적하는 `stock_purchase_history` 테이블 및 도메인 모델 추가
- 매수이력 수정/삭제 시 수량·평균단가를 전체 이력 기반으로 재계산
- 추가매수 모달에 매수이력 조회/인라인 수정/삭제 UI 구현

## 변경 내용

### 백엔드
- `StockPurchaseHistory` 도메인 모델 (create, update, getTotalCost)
- `StockPurchaseHistoryEntity` JPA Entity + Repository 인터페이스/구현체
- `PortfolioItem.recalculateFromPurchaseHistories()` 재계산 메서드 추가
- `PortfolioService` 변경: addStockItem(최초 이력 생성), addStockPurchase(이력 기반 재계산), deleteItem(이력 함께 삭제)
- `PortfolioService` 추가: getPurchaseHistories, updatePurchaseHistory, deletePurchaseHistory
- `PortfolioController` API 추가: GET/PUT/DELETE `/items/stock/{itemId}/purchases`

### 프론트엔드
- `api.js`: 매수이력 API 클라이언트 3개 메서드 추가
- `app.js`: 매수이력 상태 관리 및 CRUD 메서드 추가
- `index.html`: 추가매수 모달 내 매수이력 목록/수정/삭제 UI

## Test plan
- [ ] 주식 항목 신규 등록 시 매수이력 1건 자동 생성 확인
- [ ] 추가 매수 후 이력 추가 및 수량/평균단가 재계산 확인
- [ ] 매수이력 수정 후 수량/평균단가 재계산 확인
- [ ] 매수이력 삭제 후 재계산 확인 (마지막 1건은 삭제 불가)
- [ ] 항목 삭제 시 매수이력도 함께 삭제 확인
- [ ] 기존 데이터(이력 없는 종목)에서 빈 배열 반환 확인

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: 기존 포트폴리오 CRUD 패턴과 동일한 구조이며, JPA auto-DDL로 테이블 자동 생성됨.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)