### PR TITLE
재무제표 UI 개선 + 뉴스 키워드 구독 모델 리팩토링

### DIFF
--- a/src/main/java/com/thlee/stock/market/stockmarket/news/application/KeywordServiceImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/news/application/KeywordServiceImpl.java
@@ -8,6 +8,8 @@ import com.thlee.stock.market.stockmarket.news.domain.model.UserKeyword;
 import com.thlee.stock.market.stockmarket.news.domain.repository.KeywordRepository;
 import com.thlee.stock.market.stockmarket.news.domain.repository.NewsRepository;
 import com.thlee.stock.market.stockmarket.news.domain.repository.UserKeywordRepository;
+import com.thlee.stock.market.stockmarket.portfolio.domain.model.PortfolioItem;
+import com.thlee.stock.market.stockmarket.portfolio.domain.repository.PortfolioItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,7 @@ public class KeywordServiceImpl implements KeywordService {
     private final KeywordRepository keywordRepository;
     private final UserKeywordRepository userKeywordRepository;
     private final NewsRepository newsRepository;
+    private final PortfolioItemRepository portfolioItemRepository;
 
     @Override
     @Transactional
@@ -99,11 +102,17 @@ public class KeywordServiceImpl implements KeywordService {
                 .orElseThrow(() -> new IllegalArgumentException("구독 정보를 찾을 수 없습니다."));
         subscription.deactivate();
         userKeywordRepository.save(subscription);
+
+        // 포트폴리오 항목의 newsEnabled도 OFF
+        disablePortfolioNewsByKeywordId(userId, keywordId);
     }
 
     @Override
     @Transactional
     public void unsubscribeKeyword(Long userId, Long keywordId) {
+        // 포트폴리오 항목의 newsEnabled OFF
+        disablePortfolioNewsByKeywordId(userId, keywordId);
+
         // 1. UserKeyword 삭제
         userKeywordRepository.deleteByUserIdAndKeywordId(userId, keywordId);
 
@@ -113,5 +122,16 @@ public class KeywordServiceImpl implements KeywordService {
             newsRepository.deleteByKeywordId(keywordId);
             keywordRepository.deleteById(keywordId);
         }
+    }
+
+    private void disablePortfolioNewsByKeywordId(Long userId, Long keywordId) {
+        keywordRepository.findById(keywordId).ifPresent(keyword -> {
+            List<PortfolioItem> items = portfolioItemRepository
+                    .findByUserIdAndItemNameAndNewsEnabled(userId, keyword.getKeyword(), true);
+            for (PortfolioItem item : items) {
+                item.disableNews();
+                portfolioItemRepository.save(item);
+            }
+        });
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/repository/PortfolioItemRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/repository/PortfolioItemRepository.java
@@ -33,6 +33,11 @@ public interface PortfolioItemRepository {
     List<PortfolioItem> findByNewsEnabled(boolean newsEnabled);
 
     /**
+     * 사용자별 종목명 + 뉴스 활성화 상태로 조회
+     */
+    List<PortfolioItem> findByUserIdAndItemNameAndNewsEnabled(Long userId, String itemName, boolean newsEnabled);
+
+    /**
      * 중복 확인
      */
     boolean existsByUserIdAndItemNameAndAssetType(Long userId, String itemName, AssetType assetType);

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemJpaRepository.java
@@ -14,4 +14,6 @@ public interface PortfolioItemJpaRepository extends JpaRepository<PortfolioItemE
     List<PortfolioItemEntity> findByNewsEnabled(boolean newsEnabled);
 
     boolean existsByUserIdAndItemNameAndAssetType(Long userId, String itemName, String assetType);
+
+    List<PortfolioItemEntity> findByUserIdAndItemNameAndNewsEnabled(Long userId, String itemName, boolean newsEnabled);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemRepositoryImpl.java
@@ -50,6 +50,14 @@ public class PortfolioItemRepositoryImpl implements PortfolioItemRepository {
     }
 
     @Override
+    public List<PortfolioItem> findByUserIdAndItemNameAndNewsEnabled(Long userId, String itemName, boolean newsEnabled) {
+        return portfolioItemJpaRepository.findByUserIdAndItemNameAndNewsEnabled(userId, itemName, newsEnabled)
+                .stream()
+                .map(PortfolioItemMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public boolean existsByUserIdAndItemNameAndAssetType(Long userId, String itemName, AssetType assetType) {
         return portfolioItemJpaRepository.existsByUserIdAndItemNameAndAssetType(userId, itemName, assetType.name());
     }

--- a/src/main/resources/db/migration/news_keyword_backfill_portfolio.sql
+++ b/src/main/resources/db/migration/news_keyword_backfill_portfolio.sql
@@ -1,0 +1,19 @@
+-- ============================================================
+-- 기존 newsEnabled=true 포트폴리오 항목에 대한 keyword + user_keyword 생성
+-- 뉴스 키워드 구독 모델 리팩토링 이후 보정 스크립트 (PostgreSQL)
+-- ============================================================
+
+-- 1. newsEnabled=true인 포트폴리오 항목의 종목명으로 keyword 생성 (중복 무시)
+INSERT INTO keyword (keyword, region, created_at)
+SELECT DISTINCT p.item_name, p.region, NOW()
+FROM portfolio_item p
+WHERE p.news_enabled = true
+ON CONFLICT (keyword, region) DO NOTHING;
+
+-- 2. user_keyword 구독 관계 생성
+INSERT INTO user_keyword (user_id, keyword_id, active, created_at, updated_at)
+SELECT p.user_id, k.id, true, NOW(), NOW()
+FROM portfolio_item p
+JOIN keyword k ON k.keyword = p.item_name AND k.region = p.region
+WHERE p.news_enabled = true
+ON CONFLICT (user_id, keyword_id) DO NOTHING;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -708,12 +708,12 @@
                                                                     x-text="getStockPriceSummary(item)"></p>
                                                             </div>
                                                             <div class="flex items-center gap-2">
-                                                                <!-- 뉴스 토글 (현금 제외) -->
+                                                                <!-- 키워드 추가/삭제 (현금, ETF 제외) -->
                                                                 <button x-show="item.assetType !== 'CASH' && item.stockDetail?.subType !== 'ETF'"
                                                                     @click.stop="toggleNews(item)"
                                                                     :class="item.newsEnabled ? 'text-green-600 hover:text-green-800' : 'text-gray-400 hover:text-gray-600'"
                                                                     class="text-xs font-medium transition"
-                                                                    x-text="item.newsEnabled ? '뉴스 ON' : '뉴스 OFF'">
+                                                                    x-text="item.newsEnabled ? '키워드 삭제' : '키워드 추가'">
                                                                 </button>
                                                                 <!-- 재무상세 (국내 주식만) -->
                                                                 <button x-show="item.assetType === 'STOCK' && item.stockDetail?.country === 'KR' && item.stockDetail?.subType !== 'ETF'"
@@ -799,7 +799,7 @@
                                                                     @click.stop="toggleNews(item)"
                                                                     :class="item.newsEnabled ? 'text-green-600 hover:text-green-800' : 'text-gray-400 hover:text-gray-600'"
                                                                     class="text-xs font-medium transition"
-                                                                    x-text="item.newsEnabled ? '뉴스 ON' : '뉴스 OFF'">
+                                                                    x-text="item.newsEnabled ? '키워드 삭제' : '키워드 추가'">
                                                                 </button>
                                                                 <button x-show="item.assetType === 'STOCK'"
                                                                     @click.stop="openPurchaseModal(item)"


### PR DESCRIPTION
## Summary
- 재무제표 슬라이드 패널 UI 개선 및 DART API 에러 코드 세분화
- 뉴스 시스템을 키워드 구독 모델로 전면 리팩토링
  - Keyword를 공유 리소스로 변경, UserKeyword N:M 구독 관계 도입
  - News 테이블에서 소유권 정보 분리 (purpose/sourceId → keywordId)
  - 포트폴리오 뉴스를 키워드 기반으로 통합
  - 키워드 비활성화/삭제 시 포트폴리오 newsEnabled 연동
  - NewsSource, NewsPurpose 등 불필요 코드 삭제
- 재무상세 기본 연도를 현재년도로 변경 + ETF 뉴스/재무상세 버튼 숨김
- 포트폴리오 UI 문구 "뉴스 ON/OFF" → "키워드 추가/키워드 삭제"
- PostgreSQL 마이그레이션 스크립트 포함

## Test plan
- [ ] 키워드 등록/조회/활성화/비활성화/삭제 동작 확인
- [ ] 키워드 클릭 시 뉴스 조회 정상 동작 확인
- [ ] 포트폴리오 키워드 추가/삭제 시 keyword 자동 생성/비활성화 확인
- [ ] 키워드 화면에서 삭제/비활성화 시 포트폴리오 newsEnabled OFF 연동 확인
- [ ] 동일 키워드 등록 시 기존 키워드 재사용 확인
- [ ] ETF 종목에서 키워드/재무상세 버튼 숨김 확인
- [ ] 재무상세 기본 연도가 현재년도로 표시되는지 확인
- [ ] 마이그레이션 스크립트 실행 후 데이터 정합성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)