### PR TITLE
feat(portfolio): 해외 주식 원화 투입금액 직접 입력 기능 추가

### DIFF
--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
@@ -44,11 +44,12 @@ public class PortfolioService {
                                                String subType, String stockCode, String market,
                                                String exchangeCode, String country,
                                                Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield,
-                                               String priceCurrency) {
+                                               String priceCurrency, BigDecimal investedAmountKrw) {
         StockDetail detail = new StockDetail(
                 subType != null ? StockSubType.valueOf(subType) : null,
                 stockCode, market, exchangeCode, country, quantity, purchasePrice, dividendYield,
-                priceCurrency != null ? PriceCurrency.valueOf(priceCurrency) : PriceCurrency.KRW
+                priceCurrency != null ? PriceCurrency.valueOf(priceCurrency) : PriceCurrency.KRW,
+                investedAmountKrw
         );
         PortfolioItem item = PortfolioItem.createWithStock(
                 userId, itemName, Region.valueOf(region), detail);
@@ -164,14 +165,15 @@ public class PortfolioService {
                                                   String subType, String stockCode, String market,
                                                   String exchangeCode, String country,
                                                   Integer quantity, BigDecimal purchasePrice, BigDecimal dividendYield,
-                                                  String priceCurrency) {
+                                                  String priceCurrency, BigDecimal investedAmountKrw) {
         PortfolioItem item = findUserItem(userId, itemId);
         item.updateItemName(itemName);
         item.updateMemo(memo);
         StockDetail detail = new StockDetail(
                 subType != null ? StockSubType.valueOf(subType) : null,
                 stockCode, market, exchangeCode, country, quantity, purchasePrice, dividendYield,
-                priceCurrency != null ? PriceCurrency.valueOf(priceCurrency) : PriceCurrency.KRW
+                priceCurrency != null ? PriceCurrency.valueOf(priceCurrency) : PriceCurrency.KRW,
+                investedAmountKrw
         );
         item.updateStockDetail(detail);
         PortfolioItem saved = portfolioItemRepository.save(item);

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/StockDetailResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/StockDetailResponse.java
@@ -16,10 +16,11 @@ public class StockDetailResponse {
     private final BigDecimal avgBuyPrice;
     private final BigDecimal dividendYield;
     private final String priceCurrency;
+    private final BigDecimal investedAmountKrw;
 
     private StockDetailResponse(String subType, String stockCode, String market, String exchangeCode,
                                 String country, Integer quantity, BigDecimal avgBuyPrice,
-                                BigDecimal dividendYield, String priceCurrency) {
+                                BigDecimal dividendYield, String priceCurrency, BigDecimal investedAmountKrw) {
         this.subType = subType;
         this.stockCode = stockCode;
         this.market = market;
@@ -29,6 +30,7 @@ public class StockDetailResponse {
         this.avgBuyPrice = avgBuyPrice;
         this.dividendYield = dividendYield;
         this.priceCurrency = priceCurrency;
+        this.investedAmountKrw = investedAmountKrw;
     }
 
     public static StockDetailResponse from(StockDetail detail) {
@@ -37,7 +39,8 @@ public class StockDetailResponse {
                 detail.getStockCode(), detail.getMarket(), detail.getExchangeCode(),
                 detail.getCountry(), detail.getQuantity(),
                 detail.getAvgBuyPrice(), detail.getDividendYield(),
-                detail.getPriceCurrency() != null ? detail.getPriceCurrency().name() : null
+                detail.getPriceCurrency() != null ? detail.getPriceCurrency().name() : null,
+                detail.getInvestedAmountKrw()
         );
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/PortfolioItem.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/PortfolioItem.java
@@ -207,7 +207,8 @@ public class PortfolioItem {
                 newQuantity,
                 newAvgBuyPrice,
                 this.stockDetail.getDividendYield(),
-                this.stockDetail.getPriceCurrency()
+                this.stockDetail.getPriceCurrency(),
+                this.stockDetail.getInvestedAmountKrw()
         );
         this.investedAmount = calcInvestedAmount(newAvgBuyPrice, newQuantity);
         this.updatedAt = LocalDateTime.now();
@@ -244,7 +245,8 @@ public class PortfolioItem {
                 totalQuantity,
                 newAvgBuyPrice,
                 this.stockDetail.getDividendYield(),
-                this.stockDetail.getPriceCurrency()
+                this.stockDetail.getPriceCurrency(),
+                this.stockDetail.getInvestedAmountKrw()
         );
         this.investedAmount = calcInvestedAmount(newAvgBuyPrice, totalQuantity);
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/StockDetail.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/StockDetail.java
@@ -17,6 +17,7 @@ public class StockDetail {
     private final BigDecimal avgBuyPrice;
     private final BigDecimal dividendYield;
     private final PriceCurrency priceCurrency;
+    private final BigDecimal investedAmountKrw;
 
     public StockDetail(StockSubType subType,
                        String stockCode,
@@ -26,7 +27,8 @@ public class StockDetail {
                        Integer quantity,
                        BigDecimal avgBuyPrice,
                        BigDecimal dividendYield,
-                       PriceCurrency priceCurrency) {
+                       PriceCurrency priceCurrency,
+                       BigDecimal investedAmountKrw) {
         this.subType = subType;
         this.stockCode = stockCode;
         this.market = market;
@@ -36,5 +38,6 @@ public class StockDetail {
         this.avgBuyPrice = avgBuyPrice;
         this.dividendYield = dividendYield;
         this.priceCurrency = priceCurrency;
+        this.investedAmountKrw = investedAmountKrw;
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockItemEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/StockItemEntity.java
@@ -39,6 +39,9 @@ public class StockItemEntity extends PortfolioItemEntity {
     @Column(name = "price_currency", length = 10)
     private String priceCurrency;
 
+    @Column(name = "invested_amount_krw", precision = 18, scale = 2)
+    private BigDecimal investedAmountKrw;
+
     protected StockItemEntity() {
     }
 
@@ -59,7 +62,8 @@ public class StockItemEntity extends PortfolioItemEntity {
                            Integer quantity,
                            BigDecimal avgBuyPrice,
                            BigDecimal dividendYield,
-                           String priceCurrency) {
+                           String priceCurrency,
+                           BigDecimal investedAmountKrw) {
         super(id, userId, itemName, investedAmount, newsEnabled, region, memo, createdAt, updatedAt);
         this.subType = subType;
         this.stockCode = stockCode;
@@ -70,5 +74,6 @@ public class StockItemEntity extends PortfolioItemEntity {
         this.avgBuyPrice = avgBuyPrice;
         this.dividendYield = dividendYield;
         this.priceCurrency = priceCurrency;
+        this.investedAmountKrw = investedAmountKrw;
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/mapper/PortfolioItemMapper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/mapper/PortfolioItemMapper.java
@@ -34,7 +34,8 @@ public class PortfolioItemMapper {
                     stock.getQuantity(),
                     stock.getAvgBuyPrice(),
                     stock.getDividendYield(),
-                    stock.getPriceCurrency() != null ? PriceCurrency.valueOf(stock.getPriceCurrency()) : PriceCurrency.KRW
+                    stock.getPriceCurrency() != null ? PriceCurrency.valueOf(stock.getPriceCurrency()) : PriceCurrency.KRW,
+                    stock.getInvestedAmountKrw()
             );
         } else if (entity instanceof BondItemEntity bond) {
             bondDetail = new BondDetail(
@@ -91,7 +92,8 @@ public class PortfolioItemMapper {
                         detail.getStockCode(), detail.getMarket(), detail.getExchangeCode(),
                         detail.getCountry(), detail.getQuantity(),
                         detail.getAvgBuyPrice(), detail.getDividendYield(),
-                        detail.getPriceCurrency() != null ? detail.getPriceCurrency().name() : null
+                        detail.getPriceCurrency() != null ? detail.getPriceCurrency().name() : null,
+                        detail.getInvestedAmountKrw()
                 );
             }
             case BOND -> {

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
@@ -36,7 +36,7 @@ public class PortfolioController {
                 request.getSubType(), request.getStockCode(), request.getMarket(),
                 request.getExchangeCode(), request.getCountry(),
                 request.getQuantity(), request.getPurchasePrice(), request.getDividendYield(),
-                request.getPriceCurrency());
+                request.getPriceCurrency(), request.getInvestedAmountKrw());
         return ResponseEntity.ok(response);
     }
 
@@ -119,7 +119,7 @@ public class PortfolioController {
                 request.getSubType(), request.getStockCode(), request.getMarket(),
                 request.getExchangeCode(), request.getCountry(),
                 request.getQuantity(), request.getPurchasePrice(), request.getDividendYield(),
-                request.getPriceCurrency());
+                request.getPriceCurrency(), request.getInvestedAmountKrw());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemAddRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemAddRequest.java
@@ -18,4 +18,5 @@ public class StockItemAddRequest {
     private BigDecimal purchasePrice;
     private BigDecimal dividendYield;
     private String priceCurrency;
+    private BigDecimal investedAmountKrw;
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemUpdateRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/dto/StockItemUpdateRequest.java
@@ -17,4 +17,5 @@ public class StockItemUpdateRequest {
     private BigDecimal purchasePrice;
     private BigDecimal dividendYield;
     private String priceCurrency;
+    private BigDecimal investedAmountKrw;
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -942,6 +942,12 @@
                                                     class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                             </div>
                                         </div>
+                                        <!-- 해외 주식: 실제 투입 원화 -->
+                                        <div x-show="portfolio.addForm.priceCurrency && portfolio.addForm.priceCurrency !== 'KRW'" class="col-span-3">
+                                            <label class="block text-sm text-gray-600 mb-1">실제 투입 원화 (KRW)</label>
+                                            <input type="number" x-model="portfolio.addForm.investedAmountKrw" placeholder="실제 투자한 원화 금액"
+                                                class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                        </div>
                                     </div>
                                 </template>
 
@@ -1140,6 +1146,12 @@
                                         <div>
                                             <label class="block text-sm text-gray-600 mb-1">배당률(%)</label>
                                             <input type="number" step="0.01" x-model="portfolio.editForm.dividendYield" placeholder="0.00"
+                                                class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                        </div>
+                                        <!-- 해외 주식: 실제 투입 원화 -->
+                                        <div x-show="portfolio.editForm.priceCurrency && portfolio.editForm.priceCurrency !== 'KRW'" class="col-span-3">
+                                            <label class="block text-sm text-gray-600 mb-1">실제 투입 원화 (KRW)</label>
+                                            <input type="number" x-model="portfolio.editForm.investedAmountKrw" placeholder="실제 투자한 원화 금액"
                                                 class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                         </div>
                                     </div>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -540,6 +540,10 @@ function dashboard() {
         },
 
         getInvestedAmountKrw(item) {
+            // 해외 주식: 사용자가 입력한 원화 투자금액 우선 사용
+            if (item.assetType === 'STOCK' && item.stockDetail && item.stockDetail.investedAmountKrw) {
+                return parseFloat(item.stockDetail.investedAmountKrw);
+            }
             return item.investedAmount * this.getExchangeRate(item);
         },
 
@@ -900,7 +904,8 @@ function dashboard() {
                             quantity: Number(form.quantity),
                             purchasePrice: Number(form.purchasePrice),
                             dividendYield: form.dividendYield ? Number(form.dividendYield) : null,
-                            priceCurrency: form.priceCurrency || 'KRW'
+                            priceCurrency: form.priceCurrency || 'KRW',
+                            investedAmountKrw: form.investedAmountKrw ? Number(form.investedAmountKrw) : null
                         });
                         break;
                     case 'BOND':
@@ -1135,6 +1140,7 @@ function dashboard() {
                         form.purchasePrice = item.stockDetail.avgBuyPrice;
                         form.dividendYield = item.stockDetail.dividendYield;
                         form.priceCurrency = item.stockDetail.priceCurrency || 'KRW';
+                        form.investedAmountKrw = item.stockDetail.investedAmountKrw;
                     }
                     break;
                 case 'BOND':
@@ -1229,7 +1235,8 @@ function dashboard() {
                             quantity: Number(form.quantity),
                             purchasePrice: Number(form.purchasePrice),
                             dividendYield: form.dividendYield ? Number(form.dividendYield) : null,
-                            priceCurrency: form.priceCurrency || 'KRW'
+                            priceCurrency: form.priceCurrency || 'KRW',
+                            investedAmountKrw: form.investedAmountKrw ? Number(form.investedAmountKrw) : null
                         });
                         break;
                     case 'BOND':


### PR DESCRIPTION
- StockDetail/Entity에 investedAmountKrw 필드 추가
- 해외 주식 등록/수정 폼에 "실제 투입 원화" 입력란 추가
- getInvestedAmountKrw()에서 사용자 입력 원화 우선 사용, 없으면 환율 계산 fallback
- 매수 시점 환율과 현재 환율 차이로 인한 원금 왜곡 문제 해결