### PR TITLE
feat(stock): 해외 주식 현재가 반영 및 환율 변환 기능 추가

### DIFF
--- a/docs/brainstorms/2026-03-15-overseas-stock-price-brainstorm.md
+++ b/docs/brainstorms/2026-03-15-overseas-stock-price-brainstorm.md
@@ -1,0 +1,68 @@
+# Overseas Stock Price Integration - Brainstorm
+
+**Date:** 2026-03-15
+**Status:** Decided
+
+## What We're Building
+
+포트폴리오에 등록된 해외 주식의 현재가를 KIS API를 통해 조회하여 평가금액/수익률을 계산하고, 포트폴리오 총 평가금액에 원화 환산하여 합산하는 기능.
+
+### 현재 상태
+
+- 해외 주식 등록은 가능 (market, exchangeCode, country 필드 저장)
+- KIS API 해외 현재가 조회 인프라 존재 (`KisStockPriceAdapter`, `KisOverseasPriceOutput`)
+- 하지만 프론트엔드 `loadStockPrices()`에서 해외 주식 현재가를 조회하지 않음
+- 해외 주식은 `investedAmount`만 표시되고, 평가금액/수익률 미계산
+
+### 변경 범위
+
+1. **백엔드**: 기존 `/api/stocks/prices` API 확장 (해외 주식 현재가 포함) + 환율 조회 API 연동
+2. **프론트엔드**: 해외 주식 현재가/평가금액/수익률 표시, 총 합산 시 원화 환산
+
+### 변경하지 않는 것
+
+- 해외 주식 등록/수정 UI (이미 동작)
+- 해외 주식 재무정보 조회 (이번 범위 아님)
+- 국내 주식 기존 로직
+
+## Why This Approach
+
+- **KIS API 재활용**: 이미 토큰/인증 인프라가 구축되어 있어 해외 현재가 + 환율 조회 모두 동일 인프라 활용 가능
+- **기존 API 확장**: 별도 API를 만들지 않고 기존 `/api/stocks/prices`를 확장하여 국내/해외 통합 조회
+- **현지 통화 개별 표시 + 합산 시 원화 환산**: 개별 종목은 실제 매매 통화로 직관적이고, 포트폴리오 합산은 원화로 통일
+
+## Key Decisions
+
+| 결정 사항 | 선택 | 이유 |
+|----------|------|------|
+| 해외 주식 현재가 소스 | KIS API (기존 인프라) | 토큰/캐시 인프라 재활용 |
+| API 구조 | 기존 `/api/stocks/prices` 확장 | 국내/해외 통합 조회, 별도 API 불필요 |
+| 개별 종목 가격 표시 | 현지 통화 그대로 (USD, JPY 등) | 매매 통화와 일치하여 직관적 |
+| 통화 표시 형식 | 금액 + 통화코드 (195.00 USD) | 통화코드 후위 표기 |
+| 포트폴리오 합산 | 원화 환산 후 합산 | 총 평가금액을 원화로 통일 |
+| 환율 데이터 소스 | KIS API 환율 조회 | 기존 인프라 활용, 추가 의존성 없음 |
+
+## Technical Notes
+
+### 기존 인프라 활용 가능한 부분
+
+- `KisStockPriceAdapter`: 해외 현재가 조회 로직 이미 구현 (TR_ID: HHDFS00000300)
+- `KisOverseasPriceOutput`: 해외 주식 응답 DTO 존재
+- `KisStockPriceMapper`: 해외 응답 → 도메인 매핑 존재
+- `StockPriceResponse`: 응답 DTO에 marketType, exchangeCode 필드 포함
+- Caffeine 캐시: 해외 주식 가격도 동일 패턴으로 캐싱 가능
+
+### 추가 구현 필요한 부분
+
+- KIS API 환율 조회 클라이언트 (통화별 환율)
+- 환율 캐싱 (Caffeine, TTL 설정)
+- `StockPriceResponse`에 통화코드(currency) 필드 추가
+- 프론트엔드: `loadStockPrices()` → 해외 주식도 포함하여 현재가 조회
+- 프론트엔드: 해외 주식 개별 표시 시 `195.00 USD` 형식
+- 프론트엔드: 포트폴리오 합산 시 환율 적용하여 원화 변환
+
+### 고려 사항
+
+- 해외 주식은 시가/고가/저가 필드가 없음 (KIS API 해외 응답 제한)
+- 환율 갱신 주기: Caffeine 캐시 TTL로 관리 (예: 1시간)
+- 해외 시장 개장 시간 고려 (미국 23:30~06:00 KST 등) - 폐장 시 마지막 종가 표시

--- a/docs/plans/2026-03-15-002-feat-overseas-stock-price-exchange-rate-plan.md
+++ b/docs/plans/2026-03-15-002-feat-overseas-stock-price-exchange-rate-plan.md
@@ -1,0 +1,150 @@
+---
+title: "feat: 해외 주식 현재가 반영 및 환율 변환"
+type: feat
+status: active
+date: 2026-03-15
+origin: docs/brainstorms/2026-03-15-overseas-stock-price-brainstorm.md
+---
+
+# feat: 해외 주식 현재가 반영 및 환율 변환
+
+## Overview
+
+포트폴리오에 등록된 해외 주식의 현재가를 KIS API로 조회하고, 환율을 적용하여 포트폴리오 총 평가금액에 원화로 합산한다. 개별 종목은 현지 통화로 표시하고(`195.00 USD`), 합산 시에만 원화 환산한다.
+
+(see brainstorm: docs/brainstorms/2026-03-15-overseas-stock-price-brainstorm.md)
+
+## Problem Statement / Motivation
+
+해외 주식을 등록하면 현재가가 조회되지 않아 `investedAmount`만 표시되고, 평가금액/수익률이 계산되지 않는다. 또한 국내/해외 주식이 혼합된 포트폴리오에서 통화가 다른 금액이 단순 합산되어 잘못된 총액이 표시될 수 있다.
+
+## Proposed Solution
+
+### 서버에서 원화 환산가를 함께 내려주는 방식 채택
+
+`StockPriceResponse`에 `currency`, `exchangeRate`, `currentPriceKrw` 필드를 추가하여, 프론트엔드는 표시만 하면 되도록 설계한다. 환율 조회/변환 로직을 서버에 집중시켜 프론트엔드 복잡도를 최소화한다.
+
+## Technical Considerations
+
+### Phase 1: 백엔드 - ExchangeCode 통화 매핑
+
+`ExchangeCode` enum에 `currency` 필드 추가:
+
+```
+KRX -> KRW
+NAS, NYS, AMS -> USD
+SHS, SHI, SZS, SZI -> CNY
+TSE -> JPY
+HKS -> HKD
+HNX, HSX -> VND
+```
+
+### Phase 2: 백엔드 - KIS 환율 조회
+
+- `KisExchangeRateClient`: KIS API 환율 조회 클라이언트 신규 구현
+- `ExchangeRatePort` / `ExchangeRateAdapter`: 헥사고날 포트/어댑터
+- `ExchangeRateCacheConfig`: Caffeine 캐시 (TTL 1시간, 최대 20 엔트리)
+- 환율 조회 실패 시: 캐시된 이전 값 사용, 캐시도 없으면 환율 1.0 적용 (investedAmount fallback과 동일 효과)
+
+### Phase 3: 백엔드 - StockPriceResponse 확장
+
+`StockPriceResponse`에 3개 필드 추가:
+
+| 필드 | 타입 | 설명 | 예시 |
+|------|------|------|------|
+| currency | String | 통화코드 | "USD", "KRW" |
+| exchangeRate | BigDecimal | 원화 환율 (1 외화 = N원) | 1380.50 (KRW는 1.0) |
+| currentPriceKrw | String | 원화 환산 현재가 | "269,497" |
+
+국내 주식: `currency="KRW"`, `exchangeRate=1.0`, `currentPriceKrw=currentPrice`
+해외 주식: `currency="USD"`, `exchangeRate=1380.50`, `currentPriceKrw="269497"`
+
+### Phase 4: 프론트엔드 - 현재가/평가금액 표시
+
+**개별 종목 표시**:
+- 국내: `72,000원` (기존과 동일)
+- 해외: `195.00 USD` (현지 통화 + 통화코드)
+
+**평가금액 계산** (`getEvalAmount`):
+- `currentPriceKrw * quantity` 사용 (항상 원화 반환)
+- 기존 `currentPrice * quantity`에서 변경
+
+**수익률 계산** (`getProfitRate`):
+- `(currentPrice - avgBuyPrice) / avgBuyPrice * 100` (현지 통화 기준, 환율 불필요)
+- 기존 로직 유지
+
+**수익금액 표시**:
+- 개별 종목: 현지 통화로 표시 (`+350.00 USD`)
+- 포트폴리오 합산: 원화 (`+483,000원`)
+
+### investedAmount 통화 불일치 처리
+
+해외 주식의 `avgBuyPrice`는 현지 통화로 저장되므로, `investedAmount`도 현지 통화이다.
+- `getTotalInvested()`: 해외 주식의 `investedAmount`에 환율을 적용하여 원화로 합산
+- 환율 정보는 `stockPrices` 응답의 `exchangeRate` 필드에서 가져옴
+
+### 프론트엔드 변경 대상 함수
+
+| 함수 | 변경 내용 |
+|------|----------|
+| `getEvalAmount(item)` | `currentPriceKrw` 사용으로 변경 |
+| `getProfitAmount(item)` | 원화 기준: `getEvalAmount - (investedAmount * exchangeRate)` |
+| `getTotalInvested()` | 해외 주식 `investedAmount`에 환율 적용 |
+| `getStockPriceSummary(item)` | 해외 주식 통화 표시 (`195.00 USD`) |
+| `getSubTotalInvested(type)` | 환율 적용 합산 |
+| `getSubTotalEvalAmount(type)` | 이미 원화 반환이므로 변경 불필요 |
+
+### 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| 환율 조회 실패 | 캐시된 값 사용, 없으면 exchangeRate=1.0 |
+| 해외 시장 폐장 | KIS API가 마지막 종가 반환 (기존 동작) |
+| 해외 주식 현재가 조회 실패 | 기존 fallback (investedAmount 사용) |
+| 소수점 처리 | 해외 주식 소수점 2자리, 국내 정수 |
+| stockCode 키 충돌 | exchangeCode로 구분 (캐시 키: `stockCode_exchangeCode`) |
+
+## Acceptance Criteria
+
+### Phase 1: ExchangeCode 통화 매핑
+- [x] `ExchangeCode` enum에 `currency` 필드 추가 (`ExchangeCode.java`)
+- [x] 12개 거래소 → 6개 통화 매핑 완성
+
+### Phase 2: 환율 조회
+- [x] `KisExchangeRateClient` 구현 - KIS API 환율 조회
+- [x] `ExchangeRatePort` 인터페이스 정의 (`domain/service/`)
+- [x] `KisExchangeRateAdapter` 구현 (`infrastructure/`)
+- [x] `StockPriceService`에서 `ExchangeRatePort` 주입하여 환율 조회
+- [x] Caffeine 캐시 설정 (TTL 1시간)
+
+### Phase 3: StockPriceResponse 확장
+- [x] `StockPriceResponse`에 `currency`, `exchangeRateValue`, `currentPriceKrw` 추가
+- [x] `StockPriceService.getPrice()`에서 환율 조회 후 응답에 포함
+- [x] `ExchangeCode.getCurrency()`로 통화 매핑
+
+### Phase 4: 프론트엔드
+- [x] `getEvalAmount()` → `currentPriceKrw` 사용으로 변경 (`app.js`)
+- [x] `getTotalInvested()` → 해외 주식 환율 적용 합산 (`app.js`)
+- [x] `getProfitAmount()` → 원화 기준 수익금 계산 (`app.js`)
+- [x] `getStockPriceSummary()` → 해외 주식 통화 표시 (`app.js`)
+- [x] 개별 종목 원금 원화 환산 표시 (`index.html`)
+- [x] 도넛 차트/막대 차트 정상 반영 (기존 로직이 원화 기반이므로 자동 반영)
+
+## Dependencies & Risks
+
+- **KIS 환율 API 스펙 확인 필요**: KIS API 문서에서 환율 조회 TR의 요청/응답 형태를 확인해야 함
+- **KIS API 호출 제한**: 환율 조회 추가로 인한 API 호출량 증가 → 캐싱으로 완화
+- **VND, CNY 등 마이너 통화**: KIS API에서 지원하지 않을 수 있음 → 미지원 통화는 환율 1.0 fallback
+
+## Sources & References
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-15-overseas-stock-price-brainstorm.md](docs/brainstorms/2026-03-15-overseas-stock-price-brainstorm.md) — KIS API 활용, 현지 통화 표시, 원화 환산 합산, 기존 API 확장
+- KIS 해외 현재가: `src/.../infrastructure/stock/kis/KisStockPriceClient.java:49` (TR_ID: HHDFS00000300)
+- KIS 어댑터: `src/.../infrastructure/stock/kis/KisStockPriceAdapter.java:23`
+- StockPriceResponse: `src/.../application/dto/StockPriceResponse.java`
+- ExchangeCode enum: `src/.../domain/model/ExchangeCode.java`
+- 캐시 설정: `src/.../infrastructure/stock/kis/config/StockPriceCacheConfig.java`
+- 프론트 현재가 로드: `src/main/resources/static/js/app.js:496` (loadStockPrices)
+- 평가금액 계산: `src/main/resources/static/js/app.js:522` (getEvalAmount)
+- 기존 설계: `.claude/designs/stock/stock-price-cache/stock-price-cache.md`
+- 토큰 관리: `.claude/designs/stock/kis-token-management/kis-token-management.md`

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
@@ -10,6 +10,7 @@ import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.AssetType
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.BondSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.FundSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.RealEstateSubType;
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.PriceCurrency;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.StockSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.repository.PortfolioItemRepository;
 import com.thlee.stock.market.stockmarket.portfolio.domain.repository.StockPurchaseHistoryRepository;
@@ -42,10 +43,12 @@ public class PortfolioService {
                                                String region, String memo,
                                                String subType, String stockCode, String market,
                                                String exchangeCode, String country,
-                                               Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield) {
+                                               Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield,
+                                               String priceCurrency) {
         StockDetail detail = new StockDetail(
                 subType != null ? StockSubType.valueOf(subType) : null,
-                stockCode, market, exchangeCode, country, quantity, purchasePrice, dividendYield
+                stockCode, market, exchangeCode, country, quantity, purchasePrice, dividendYield,
+                priceCurrency != null ? PriceCurrency.valueOf(priceCurrency) : PriceCurrency.KRW
         );
         PortfolioItem item = PortfolioItem.createWithStock(
                 userId, itemName, Region.valueOf(region), detail);
@@ -160,13 +163,15 @@ public class PortfolioService {
                                                   String itemName, String memo,
                                                   String subType, String stockCode, String market,
                                                   String exchangeCode, String country,
-                                                  Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield) {
+                                                  Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield,
+                                                  String priceCurrency) {
         PortfolioItem item = findUserItem(userId, itemId);
         item.updateItemName(itemName);
         item.updateMemo(memo);
         StockDetail detail = new StockDetail(
                 subType != null ? StockSubType.valueOf(subType) : null,
-                stockCode, market, exchangeCode, country, quantity, purchasePrice, dividendYield
+                stockCode, market, exchangeCode, country, quantity, purchasePrice, dividendYield,
+                priceCurrency != null ? PriceCurrency.valueOf(priceCurrency) : PriceCurrency.KRW
         );
         item.updateStockDetail(detail);
         PortfolioItem saved = portfolioItemRepository.save(item);

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/StockDetailResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/StockDetailResponse.java
@@ -15,10 +15,11 @@ public class StockDetailResponse {
     private final Integer quantity;
     private final BigDecimal avgBuyPrice;
     private final BigDecimal dividendYield;
+    private final String priceCurrency;
 
     private StockDetailResponse(String subType, String stockCode, String market, String exchangeCode,
                                 String country, Integer quantity, BigDecimal avgBuyPrice,
-                                BigDecimal dividendYield) {
+                                BigDecimal dividendYield, String priceCurrency) {
         this.subType = subType;
         this.stockCode = stockCode;
         this.market = market;
@@ -27,6 +28,7 @@ public class StockDetailResponse {
         this.quantity = quantity;
         this.avgBuyPrice = avgBuyPrice;
         this.dividendYield = dividendYield;
+        this.priceCurrency = priceCurrency;
     }
 
     public static StockDetailResponse from(StockDetail detail) {
@@ -34,7 +36,8 @@ public class StockDetailResponse {
                 detail.getSubType() != null ? detail.getSubType().name() : null,
                 detail.getStockCode(), detail.getMarket(), detail.getExchangeCode(),
                 detail.getCountry(), detail.getQuantity(),
-                detail.getAvgBuyPrice(), detail.getDividendYield()
+                detail.getAvgBuyPrice(), detail.getDividendYield(),
+                detail.getPriceCurrency() != null ? detail.getPriceCurrency().name() : null
         );
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/PortfolioItem.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/PortfolioItem.java
@@ -206,7 +206,8 @@ public class PortfolioItem {
                 this.stockDetail.getCountry(),
                 newQuantity,
                 newAvgBuyPrice,
-                this.stockDetail.getDividendYield()
+                this.stockDetail.getDividendYield(),
+                this.stockDetail.getPriceCurrency()
         );
         this.investedAmount = calcInvestedAmount(newAvgBuyPrice, newQuantity);
         this.updatedAt = LocalDateTime.now();
@@ -242,7 +243,8 @@ public class PortfolioItem {
                 this.stockDetail.getCountry(),
                 totalQuantity,
                 newAvgBuyPrice,
-                this.stockDetail.getDividendYield()
+                this.stockDetail.getDividendYield(),
+                this.stockDetail.getPriceCurrency()
         );
         this.investedAmount = calcInvestedAmount(newAvgBuyPrice, totalQuantity);
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/StockDetail.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/StockDetail.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.portfolio.domain.model;
 
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.PriceCurrency;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.StockSubType;
 import lombok.Getter;
 
@@ -15,6 +16,7 @@ public class StockDetail {
     private final Integer quantity;
     private final BigDecimal avgBuyPrice;
     private final BigDecimal dividendYield;
+    private final PriceCurrency priceCurrency;
 
     public StockDetail(StockSubType subType,
                        String stockCode,
@@ -23,7 +25,8 @@ public class StockDetail {
                        String country,
                        Integer quantity,
                        BigDecimal avgBuyPrice,
-                       BigDecimal dividendYield) {
+                       BigDecimal dividendYield,
+                       PriceCurrency priceCurrency) {
         this.subType = subType;
         this.stockCode = stockCode;
         this.market = market;
@@ -32,5 +35,6 @@ public class StockDetail {
         this.quantity = quantity;
         this.avgBuyPrice = avgBuyPrice;
         this.dividendYield = dividendYield;
+        this.priceCurrency = priceCurrency;
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/enums/PriceCurrency.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/enums/PriceCurrency.java
@@ -1,0 +1,17 @@
+package com.thlee.stock.market.stockmarket.portfolio.domain.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PriceCurrency {
+    KRW("원"),
+    USD("달러"),
+    JPY("엔"),
+    CNY("위안"),
+    HKD("홍콩달러"),
+    VND("동");
+
+    private final String label;
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockItemEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockItemEntity.java
@@ -36,6 +36,9 @@ public class StockItemEntity extends PortfolioItemEntity {
     @Column(name = "dividend_yield", precision = 5, scale = 2)
     private BigDecimal dividendYield;
 
+    @Column(name = "price_currency", length = 10)
+    private String priceCurrency;
+
     protected StockItemEntity() {
     }
 
@@ -55,7 +58,8 @@ public class StockItemEntity extends PortfolioItemEntity {
                            String country,
                            Integer quantity,
                            BigDecimal avgBuyPrice,
-                           BigDecimal dividendYield) {
+                           BigDecimal dividendYield,
+                           String priceCurrency) {
         super(id, userId, itemName, investedAmount, newsEnabled, region, memo, createdAt, updatedAt);
         this.subType = subType;
         this.stockCode = stockCode;
@@ -65,5 +69,6 @@ public class StockItemEntity extends PortfolioItemEntity {
         this.quantity = quantity;
         this.avgBuyPrice = avgBuyPrice;
         this.dividendYield = dividendYield;
+        this.priceCurrency = priceCurrency;
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/mapper/PortfolioItemMapper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/mapper/PortfolioItemMapper.java
@@ -5,6 +5,7 @@ import com.thlee.stock.market.stockmarket.portfolio.domain.model.*;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.AssetType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.BondSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.FundSubType;
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.PriceCurrency;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.RealEstateSubType;
 import com.thlee.stock.market.stockmarket.portfolio.domain.model.enums.StockSubType;
 import com.thlee.stock.market.stockmarket.portfolio.infrastructure.persistence.*;
@@ -32,7 +33,8 @@ public class PortfolioItemMapper {
                     stock.getCountry(),
                     stock.getQuantity(),
                     stock.getAvgBuyPrice(),
-                    stock.getDividendYield()
+                    stock.getDividendYield(),
+                    stock.getPriceCurrency() != null ? PriceCurrency.valueOf(stock.getPriceCurrency()) : PriceCurrency.KRW
             );
         } else if (entity instanceof BondItemEntity bond) {
             bondDetail = new BondDetail(
@@ -88,7 +90,8 @@ public class PortfolioItemMapper {
                         detail.getSubType() != null ? detail.getSubType().name() : null,
                         detail.getStockCode(), detail.getMarket(), detail.getExchangeCode(),
                         detail.getCountry(), detail.getQuantity(),
-                        detail.getAvgBuyPrice(), detail.getDividendYield()
+                        detail.getAvgBuyPrice(), detail.getDividendYield(),
+                        detail.getPriceCurrency() != null ? detail.getPriceCurrency().name() : null
                 );
             }
             case BOND -> {

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
@@ -35,7 +35,8 @@ public class PortfolioController {
                 request.getRegion(), request.getMemo(),
                 request.getSubType(), request.getStockCode(), request.getMarket(),
                 request.getExchangeCode(), request.getCountry(),
-                request.getQuantity(), request.getPurchasePrice(), request.getDividendYield());
+                request.getQuantity(), request.getPurchasePrice(), request.getDividendYield(),
+                request.getPriceCurrency());
         return ResponseEntity.ok(response);
     }
 
@@ -117,7 +118,8 @@ public class PortfolioController {
                 request.getItemName(), request.getMemo(),
                 request.getSubType(), request.getStockCode(), request.getMarket(),
                 request.getExchangeCode(), request.getCountry(),
-                request.getQuantity(), request.getPurchasePrice(), request.getDividendYield());
+                request.getQuantity(), request.getPurchasePrice(), request.getDividendYield(),
+                request.getPriceCurrency());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemAddRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemAddRequest.java
@@ -17,4 +17,5 @@ public class StockItemAddRequest {
     private Integer quantity;
     private BigDecimal purchasePrice;
     private BigDecimal dividendYield;
+    private String priceCurrency;
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemUpdateRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemUpdateRequest.java
@@ -16,4 +16,5 @@ public class StockItemUpdateRequest {
     private Integer quantity;
     private BigDecimal purchasePrice;
     private BigDecimal dividendYield;
+    private String priceCurrency;
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/application/StockPriceService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/application/StockPriceService.java
@@ -5,11 +5,13 @@ import com.thlee.stock.market.stockmarket.stock.application.dto.StockPriceRespon
 import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
 import com.thlee.stock.market.stockmarket.stock.domain.model.MarketType;
 import com.thlee.stock.market.stockmarket.stock.domain.model.StockPrice;
+import com.thlee.stock.market.stockmarket.stock.domain.service.ExchangeRatePort;
 import com.thlee.stock.market.stockmarket.stock.domain.service.StockPricePort;
 import com.thlee.stock.market.stockmarket.stock.presentation.dto.BulkStockPriceRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,10 +21,13 @@ import java.util.Map;
 public class StockPriceService {
 
     private final StockPricePort stockPricePort;
+    private final ExchangeRatePort exchangeRatePort;
 
     public StockPriceResponse getPrice(String stockCode, MarketType marketType, ExchangeCode exchangeCode) {
         StockPrice price = stockPricePort.getPrice(stockCode, marketType, exchangeCode);
-        return StockPriceResponse.from(price);
+        String currency = exchangeCode.getCurrency();
+        BigDecimal exchangeRate = exchangeRatePort.getRate(currency);
+        return StockPriceResponse.from(price, currency, exchangeRate);
     }
 
     public BulkStockPriceResponse getPrices(List<BulkStockPriceRequest.StockPriceItem> stocks) {

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/application/dto/StockPriceResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/application/dto/StockPriceResponse.java
@@ -4,6 +4,9 @@ import com.thlee.stock.market.stockmarket.stock.domain.model.StockPrice;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Getter
 @RequiredArgsConstructor
 public class StockPriceResponse {
@@ -21,8 +24,17 @@ public class StockPriceResponse {
     private final String open;
     private final String marketType;
     private final String exchangeCode;
+    private final String currency;
+    private final BigDecimal exchangeRateValue;
+    private final String currentPriceKrw;
 
     public static StockPriceResponse from(StockPrice price) {
+        return from(price, "KRW", BigDecimal.ONE);
+    }
+
+    public static StockPriceResponse from(StockPrice price, String currency, BigDecimal exchangeRate) {
+        String priceKrw = calculatePriceKrw(price.currentPrice(), exchangeRate);
+
         return new StockPriceResponse(
             price.stockCode(),
             price.currentPrice(),
@@ -36,7 +48,22 @@ public class StockPriceResponse {
             price.low(),
             price.open(),
             price.marketType().name(),
-            price.exchangeCode().name()
+            price.exchangeCode().name(),
+            currency,
+            exchangeRate,
+            priceKrw
         );
+    }
+
+    private static String calculatePriceKrw(String currentPrice, BigDecimal exchangeRate) {
+        if (currentPrice == null || currentPrice.isEmpty()) {
+            return "0";
+        }
+        try {
+            BigDecimal price = new BigDecimal(currentPrice.replace(",", ""));
+            return price.multiply(exchangeRate).setScale(0, RoundingMode.HALF_UP).toPlainString();
+        } catch (NumberFormatException e) {
+            return "0";
+        }
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/model/ExchangeCode.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/model/ExchangeCode.java
@@ -11,28 +11,29 @@ import lombok.RequiredArgsConstructor;
 public enum ExchangeCode {
 
     // 국내
-    KRX("한국거래소"),
+    KRX("한국거래소", "KRW"),
 
     // 미국
-    NAS("나스닥"),
-    NYS("뉴욕증권거래소"),
-    AMS("아멕스"),
+    NAS("나스닥", "USD"),
+    NYS("뉴욕증권거래소", "USD"),
+    AMS("아멕스", "USD"),
 
     // 중국
-    SHS("상해증권거래소"),
-    SHI("상해지수"),
-    SZS("심천증권거래소"),
-    SZI("심천지수"),
+    SHS("상해증권거래소", "CNY"),
+    SHI("상해지수", "CNY"),
+    SZS("심천증권거래소", "CNY"),
+    SZI("심천지수", "CNY"),
 
     // 일본
-    TSE("도쿄증권거래소"),
+    TSE("도쿄증권거래소", "JPY"),
 
     // 홍콩
-    HKS("홍콩증권거래소"),
+    HKS("홍콩증권거래소", "HKD"),
 
     // 베트남
-    HNX("하노이증권거래소"),
-    HSX("호치민증권거래소");
+    HNX("하노이증권거래소", "VND"),
+    HSX("호치민증권거래소", "VND");
 
     private final String description;
+    private final String currency;
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/service/ExchangeRatePort.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/service/ExchangeRatePort.java
@@ -1,0 +1,11 @@
+package com.thlee.stock.market.stockmarket.stock.domain.service;
+
+import java.math.BigDecimal;
+
+/**
+ * 환율 조회 포트.
+ * 통화코드에 대한 원화 환율 (1 외화 = N원)을 반환한다.
+ */
+public interface ExchangeRatePort {
+    BigDecimal getRate(String currency);
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/ExchangeRateCacheConfig.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/ExchangeRateCacheConfig.java
@@ -1,0 +1,22 @@
+package com.thlee.stock.market.stockmarket.stock.infrastructure.exchangerate.koreaexim;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class ExchangeRateCacheConfig {
+
+    @Bean
+    public CacheManager exchangeRateCacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("exchangeRate");
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .maximumSize(20));
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/KoreaEximExchangeRateAdapter.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/KoreaEximExchangeRateAdapter.java
@@ -1,0 +1,76 @@
+package com.thlee.stock.market.stockmarket.stock.infrastructure.exchangerate.koreaexim;
+
+import com.thlee.stock.market.stockmarket.stock.domain.service.ExchangeRatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 한국수출입은행 API를 통한 환율 조회 어댑터.
+ * 전체 통화를 한 번에 조회하여 캐싱하고, 개별 통화 요청 시 캐시에서 반환한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class KoreaEximExchangeRateAdapter implements ExchangeRatePort {
+
+    private final KoreaEximExchangeRateClient client;
+    private final Map<String, BigDecimal> rateCache = new ConcurrentHashMap<>();
+
+    private static final BigDecimal DEFAULT_RATE = BigDecimal.ONE;
+
+    /**
+     * JPY(100), IDR(100), VND(100) 등 100단위 통화 처리.
+     * 수출입은행은 JPY를 "JPY(100)" 코드로 반환하며, 환율도 100단위 기준이다.
+     */
+    private static final Map<String, String> CURRENCY_UNIT_MAP = Map.of(
+        "JPY(100)", "JPY",
+        "IDR(100)", "IDR",
+        "VND(100)", "VND"
+    );
+
+    @Cacheable(cacheManager = "exchangeRateCacheManager", cacheNames = "exchangeRate", key = "#currency")
+    @Override
+    public BigDecimal getRate(String currency) {
+        if ("KRW".equals(currency)) {
+            return BigDecimal.ONE;
+        }
+
+        loadRatesIfEmpty();
+
+        BigDecimal rate = rateCache.get(currency);
+        return rate != null ? rate : DEFAULT_RATE;
+    }
+
+    private void loadRatesIfEmpty() {
+        if (!rateCache.isEmpty()) {
+            return;
+        }
+
+        try {
+            List<KoreaEximExchangeRateClient.ExchangeRateItem> items = client.getExchangeRates();
+            for (KoreaEximExchangeRateClient.ExchangeRateItem item : items) {
+                String unit = item.getCurrencyUnit();
+                String baseRateStr = item.getBaseRate();
+                if (unit == null || baseRateStr == null) continue;
+
+                BigDecimal baseRate = new BigDecimal(baseRateStr.replace(",", ""));
+
+                // 100단위 통화 처리 (JPY(100) → JPY, 환율 / 100)
+                String mappedCurrency = CURRENCY_UNIT_MAP.get(unit);
+                if (mappedCurrency != null) {
+                    rateCache.put(mappedCurrency, baseRate.divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP));
+                } else {
+                    rateCache.put(unit, baseRate);
+                }
+            }
+        } catch (Exception e) {
+            // 조회 실패 시 빈 상태 유지, 다음 요청에서 재시도
+        }
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/KoreaEximExchangeRateClient.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/KoreaEximExchangeRateClient.java
@@ -1,0 +1,78 @@
+package com.thlee.stock.market.stockmarket.stock.infrastructure.exchangerate.koreaexim;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 한국수출입은행 환율 조회 클라이언트.
+ * 당일 매매기준율을 조회한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class KoreaEximExchangeRateClient {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+    private final KoreaEximProperties properties;
+
+    private static final int MAX_RETRY_DAYS = 5;
+
+    /**
+     * 환율을 조회한다.
+     * 비영업일이나 영업일 11시 이전에는 데이터가 없으므로,
+     * 당일부터 최대 5일 전까지 순차적으로 조회하여 가장 최근 영업일 환율을 반환한다.
+     *
+     * @return 통화별 환율 목록
+     */
+    public List<ExchangeRateItem> getExchangeRates() {
+        LocalDate date = LocalDate.now();
+
+        for (int i = 0; i < MAX_RETRY_DAYS; i++) {
+            List<ExchangeRateItem> result = fetchByDate(date.minusDays(i));
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<ExchangeRateItem> fetchByDate(LocalDate date) {
+        try {
+            List<ExchangeRateItem> result = restClient.get()
+                .uri(properties.getUrl() + "?authkey={authkey}&searchdate={searchdate}&data=AP01",
+                    properties.getAuthkey(), date.format(DATE_FORMAT))
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+
+            return (result != null && !result.isEmpty()) ? result : Collections.emptyList();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ExchangeRateItem {
+
+        @JsonProperty("cur_unit")
+        private String currencyUnit;     // 통화코드 (USD, JPY(100) 등)
+
+        @JsonProperty("deal_bas_r")
+        private String baseRate;         // 매매기준율 (쉼표 포함, 예: "1,380.5")
+
+        @JsonProperty("cur_nm")
+        private String currencyName;     // 통화명 (예: "미국 달러")
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/KoreaEximProperties.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/exchangerate/koreaexim/KoreaEximProperties.java
@@ -1,0 +1,16 @@
+package com.thlee.stock.market.stockmarket.stock.infrastructure.exchangerate.koreaexim;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "koreaexim.api")
+public class KoreaEximProperties {
+
+    private String url = "https://oapi.koreaexim.go.kr/site/program/financial/exchangeJSON";
+    private String authkey;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,12 @@ stock:
       service-key: ${DATAGOKR_SERVICE_KEY}
       num-of-rows: 100
 
+# 한국수출입은행 환율 API
+koreaexim:
+  api:
+    url: https://oapi.koreaexim.go.kr/site/program/financial/exchangeJSON
+    authkey: ${KOREAEXIM_API_KEY}
+
 # DART OpenAPI (전자공시시스템)
 dart:
   api:

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -595,7 +595,7 @@
                                                             <div>
                                                                 <div class="flex items-center gap-2">
                                                                     <span class="text-sm font-medium text-gray-800" x-text="item.itemName"></span>
-                                                                    <span class="text-xs text-gray-400" x-text="'원금 ' + Format.number(item.investedAmount, 0) + '원'"></span>
+                                                                    <span class="text-xs text-gray-400" x-text="'원금 ' + Format.number(getInvestedAmountKrw(item), 0) + '원'"></span>
                                                                     <span class="text-xs font-medium"
                                                                         :class="getProfitAmount(item) > 0 ? 'text-red-500' : getProfitAmount(item) < 0 ? 'text-blue-500' : 'text-gray-400'"
                                                                         x-text="Format.number(getEvalAmount(item), 0) + '원'"></span>
@@ -925,8 +925,15 @@
                                                     class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                             </div>
                                             <div>
-                                                <label class="block text-sm text-gray-600 mb-1">매수가 *</label>
-                                                <input type="number" x-model="portfolio.addForm.purchasePrice" placeholder="0"
+                                                <label class="block text-sm text-gray-600 mb-1">
+                                                    매수가 *
+                                                    <span x-show="portfolio.addForm.priceCurrency && portfolio.addForm.priceCurrency !== 'KRW'"
+                                                          class="text-blue-500 font-medium"
+                                                          x-text="'(' + portfolio.addForm.priceCurrency + ')'"></span>
+                                                </label>
+                                                <input type="number" x-model="portfolio.addForm.purchasePrice"
+                                                    :step="portfolio.addForm.priceCurrency && portfolio.addForm.priceCurrency !== 'KRW' ? '0.01' : '1'"
+                                                    :placeholder="portfolio.addForm.priceCurrency && portfolio.addForm.priceCurrency !== 'KRW' ? '0.00' : '0'"
                                                     class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                             </div>
                                             <div>
@@ -1047,7 +1054,7 @@
                                     </div>
                                 </template>
 
-                                <div>
+                                <div x-show="portfolio.selectedAssetType !== 'STOCK'">
                                     <label class="block text-sm text-gray-600 mb-1">리전</label>
                                     <select x-model="portfolio.addForm.region"
                                         class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
@@ -1119,8 +1126,15 @@
                                                 class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                         </div>
                                         <div>
-                                            <label class="block text-sm text-gray-600 mb-1">매수가 *</label>
-                                            <input type="number" x-model="portfolio.editForm.purchasePrice" placeholder="0"
+                                            <label class="block text-sm text-gray-600 mb-1">
+                                                매수가 *
+                                                <span x-show="portfolio.editForm.priceCurrency && portfolio.editForm.priceCurrency !== 'KRW'"
+                                                      class="text-blue-500 font-medium"
+                                                      x-text="'(' + portfolio.editForm.priceCurrency + ')'"></span>
+                                            </label>
+                                            <input type="number" x-model="portfolio.editForm.purchasePrice"
+                                                :step="portfolio.editForm.priceCurrency && portfolio.editForm.priceCurrency !== 'KRW' ? '0.01' : '1'"
+                                                :placeholder="portfolio.editForm.priceCurrency && portfolio.editForm.priceCurrency !== 'KRW' ? '0.00' : '0'"
                                                 class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                         </div>
                                         <div>
@@ -1277,9 +1291,16 @@
                                 class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1">매수 단가</label>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">
+                                매수 단가
+                                <span x-show="portfolio.purchaseItem?.stockDetail?.priceCurrency && portfolio.purchaseItem.stockDetail.priceCurrency !== 'KRW'"
+                                      class="text-blue-500 font-medium"
+                                      x-text="'(' + portfolio.purchaseItem.stockDetail.priceCurrency + ')'"></span>
+                            </label>
                             <input type="number" x-model="portfolio.purchaseForm.purchasePrice"
-                                placeholder="1주당 매수가" min="1"
+                                :step="portfolio.purchaseItem?.stockDetail?.priceCurrency && portfolio.purchaseItem.stockDetail.priceCurrency !== 'KRW' ? '0.01' : '1'"
+                                :placeholder="portfolio.purchaseItem?.stockDetail?.priceCurrency && portfolio.purchaseItem.stockDetail.priceCurrency !== 'KRW' ? '1주당 매수가 (외화)' : '1주당 매수가'"
+                                min="0.01"
                                 class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">
                         </div>
                     </div>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -522,15 +522,29 @@ function dashboard() {
         getEvalAmount(item) {
             if (item.assetType === 'STOCK' && item.stockDetail) {
                 var priceData = this.portfolio.stockPrices[item.stockDetail.stockCode];
-                if (priceData && priceData.currentPrice) {
-                    return parseFloat(priceData.currentPrice) * item.stockDetail.quantity;
+                if (priceData && priceData.currentPriceKrw) {
+                    return parseFloat(priceData.currentPriceKrw) * item.stockDetail.quantity;
                 }
             }
             return item.investedAmount;
         },
 
+        getExchangeRate(item) {
+            if (item.assetType !== 'STOCK' || !item.stockDetail) return 1;
+            // priceCurrency가 KRW이면 이미 원화이므로 환율 적용 불필요
+            var priceCurrency = item.stockDetail.priceCurrency;
+            if (!priceCurrency || priceCurrency === 'KRW') return 1;
+            var priceData = this.portfolio.stockPrices[item.stockDetail.stockCode];
+            if (!priceData || !priceData.exchangeRateValue) return 1;
+            return parseFloat(priceData.exchangeRateValue);
+        },
+
+        getInvestedAmountKrw(item) {
+            return item.investedAmount * this.getExchangeRate(item);
+        },
+
         getProfitAmount(item) {
-            return this.getEvalAmount(item) - item.investedAmount;
+            return this.getEvalAmount(item) - this.getInvestedAmountKrw(item);
         },
 
         getProfitRate(item) {
@@ -575,13 +589,15 @@ function dashboard() {
         },
 
         getTotalInvested() {
-            return this.portfolio.items.reduce(function(sum, item) { return sum + item.investedAmount; }, 0);
+            return this.portfolio.items.reduce(function(sum, item) {
+                return sum + this.getInvestedAmountKrw(item);
+            }.bind(this), 0);
         },
 
         getSubTotalInvested(assetType) {
             return this.portfolio.items
                 .filter(function(item) { return item.assetType === assetType; })
-                .reduce(function(sum, item) { return sum + item.investedAmount; }, 0);
+                .reduce(function(sum, item) { return sum + this.getInvestedAmountKrw(item); }.bind(this), 0);
         },
 
         getSubTotalEvalAmount(assetType) {
@@ -691,7 +707,11 @@ function dashboard() {
             if (item.assetType !== 'STOCK' || !item.stockDetail) return '';
             var priceData = this.portfolio.stockPrices[item.stockDetail.stockCode];
             if (!priceData || !priceData.currentPrice) return '';
-            var parts = ['현재가 ' + Format.number(priceData.currentPrice) + '원'];
+            var currency = priceData.currency || 'KRW';
+            var priceDisplay = currency === 'KRW'
+                ? '현재가 ' + Format.number(priceData.currentPrice) + '원'
+                : '현재가 ' + Format.number(priceData.currentPrice, 2) + ' ' + currency;
+            var parts = [priceDisplay];
             var rate = this.getProfitRate(item);
             if (rate !== null) {
                 var sign = rate >= 0 ? '+' : '';
@@ -708,7 +728,12 @@ function dashboard() {
                     var parts = [item.stockDetail.market + ':' + item.stockDetail.stockCode];
                     if (item.stockDetail.subType === 'ETF') parts.push('ETF');
                     if (item.stockDetail.quantity) parts.push(item.stockDetail.quantity + '주');
-                    if (item.stockDetail.avgBuyPrice) parts.push('평균 ' + Format.number(item.stockDetail.avgBuyPrice) + '원');
+                    if (item.stockDetail.avgBuyPrice) {
+                        var cur = item.stockDetail.priceCurrency;
+                        var suffix = (!cur || cur === 'KRW') ? '원' : ' ' + cur;
+                        var decimals = (!cur || cur === 'KRW') ? 0 : 2;
+                        parts.push('평균 ' + Format.number(item.stockDetail.avgBuyPrice, decimals) + suffix);
+                    }
                     return parts.join(' · ');
                 case 'BOND':
                     if (!item.bondDetail) return '';
@@ -799,6 +824,20 @@ function dashboard() {
             this.portfolio.addForm.ticker = stock.stockCode;
             this.portfolio.addForm.exchange = stock.marketType;
             this.portfolio.addForm.exchangeCode = stock.exchangeCode;
+            this.portfolio.addForm.region = stock.exchangeCode === 'KRX' ? 'DOMESTIC' : 'INTERNATIONAL';
+            this.portfolio.addForm.priceCurrency = this.getCurrencyByExchangeCode(stock.exchangeCode);
+        },
+
+        getCurrencyByExchangeCode(exchangeCode) {
+            var mapping = {
+                KRX: 'KRW',
+                NAS: 'USD', NYS: 'USD', AMS: 'USD',
+                SHS: 'CNY', SHI: 'CNY', SZS: 'CNY', SZI: 'CNY',
+                TSE: 'JPY',
+                HKS: 'HKD',
+                HNX: 'VND', HSX: 'VND'
+            };
+            return mapping[exchangeCode] || 'KRW';
         },
 
         clearSelectedStock() {
@@ -807,6 +846,18 @@ function dashboard() {
             this.portfolio.addForm.ticker = '';
             this.portfolio.addForm.exchange = '';
             this.portfolio.addForm.exchangeCode = '';
+        },
+
+        getCountryByExchangeCode(exchangeCode) {
+            var mapping = {
+                KRX: 'KR',
+                NAS: 'US', NYS: 'US', AMS: 'US',
+                SHS: 'CN', SHI: 'CN', SZS: 'CN', SZI: 'CN',
+                TSE: 'JP',
+                HKS: 'HK',
+                HNX: 'VN', HSX: 'VN'
+            };
+            return mapping[exchangeCode] || null;
         },
 
         async submitAddItem() {
@@ -845,10 +896,11 @@ function dashboard() {
                             stockCode: form.ticker,
                             market: form.exchange,
                             exchangeCode: form.exchangeCode,
-                            country: form.region === 'DOMESTIC' ? 'KR' : null,
+                            country: this.getCountryByExchangeCode(form.exchangeCode),
                             quantity: Number(form.quantity),
                             purchasePrice: Number(form.purchasePrice),
-                            dividendYield: form.dividendYield ? Number(form.dividendYield) : null
+                            dividendYield: form.dividendYield ? Number(form.dividendYield) : null,
+                            priceCurrency: form.priceCurrency || 'KRW'
                         });
                         break;
                     case 'BOND':
@@ -1082,6 +1134,7 @@ function dashboard() {
                         form.quantity = item.stockDetail.quantity;
                         form.purchasePrice = item.stockDetail.avgBuyPrice;
                         form.dividendYield = item.stockDetail.dividendYield;
+                        form.priceCurrency = item.stockDetail.priceCurrency || 'KRW';
                     }
                     break;
                 case 'BOND':
@@ -1133,6 +1186,7 @@ function dashboard() {
             this.portfolio.editForm.ticker = stock.stockCode;
             this.portfolio.editForm.exchange = stock.marketType;
             this.portfolio.editForm.exchangeCode = stock.exchangeCode;
+            this.portfolio.editForm.priceCurrency = this.getCurrencyByExchangeCode(stock.exchangeCode);
         },
 
         async submitEditItem() {
@@ -1174,7 +1228,8 @@ function dashboard() {
                             country: stockDetail.country,
                             quantity: Number(form.quantity),
                             purchasePrice: Number(form.purchasePrice),
-                            dividendYield: form.dividendYield ? Number(form.dividendYield) : null
+                            dividendYield: form.dividendYield ? Number(form.dividendYield) : null,
+                            priceCurrency: form.priceCurrency || 'KRW'
                         });
                         break;
                     case 'BOND':


### PR DESCRIPTION
## Summary
- 한국수출입은행 API를 통한 환율 조회 (Caffeine 1시간 캐시, 비영업일 자동 fallback)
- ExchangeCode enum에 currency 필드 추가 (12개 거래소 → 6개 통화 매핑)
- StockPriceResponse에 currency, exchangeRate, currentPriceKrw 필드 추가
- PriceCurrency enum 신규 추가 (KRW, USD, JPY, CNY, HKD, VND)
- StockDetail/Entity에 priceCurrency 필드 추가 (매수가 통화 명시)
- 해외 주식 개별 종목은 현지 통화 표시 (26.03 USD), 포트폴리오 합산은 원화 환산
- 등록/수정/추가매수 폼에 통화 단위 표시 및 외화 입력 지원
- 주식 등록 시 exchangeCode 기반 country/region/priceCurrency 자동 설정

## Test plan
- [ ] 해외 주식 등록 시 매수가 외화 입력 확인 (라벨에 USD 등 통화 표시)
- [ ] 해외 주식 현재가가 현지 통화로 표시되는지 확인 (26.03 USD)
- [ ] 포트폴리오 총 평가금액/수익금이 원화 환산되어 합산되는지 확인
- [ ] 국내 주식 기존 동작에 영향 없는지 확인
- [ ] 수정 폼에서 priceCurrency가 유지되는지 확인
- [ ] 추가 매수 폼에서 통화 단위 표시 확인
- [ ] KOREAEXIM_API_KEY 환경변수 설정 후 환율 정상 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)