### PR TITLE
feat(favorite): 관심지표 표시 모드 토글 (그래프 ↔ 지표) (#38)

### DIFF
--- a/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
+++ b/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
@@ -4,26 +4,36 @@
 
 ## 작업 리스트
 
-### Domain 계층
-- [ ] `FavoriteDisplayMode` enum 신규 작성 (INDICATOR, GRAPH)
-- [ ] `FavoriteIndicator` 도메인 모델에 `displayMode` 필드 추가
-- [ ] `FavoriteIndicator.changeDisplayMode(FavoriteDisplayMode)` 도메인 메서드 추가
-- [ ] `FavoriteIndicatorRepository` 포트에 `updateDisplayMode(...)` 메서드 추가
+### Domain 계층 (favorite)
+- [x] `FavoriteDisplayMode` enum 신규 작성 (INDICATOR, GRAPH)
+- [x] `FavoriteIndicator` 도메인 모델에 `displayMode` 필드 추가
+- [x] `FavoriteIndicator.changeDisplayMode(FavoriteDisplayMode)` 도메인 메서드 추가
+- [x] `FavoriteIndicatorRepository` 포트에 `updateDisplayMode(...)` 메서드 추가
 
-### Infrastructure 계층
-- [ ] `UserFavoriteIndicatorEntity`에 `display_mode` 컬럼 추가 — `@Enumerated(EnumType.STRING)` + `columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'"` **— Entity 변경 사전 승인 필요**
-- [ ] `FavoriteIndicatorMapper`: Entity ↔ Domain displayMode 매핑 추가
-- [ ] `FavoriteIndicatorRepositoryImpl.updateDisplayMode(...)` 구현
-- [ ] `UserFavoriteIndicatorJpaRepository`: `findByUserIdAndSourceTypeAndIndicatorCode(...)` 추가 (단건 조회)
+### Infrastructure 계층 (favorite)
+- [x] `UserFavoriteIndicatorEntity`에 `display_mode` 컬럼 추가 — `@Enumerated(EnumType.STRING)` + `columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'"` **— Entity 변경 사전 승인 완료**
+- [x] `FavoriteIndicatorMapper`: Entity ↔ Domain displayMode 매핑 추가
+- [x] `FavoriteIndicatorRepositoryImpl.updateDisplayMode(...)` 구현
+- [x] `UserFavoriteIndicatorJpaRepository.updateDisplayMode(...)` `@Modifying` 쿼리 추가
 
-### Application 계층
+### Economics 모듈 신규 history 조회 메서드 추가 (favorite 가 활용)
+- [ ] `EcosIndicatorRepository.findHistory(className, keystatName, limit)` 포트 추가
+- [ ] `EcosIndicatorJpaRepository`에 native ROW_NUMBER 쿼리로 `findHistory(...)` 추가
+- [ ] `EcosIndicatorRepositoryImpl.findHistory(...)` 구현 (Entity → Domain 매핑)
+- [ ] `EcosIndicatorService.findHistory(className, keystatName, limit)` 위임 메서드 추가
+- [ ] `GlobalIndicatorRepository.findHistory(countryName, indicatorType, limit)` 포트 추가
+- [ ] `GlobalIndicatorJpaRepository.findHistory(...)` native ROW_NUMBER 쿼리 추가
+- [ ] `GlobalIndicatorRepositoryImpl.findHistory(...)` 구현
+- [ ] `GlobalIndicatorQueryService.findHistory(countryName, indicatorType, limit)` 위임 메서드 추가
+
+### Application 계층 (favorite)
 - [ ] `FavoriteIndicatorService.changeDisplayMode(userId, sourceType, indicatorCode, mode)` 메서드 추가
-- [ ] `FavoriteIndicatorService.findEnrichedWithHistory(userId)` — 그래프 모드 항목에 한해 시계열 포함
-- [ ] EcosIndicatorService.getHistoryByCategory()/GlobalIndicatorQueryService.getHistoryByIndicatorType() 활용
-- [ ] 시계열 조회 N+1 방지 — 한 번에 batch 조회 후 Map 매핑
+- [ ] `findEnrichedByUserId(userId)` 확장: GRAPH 모드 항목에 한해 시계열을 함께 모아 응답에 포함
+- [ ] EnrichedEcosFavorite/EnrichedGlobalFavorite 레코드에 `history: List<HistoryPoint>` 추가
+- [ ] indicatorCode 파싱하여 economics 모듈 신규 `findHistory(...)` 호출 (GRAPH 항목별 단건 조회)
 
 ### Presentation 계층
-- [ ] `PUT /api/favorites/display-mode` API 신규 추가 (요청: sourceType, indicatorCode, mode)
+- [ ] `PUT /api/favorites/display-mode` API 신규 추가
 - [ ] `FavoriteDisplayModeRequest` DTO 신규 작성
 - [ ] `EnrichedFavoriteResponse`의 EcosItem/GlobalItem에 `displayMode`, `history` 필드 추가
 - [ ] `EnrichedHistoryPoint` DTO 신규 작성 (snapshotDate, dataValue)
@@ -45,109 +55,117 @@
 2. 마지막 선택값은 **DB 저장**으로 영속화
 3. 대시보드에서 **그래프 영역과 단순 지표 영역을 분리**
 
-현재 `/api/favorites/enriched`는 최신값만 반환, 프론트는 단순 카드로만 표시. 시계열 데이터는 economics 모듈에 이미 조회 API 존재 (`EcosIndicatorService.getHistoryByCategory`, `GlobalIndicatorQueryService.getHistoryByIndicatorType`).
+현재 `/api/favorites/enriched`는 최신값만 반환, 프론트는 단순 카드로만 표시.
+
+**[설계 변경]** 초기 설계에서 활용하려던 `EcosIndicatorService.getHistoryByCategory()` / `GlobalIndicatorQueryService.getHistoryByIndicatorType()` 두 메서드는 **`(className, keystatName, cycle)` 또는 `(country, cycle)` 조합당 최신 1행만 반환**하는 것으로 확인됨 (cycle별 deduplicate). 시계열 그래프용 데이터가 아니므로 economics 모듈에 **신규 history 조회 메서드**를 추가한다.
 
 ---
 
 ## 핵심 결정
 
-- **표시 모드 식별 단위**: `(userId, sourceType, indicatorCode)` 단위로 displayMode 저장 (기존 unique 키와 동일). 사용자별 개별 지표마다 모드 다름.
-- **enum 값**: `INDICATOR`(기본), `GRAPH` 두 가지. 추후 확장 여지 둠.
-- **DB default 처리**: `@Column(columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'")` 방식 사용. `ddl-auto: update`가 ALTER TABLE 시 default까지 포함하여 기존 row에 'INDICATOR' 자동 적용 → 별도 SQL 마이그레이션 파일 불필요.
-- **시계열 데이터 전달 방식**: 단순 enriched 응답에 history 배열을 함께 담음 (별도 endpoint 분리하지 않음). 단, **GRAPH 모드 항목에만** history 포함 → 트래픽 절감.
-- **시계열 길이**: 우선 최근 30포인트 한도. 차트 가독성과 응답 크기 균형.
-- **프론트 영역 분리**: 한 화면에 두 섹션(`#favoriteGraphSection`, `#favoriteIndicatorSection`)을 두고, 카드 단위로 항목을 분배. 같은 카드를 토글하면 다른 섹션으로 이동.
-- **토글 UX**: 카드 우상단 작은 토글 버튼. 즉시 PUT 호출 → 성공 시 카드를 반대편 섹션으로 이동(전체 새로고침 X).
+- **표시 모드 식별 단위**: `(userId, sourceType, indicatorCode)` 단위로 displayMode 저장 (기존 unique 키와 동일).
+- **enum 값**: `INDICATOR`(기본), `GRAPH` 두 가지.
+- **DB default 처리**: `@Column(columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'")` + `ddl-auto: update`로 ALTER TABLE 자동 처리. 별도 SQL 마이그레이션 불필요.
+- **시계열 데이터 전달 방식**: `/api/favorites/enriched` 응답에 history 배열을 함께 담음. **GRAPH 모드 항목에만** 포함 → 트래픽 절감.
+- **시계열 길이**: 우선 최근 30포인트.
+- **시계열 조회 방식 (변경)**: GRAPH 항목별로 economics 모듈의 신규 `findHistory(...)`를 단건 호출. 사용자 1인의 GRAPH 항목 수가 수 개 ~ 수십 개 수준이고 limit가 작아 부하 미미. 추후 N+1 영향 발생 시 batch IN 쿼리로 전환.
+- **economics history 쿼리**: PostgreSQL native + ROW_NUMBER로 `(className, keystatName)` 또는 `(countryName, indicatorType)` 조합당 최근 N개 snapshotDate desc 반환.
+- **프론트 영역 분리**: 한 화면에 두 섹션(`#favoriteGraphSection`, `#favoriteIndicatorSection`)을 두고, 카드 단위 분배.
+- **토글 UX**: 카드 우상단 토글 버튼. 즉시 PUT 호출 → 카드를 반대편 섹션으로 이동.
 
 ---
 
 ## 구현
 
-### Domain 계층
+### Domain 계층 (favorite)
 
-**위치**: `favorite/domain/model/`
+**위치**: `favorite/domain/model/`, `favorite/domain/repository/`
 
 - `FavoriteDisplayMode.java` — enum (INDICATOR, GRAPH)
-- `FavoriteIndicator.java` — `displayMode` 필드 + `changeDisplayMode()` 도메인 메서드 추가
+- `FavoriteIndicator.java` — `displayMode` 필드 + `changeDisplayMode()` 메서드
+- `FavoriteIndicatorRepository.java` — `updateDisplayMode(...)` 포트 메서드
 
-**Repository 포트**: `favorite/domain/repository/FavoriteIndicatorRepository.java`
-- `void updateDisplayMode(Long userId, FavoriteIndicatorSourceType sourceType, String indicatorCode, FavoriteDisplayMode mode)`
+### Infrastructure 계층 (favorite)
 
-[구현 예시](./examples/domain-model-example.md)
+**Entity**: `UserFavoriteIndicatorEntity` — `display_mode` 컬럼 추가, `columnDefinition`으로 default 처리, `@PrePersist` null 안전 처리.
 
-### Infrastructure 계층
+**JPA**: `UserFavoriteIndicatorJpaRepository.updateDisplayMode` `@Modifying` 쿼리.
 
-**Entity**: `favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java`
-- `@Enumerated(EnumType.STRING)` + `@Column(name = "display_mode", nullable = false, length = 10, columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'")` 필드 추가
-- `ddl-auto: update` 가 `ALTER TABLE` 자동 실행, PostgreSQL이 기존 row에 default 'INDICATOR' 채움 → 별도 SQL 마이그레이션 불필요
+### Economics 모듈 신규 history 메서드
 
-**Mapper**: `favorite/infrastructure/persistence/FavoriteIndicatorMapper.java`
-- toDomain/toEntity에 displayMode 매핑 추가
+**ECOS**:
+- 포트: `EcosIndicatorRepository.findHistory(String className, String keystatName, int limit)` → `List<EcosIndicator>`
+- JPA Native:
+  ```sql
+  SELECT t.* FROM (
+      SELECT e.*, ROW_NUMBER() OVER (
+          PARTITION BY e.class_name, e.keystat_name
+          ORDER BY e.snapshot_date DESC
+      ) AS rn
+      FROM ecos_indicator e
+      WHERE e.class_name = :className AND e.keystat_name = :keystatName
+  ) t
+  WHERE t.rn <= :limit
+  ORDER BY t.snapshot_date ASC
+  ```
+- Service: `EcosIndicatorService.findHistory(...)` 위임만.
 
-**Repository 구현체**: `favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java`
-- `updateDisplayMode(...)` 구현 (JpaRepository 통한 update)
+**GLOBAL**:
+- 포트: `GlobalIndicatorRepository.findHistory(String countryName, GlobalEconomicIndicatorType indicatorType, int limit)` → `List<GlobalIndicator>`
+- JPA Native: 동일 ROW_NUMBER 패턴, PARTITION BY country_name, indicator_type
+- Service: `GlobalIndicatorQueryService.findHistory(...)` 위임만.
 
-**JPA Repository**: `favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java`
-- `Optional<UserFavoriteIndicatorEntity> findByUserIdAndSourceTypeAndIndicatorCode(...)` 시그니처 추가
-
-[구현 예시](./examples/infrastructure-example.md)
-
-### Application 계층
+### Application 계층 (favorite)
 
 **위치**: `favorite/application/FavoriteIndicatorService.java`
 
-신규/변경 메서드:
-- `changeDisplayMode(userId, sourceType, indicatorCode, mode)` — 단순 update 위임
-- `getEnriched(userId)` 기존 메서드를 확장: GRAPH 모드 항목들에 한해 시계열을 함께 모아 응답 빌드
+신규/변경:
+- `changeDisplayMode(userId, sourceType, indicatorCode, mode)` — `repository.updateDisplayMode(...)` 위임.
+- `findEnrichedByUserId(userId)` 확장:
+  - 기존 enriched 결과 빌드
+  - GRAPH 모드 항목들에 한해 `EcosIndicatorService.findHistory(...)` / `GlobalIndicatorQueryService.findHistory(...)` 단건 호출
+  - 시계열을 `EnrichedEcosFavorite` / `EnrichedGlobalFavorite` 레코드에 `history: List<HistoryPoint>`로 첨부
+- `HistoryPoint(LocalDate snapshotDate, String dataValue)` record 신규 (Service 내부 record)
 
-시계열 조회 흐름:
-1. 사용자 관심지표 전체 조회 → displayMode가 GRAPH인 항목만 필터
-2. ECOS는 className+keystatName 조합으로, GLOBAL은 indicatorType 단위로 묶어 일괄 조회
-3. 결과를 indicatorCode → List<HistoryPoint> 형태 Map으로 매핑
-4. 응답 DTO 빌드 시 항목별 history 주입
-
-[구현 예시](./examples/application-service-example.md)
+indicatorCode 파싱:
+- ECOS: `className::keystatName`
+- GLOBAL: `countryName::indicatorType`
+- 파싱 실패 항목은 history 없이 통과 (실패 격리)
 
 ### Presentation 계층
 
-**Controller**: `favorite/presentation/FavoriteIndicatorController.java`
-
-신규 API:
+**Controller** (`FavoriteIndicatorController`):
 - `PUT /api/favorites/display-mode`
   - Request: `FavoriteDisplayModeRequest { sourceType, indicatorCode, mode }`
-  - Response: 204 No Content (또는 변경된 항목 반환)
+  - Response: 204 No Content
 
-응답 DTO 변경:
+**응답 DTO**:
 - `EnrichedFavoriteResponse.EcosItem` / `GlobalItem`에 `displayMode: String`, `history: List<EnrichedHistoryPoint>` 필드 추가
-- `EnrichedHistoryPoint { snapshotDate: LocalDate, dataValue: BigDecimal }` 신규
-
-[구현 예시](./examples/presentation-example.md)
+- `EnrichedHistoryPoint(LocalDate snapshotDate, String dataValue)` record 신규
 
 ### Frontend 계층
 
-**HTML**: `src/main/resources/static/index.html`
+**HTML** (`index.html`):
 - 기존 관심지표 단일 영역(L404-550)을 두 컨테이너로 분리:
-  - `#favoriteGraphSection` (그래프 카드)
-  - `#favoriteIndicatorSection` (단순 지표 카드)
-- 두 영역 모두 수평 스크롤 카드 레이아웃 유지, 섹션 헤더 구분
+  - `#favoriteGraphSection`
+  - `#favoriteIndicatorSection`
 
-**JS**: `src/main/resources/static/js/components/favorite.js`
-- `render()` 시 displayMode 기준으로 두 영역에 분배
-- 그래프 카드 내부 `<canvas>` 추가 → Chart.js로 라인 차트
-- 토글 버튼 핸들러: PUT 호출 성공 시 카드를 반대 섹션으로 이동 (DOM 재배치)
+**JS** (`favorite.js`):
+- `render()` 시 displayMode 기준 분배
+- 그래프 카드 내부 `<canvas>` → Chart.js 라인 차트
+- 토글 버튼 핸들러: PUT 호출 성공 시 카드 DOM 재배치 (전체 새로고침 X)
 - Chart 인스턴스 캐싱 + 토글/언마운트 시 destroy
-
-[구현 예시](./examples/frontend-example.md)
 
 ---
 
 ## 주의사항
 
-- **Entity 컬럼 추가는 사전 승인 필요** (CLAUDE.md 규칙 7번). 본 설계가 그 승인 요청을 겸함.
-- 기존 `/api/favorites/enriched` 응답 스키마에 신규 필드(displayMode, history)를 추가하지만, 신규 필드는 nullable/optional 취급 → 기존 프론트와 호환 유지.
-- 시계열 batch 조회 시 N+1 발생 주의: GRAPH 항목이 많아도 ECOS/GLOBAL 각 1회 호출로 끝나도록 모아서 조회.
+- **Entity 컬럼 추가 사전 승인 완료** (CLAUDE.md 규칙 7번).
+- 기존 `/api/favorites/enriched` 응답 스키마에 신규 필드(displayMode, history) 추가하지만 nullable/optional → 기존 프론트와 호환.
+- **history 조회 부하**: 항목별 단건 호출이라 GRAPH 항목 N개 시 N개 쿼리. limit가 작아(30포인트) 부담은 작지만, 사용자별 GRAPH 항목 수가 수십 개를 넘으면 batch IN 쿼리로 전환 검토.
 - Chart.js는 이미 `index.html` L8에 로드됨 (추가 의존성 없음).
-- 동일 사용자가 빠르게 토글 연타 시 race condition 방지를 위해 클라이언트에서 토글 버튼 disable + 디바운스.
+- 동일 사용자가 빠르게 토글 연타 시 race condition 방지: 클라이언트에서 토글 버튼 disable + 디바운스.
 - displayMode 컬럼은 `@Enumerated(EnumType.STRING)`로 저장 — 추후 enum 추가 안전.
-- 시계열이 없는 지표(`hasData=false`)는 GRAPH 모드라도 빈 차트 placeholder 또는 "데이터 없음" 메시지 표시.
-- 컬럼 추가는 `ddl-auto: update`로 자동 처리. 운영 배포 시 ALTER TABLE 실행 시간이 테이블 크기에 비례하므로, 사용자 수가 충분히 많아지면 점검 시간대 배포 권장.
+- 시계열이 없는 지표는 GRAPH 모드라도 "데이터 없음" placeholder 표시.
+- 컬럼 추가는 `ddl-auto: update`로 자동 처리.
+- economics history 메서드는 favorite에서만 사용. 추후 다른 모듈/대시보드에서 시계열이 필요하면 재사용.

--- a/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
+++ b/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
@@ -1,0 +1,159 @@
+# 관심지표 표시 모드 토글 (그래프 ↔ 지표) 설계
+
+> 관련 이슈: [#38 관심지표 그래프 보기](https://github.com/osnet-th/stock-market/issues/38)
+
+## 작업 리스트
+
+### Domain 계층
+- [ ] `FavoriteDisplayMode` enum 신규 작성 (INDICATOR, GRAPH)
+- [ ] `FavoriteIndicator` 도메인 모델에 `displayMode` 필드 추가
+- [ ] `FavoriteIndicator.changeDisplayMode(FavoriteDisplayMode)` 도메인 메서드 추가
+- [ ] `FavoriteIndicatorRepository` 포트에 `updateDisplayMode(...)` 메서드 추가
+
+### Infrastructure 계층
+- [ ] `UserFavoriteIndicatorEntity`에 `display_mode` 컬럼 추가 (VARCHAR(10), NOT NULL, default 'INDICATOR') **— Entity 변경 사전 승인 필요**
+- [ ] DB 마이그레이션 SQL 작성 (`ALTER TABLE user_favorite_indicator ADD COLUMN display_mode VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'`)
+- [ ] `FavoriteIndicatorMapper`: Entity ↔ Domain displayMode 매핑 추가
+- [ ] `FavoriteIndicatorRepositoryImpl.updateDisplayMode(...)` 구현
+- [ ] `UserFavoriteIndicatorJpaRepository`: `findByUserIdAndSourceTypeAndIndicatorCode(...)` 추가 (단건 조회)
+
+### Application 계층
+- [ ] `FavoriteIndicatorService.changeDisplayMode(userId, sourceType, indicatorCode, mode)` 메서드 추가
+- [ ] `FavoriteIndicatorService.findEnrichedWithHistory(userId)` — 그래프 모드 항목에 한해 시계열 포함
+- [ ] EcosIndicatorService.getHistoryByCategory()/GlobalIndicatorQueryService.getHistoryByIndicatorType() 활용
+- [ ] 시계열 조회 N+1 방지 — 한 번에 batch 조회 후 Map 매핑
+
+### Presentation 계층
+- [ ] `PUT /api/favorites/display-mode` API 신규 추가 (요청: sourceType, indicatorCode, mode)
+- [ ] `FavoriteDisplayModeRequest` DTO 신규 작성
+- [ ] `EnrichedFavoriteResponse`의 EcosItem/GlobalItem에 `displayMode`, `history` 필드 추가
+- [ ] `EnrichedHistoryPoint` DTO 신규 작성 (snapshotDate, dataValue)
+
+### Frontend 계층
+- [ ] `index.html` 대시보드: "그래프 영역"과 "단순 지표 영역" 카드 컨테이너 분리
+- [ ] `favorite.js`: 항목별 displayMode에 따라 두 영역에 분기 렌더
+- [ ] 카드별 "지표/그래프" 토글 버튼 UI 추가
+- [ ] 토글 시 `PUT /api/favorites/display-mode` 호출 후 화면 재배치
+- [ ] Chart.js 라인 차트 렌더링 함수 작성 (`renderFavoriteChart(canvasId, points)`)
+- [ ] 차트 라이프사이클 관리 (Chart 인스턴스 destroy → re-render)
+
+---
+
+## 배경
+
+이슈 #38 요구사항:
+1. 관심지표 항목별로 **그래프 / 단순 지표** 표시 방식 선택
+2. 마지막 선택값은 **DB 저장**으로 영속화
+3. 대시보드에서 **그래프 영역과 단순 지표 영역을 분리**
+
+현재 `/api/favorites/enriched`는 최신값만 반환, 프론트는 단순 카드로만 표시. 시계열 데이터는 economics 모듈에 이미 조회 API 존재 (`EcosIndicatorService.getHistoryByCategory`, `GlobalIndicatorQueryService.getHistoryByIndicatorType`).
+
+---
+
+## 핵심 결정
+
+- **표시 모드 식별 단위**: `(userId, sourceType, indicatorCode)` 단위로 displayMode 저장 (기존 unique 키와 동일). 사용자별 개별 지표마다 모드 다름.
+- **enum 값**: `INDICATOR`(기본), `GRAPH` 두 가지. 추후 확장 여지 둠.
+- **DB default**: 기존 row에는 'INDICATOR'를 default로 지정 → 마이그레이션 시 기존 사용자 영향 없음.
+- **시계열 데이터 전달 방식**: 단순 enriched 응답에 history 배열을 함께 담음 (별도 endpoint 분리하지 않음). 단, **GRAPH 모드 항목에만** history 포함 → 트래픽 절감.
+- **시계열 길이**: 우선 최근 30포인트 한도. 차트 가독성과 응답 크기 균형.
+- **프론트 영역 분리**: 한 화면에 두 섹션(`#favoriteGraphSection`, `#favoriteIndicatorSection`)을 두고, 카드 단위로 항목을 분배. 같은 카드를 토글하면 다른 섹션으로 이동.
+- **토글 UX**: 카드 우상단 작은 토글 버튼. 즉시 PUT 호출 → 성공 시 카드를 반대편 섹션으로 이동(전체 새로고침 X).
+
+---
+
+## 구현
+
+### Domain 계층
+
+**위치**: `favorite/domain/model/`
+
+- `FavoriteDisplayMode.java` — enum (INDICATOR, GRAPH)
+- `FavoriteIndicator.java` — `displayMode` 필드 + `changeDisplayMode()` 도메인 메서드 추가
+
+**Repository 포트**: `favorite/domain/repository/FavoriteIndicatorRepository.java`
+- `void updateDisplayMode(Long userId, FavoriteIndicatorSourceType sourceType, String indicatorCode, FavoriteDisplayMode mode)`
+
+[구현 예시](./examples/domain-model-example.md)
+
+### Infrastructure 계층
+
+**Entity**: `favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java`
+- `@Column(name = "display_mode", nullable = false, length = 10) @Enumerated(EnumType.STRING)` 추가
+
+**Mapper**: `favorite/infrastructure/persistence/FavoriteIndicatorMapper.java`
+- toDomain/toEntity에 displayMode 매핑 추가
+
+**Repository 구현체**: `favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java`
+- `updateDisplayMode(...)` 구현 (JpaRepository 통한 update)
+
+**JPA Repository**: `favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java`
+- `Optional<UserFavoriteIndicatorEntity> findByUserIdAndSourceTypeAndIndicatorCode(...)` 시그니처 추가
+
+**DB 마이그레이션**: `src/main/resources/db/migration/Vxxxx__add_display_mode_to_favorite.sql`
+```sql
+ALTER TABLE user_favorite_indicator
+  ADD COLUMN display_mode VARCHAR(10) NOT NULL DEFAULT 'INDICATOR';
+```
+
+[구현 예시](./examples/infrastructure-example.md)
+
+### Application 계층
+
+**위치**: `favorite/application/FavoriteIndicatorService.java`
+
+신규/변경 메서드:
+- `changeDisplayMode(userId, sourceType, indicatorCode, mode)` — 단순 update 위임
+- `getEnriched(userId)` 기존 메서드를 확장: GRAPH 모드 항목들에 한해 시계열을 함께 모아 응답 빌드
+
+시계열 조회 흐름:
+1. 사용자 관심지표 전체 조회 → displayMode가 GRAPH인 항목만 필터
+2. ECOS는 className+keystatName 조합으로, GLOBAL은 indicatorType 단위로 묶어 일괄 조회
+3. 결과를 indicatorCode → List<HistoryPoint> 형태 Map으로 매핑
+4. 응답 DTO 빌드 시 항목별 history 주입
+
+[구현 예시](./examples/application-service-example.md)
+
+### Presentation 계층
+
+**Controller**: `favorite/presentation/FavoriteIndicatorController.java`
+
+신규 API:
+- `PUT /api/favorites/display-mode`
+  - Request: `FavoriteDisplayModeRequest { sourceType, indicatorCode, mode }`
+  - Response: 204 No Content (또는 변경된 항목 반환)
+
+응답 DTO 변경:
+- `EnrichedFavoriteResponse.EcosItem` / `GlobalItem`에 `displayMode: String`, `history: List<EnrichedHistoryPoint>` 필드 추가
+- `EnrichedHistoryPoint { snapshotDate: LocalDate, dataValue: BigDecimal }` 신규
+
+[구현 예시](./examples/presentation-example.md)
+
+### Frontend 계층
+
+**HTML**: `src/main/resources/static/index.html`
+- 기존 관심지표 단일 영역(L404-550)을 두 컨테이너로 분리:
+  - `#favoriteGraphSection` (그래프 카드)
+  - `#favoriteIndicatorSection` (단순 지표 카드)
+- 두 영역 모두 수평 스크롤 카드 레이아웃 유지, 섹션 헤더 구분
+
+**JS**: `src/main/resources/static/js/components/favorite.js`
+- `render()` 시 displayMode 기준으로 두 영역에 분배
+- 그래프 카드 내부 `<canvas>` 추가 → Chart.js로 라인 차트
+- 토글 버튼 핸들러: PUT 호출 성공 시 카드를 반대 섹션으로 이동 (DOM 재배치)
+- Chart 인스턴스 캐싱 + 토글/언마운트 시 destroy
+
+[구현 예시](./examples/frontend-example.md)
+
+---
+
+## 주의사항
+
+- **Entity 컬럼 추가는 사전 승인 필요** (CLAUDE.md 규칙 7번). 본 설계가 그 승인 요청을 겸함.
+- 기존 `/api/favorites/enriched` 응답 스키마에 신규 필드(displayMode, history)를 추가하지만, 신규 필드는 nullable/optional 취급 → 기존 프론트와 호환 유지.
+- 시계열 batch 조회 시 N+1 발생 주의: GRAPH 항목이 많아도 ECOS/GLOBAL 각 1회 호출로 끝나도록 모아서 조회.
+- Chart.js는 이미 `index.html` L8에 로드됨 (추가 의존성 없음).
+- 동일 사용자가 빠르게 토글 연타 시 race condition 방지를 위해 클라이언트에서 토글 버튼 disable + 디바운스.
+- displayMode 컬럼은 `@Enumerated(EnumType.STRING)`로 저장 — 추후 enum 추가 안전.
+- 시계열이 없는 지표(`hasData=false`)는 GRAPH 모드라도 빈 차트 placeholder 또는 "데이터 없음" 메시지 표시.
+- 마이그레이션 파일 버전 번호는 기존 마지막 마이그레이션 다음 번호로 부여 (작성 시점에 확인).

--- a/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
+++ b/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
@@ -17,34 +17,34 @@
 - [x] `UserFavoriteIndicatorJpaRepository.updateDisplayMode(...)` `@Modifying` 쿼리 추가
 
 ### Economics 모듈 신규 history 조회 메서드 추가 (favorite 가 활용)
-- [ ] `EcosIndicatorRepository.findHistory(className, keystatName, limit)` 포트 추가
-- [ ] `EcosIndicatorJpaRepository`에 native ROW_NUMBER 쿼리로 `findHistory(...)` 추가
-- [ ] `EcosIndicatorRepositoryImpl.findHistory(...)` 구현 (Entity → Domain 매핑)
-- [ ] `EcosIndicatorService.findHistory(className, keystatName, limit)` 위임 메서드 추가
-- [ ] `GlobalIndicatorRepository.findHistory(countryName, indicatorType, limit)` 포트 추가
-- [ ] `GlobalIndicatorJpaRepository.findHistory(...)` native ROW_NUMBER 쿼리 추가
-- [ ] `GlobalIndicatorRepositoryImpl.findHistory(...)` 구현
-- [ ] `GlobalIndicatorQueryService.findHistory(countryName, indicatorType, limit)` 위임 메서드 추가
+- [x] `EcosIndicatorRepository.findHistory(className, keystatName, limit)` 포트 추가
+- [x] `EcosIndicatorJpaRepository`에 native ROW_NUMBER 쿼리로 `findHistory(...)` 추가
+- [x] `EcosIndicatorRepositoryImpl.findHistory(...)` 구현 (Entity → Domain 매핑)
+- [x] `EcosIndicatorService.findHistory(className, keystatName, limit)` 위임 메서드 추가
+- [x] `GlobalIndicatorRepository.findHistory(countryName, indicatorType, limit)` 포트 추가
+- [x] `GlobalIndicatorJpaRepository.findHistory(...)` native ROW_NUMBER 쿼리 추가
+- [x] `GlobalIndicatorRepositoryImpl.findHistory(...)` 구현
+- [x] `GlobalIndicatorQueryService.findHistory(countryName, indicatorType, limit)` 위임 메서드 추가
 
 ### Application 계층 (favorite)
-- [ ] `FavoriteIndicatorService.changeDisplayMode(userId, sourceType, indicatorCode, mode)` 메서드 추가
-- [ ] `findEnrichedByUserId(userId)` 확장: GRAPH 모드 항목에 한해 시계열을 함께 모아 응답에 포함
-- [ ] EnrichedEcosFavorite/EnrichedGlobalFavorite 레코드에 `history: List<HistoryPoint>` 추가
-- [ ] indicatorCode 파싱하여 economics 모듈 신규 `findHistory(...)` 호출 (GRAPH 항목별 단건 조회)
+- [x] `FavoriteIndicatorService.changeDisplayMode(userId, sourceType, indicatorCode, mode)` 메서드 추가
+- [x] `findEnrichedByUserId(userId)` 확장: GRAPH 모드 항목에 한해 시계열을 함께 모아 응답에 포함
+- [x] EnrichedEcosFavorite/EnrichedGlobalFavorite 레코드에 `history: List<HistoryPoint>` 추가
+- [x] indicatorCode 파싱하여 economics 모듈 신규 `findHistory(...)` 호출 (GRAPH 항목별 단건 조회)
 
 ### Presentation 계층
-- [ ] `PUT /api/favorites/display-mode` API 신규 추가
-- [ ] `FavoriteDisplayModeRequest` DTO 신규 작성
-- [ ] `EnrichedFavoriteResponse`의 EcosItem/GlobalItem에 `displayMode`, `history` 필드 추가
-- [ ] `EnrichedHistoryPoint` DTO 신규 작성 (snapshotDate, dataValue)
+- [x] `PUT /api/favorites/display-mode` API 신규 추가
+- [x] `FavoriteDisplayModeRequest` DTO 신규 작성
+- [x] `EnrichedFavoriteResponse`의 EcosItem/GlobalItem에 `displayMode`, `history` 필드 추가
+- [x] `EnrichedHistoryPoint` DTO 신규 작성 (snapshotDate, dataValue)
 
 ### Frontend 계층
-- [ ] `index.html` 대시보드: "그래프 영역"과 "단순 지표 영역" 카드 컨테이너 분리
-- [ ] `favorite.js`: 항목별 displayMode에 따라 두 영역에 분기 렌더
-- [ ] 카드별 "지표/그래프" 토글 버튼 UI 추가
-- [ ] 토글 시 `PUT /api/favorites/display-mode` 호출 후 화면 재배치
-- [ ] Chart.js 라인 차트 렌더링 함수 작성 (`renderFavoriteChart(canvasId, points)`)
-- [ ] 차트 라이프사이클 관리 (Chart 인스턴스 destroy → re-render)
+- [x] `index.html` 대시보드: "그래프 영역"과 "단순 지표 영역" 카드 컨테이너 분리
+- [x] `favorite.js`: 항목별 displayMode에 따라 두 영역에 분기 렌더
+- [x] 카드별 "지표/그래프" 토글 버튼 UI 추가
+- [x] 토글 시 `PUT /api/favorites/display-mode` 호출 후 화면 재배치
+- [x] Chart.js 라인 차트 렌더링 함수 작성 (`renderFavoriteChart(canvasId, points)`)
+- [x] 차트 라이프사이클 관리 (Chart 인스턴스 destroy → re-render)
 
 ---
 

--- a/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
+++ b/.claude/designs/favorite/display-mode-toggle/display-mode-toggle.md
@@ -11,8 +11,7 @@
 - [ ] `FavoriteIndicatorRepository` 포트에 `updateDisplayMode(...)` 메서드 추가
 
 ### Infrastructure 계층
-- [ ] `UserFavoriteIndicatorEntity`에 `display_mode` 컬럼 추가 (VARCHAR(10), NOT NULL, default 'INDICATOR') **— Entity 변경 사전 승인 필요**
-- [ ] DB 마이그레이션 SQL 작성 (`ALTER TABLE user_favorite_indicator ADD COLUMN display_mode VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'`)
+- [ ] `UserFavoriteIndicatorEntity`에 `display_mode` 컬럼 추가 — `@Enumerated(EnumType.STRING)` + `columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'"` **— Entity 변경 사전 승인 필요**
 - [ ] `FavoriteIndicatorMapper`: Entity ↔ Domain displayMode 매핑 추가
 - [ ] `FavoriteIndicatorRepositoryImpl.updateDisplayMode(...)` 구현
 - [ ] `UserFavoriteIndicatorJpaRepository`: `findByUserIdAndSourceTypeAndIndicatorCode(...)` 추가 (단건 조회)
@@ -54,7 +53,7 @@
 
 - **표시 모드 식별 단위**: `(userId, sourceType, indicatorCode)` 단위로 displayMode 저장 (기존 unique 키와 동일). 사용자별 개별 지표마다 모드 다름.
 - **enum 값**: `INDICATOR`(기본), `GRAPH` 두 가지. 추후 확장 여지 둠.
-- **DB default**: 기존 row에는 'INDICATOR'를 default로 지정 → 마이그레이션 시 기존 사용자 영향 없음.
+- **DB default 처리**: `@Column(columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'")` 방식 사용. `ddl-auto: update`가 ALTER TABLE 시 default까지 포함하여 기존 row에 'INDICATOR' 자동 적용 → 별도 SQL 마이그레이션 파일 불필요.
 - **시계열 데이터 전달 방식**: 단순 enriched 응답에 history 배열을 함께 담음 (별도 endpoint 분리하지 않음). 단, **GRAPH 모드 항목에만** history 포함 → 트래픽 절감.
 - **시계열 길이**: 우선 최근 30포인트 한도. 차트 가독성과 응답 크기 균형.
 - **프론트 영역 분리**: 한 화면에 두 섹션(`#favoriteGraphSection`, `#favoriteIndicatorSection`)을 두고, 카드 단위로 항목을 분배. 같은 카드를 토글하면 다른 섹션으로 이동.
@@ -79,7 +78,8 @@
 ### Infrastructure 계층
 
 **Entity**: `favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java`
-- `@Column(name = "display_mode", nullable = false, length = 10) @Enumerated(EnumType.STRING)` 추가
+- `@Enumerated(EnumType.STRING)` + `@Column(name = "display_mode", nullable = false, length = 10, columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'")` 필드 추가
+- `ddl-auto: update` 가 `ALTER TABLE` 자동 실행, PostgreSQL이 기존 row에 default 'INDICATOR' 채움 → 별도 SQL 마이그레이션 불필요
 
 **Mapper**: `favorite/infrastructure/persistence/FavoriteIndicatorMapper.java`
 - toDomain/toEntity에 displayMode 매핑 추가
@@ -89,12 +89,6 @@
 
 **JPA Repository**: `favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java`
 - `Optional<UserFavoriteIndicatorEntity> findByUserIdAndSourceTypeAndIndicatorCode(...)` 시그니처 추가
-
-**DB 마이그레이션**: `src/main/resources/db/migration/Vxxxx__add_display_mode_to_favorite.sql`
-```sql
-ALTER TABLE user_favorite_indicator
-  ADD COLUMN display_mode VARCHAR(10) NOT NULL DEFAULT 'INDICATOR';
-```
 
 [구현 예시](./examples/infrastructure-example.md)
 
@@ -156,4 +150,4 @@ ALTER TABLE user_favorite_indicator
 - 동일 사용자가 빠르게 토글 연타 시 race condition 방지를 위해 클라이언트에서 토글 버튼 disable + 디바운스.
 - displayMode 컬럼은 `@Enumerated(EnumType.STRING)`로 저장 — 추후 enum 추가 안전.
 - 시계열이 없는 지표(`hasData=false`)는 GRAPH 모드라도 빈 차트 placeholder 또는 "데이터 없음" 메시지 표시.
-- 마이그레이션 파일 버전 번호는 기존 마지막 마이그레이션 다음 번호로 부여 (작성 시점에 확인).
+- 컬럼 추가는 `ddl-auto: update`로 자동 처리. 운영 배포 시 ALTER TABLE 실행 시간이 테이블 크기에 비례하므로, 사용자 수가 충분히 많아지면 점검 시간대 배포 권장.

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/application/EcosIndicatorService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/application/EcosIndicatorService.java
@@ -63,6 +63,14 @@ public class EcosIndicatorService {
     }
 
     /**
+     * 단일 지표 시계열 조회: (className, keystatName) 기준 최근 limit개 snapshotDate 오름차순
+     */
+    @Transactional(readOnly = true)
+    public List<EcosIndicator> findHistory(String className, String keystatName, int limit) {
+        return ecosIndicatorRepository.findHistory(className, keystatName, limit);
+    }
+
+    /**
      * 전체 최신값 조회 (관심 지표 enrichment용)
      */
     @Transactional(readOnly = true)

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/application/GlobalIndicatorQueryService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/application/GlobalIndicatorQueryService.java
@@ -61,6 +61,14 @@ public class GlobalIndicatorQueryService {
     }
 
     /**
+     * 단일 지표 시계열 조회: (countryName, indicatorType) 기준 최근 limit개 snapshotDate 오름차순
+     */
+    @Transactional(readOnly = true)
+    public List<GlobalIndicator> findHistory(String countryName, GlobalEconomicIndicatorType indicatorType, int limit) {
+        return globalIndicatorRepository.findHistory(countryName, indicatorType, limit);
+    }
+
+    /**
      * 전체 최신값 조회 (관심 지표 enrichment용)
      */
     @Transactional(readOnly = true)

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/repository/EcosIndicatorRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/repository/EcosIndicatorRepository.java
@@ -25,4 +25,9 @@ public interface EcosIndicatorRepository {
      * 동일 (className, keystatName, cycle) 조합에 대해 최신 snapshotDate 기준 1건만 반환
      */
     List<EcosIndicator> findLatestHistoryByClassNames(Set<String> classNames);
+
+    /**
+     * 단일 지표 시계열 조회: (className, keystatName) 기준으로 최근 limit개 snapshotDate 오름차순 반환
+     */
+    List<EcosIndicator> findHistory(String className, String keystatName, int limit);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/repository/GlobalIndicatorRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/repository/GlobalIndicatorRepository.java
@@ -24,4 +24,9 @@ public interface GlobalIndicatorRepository {
      * 지표타입별 히스토리 조회 (cycle별 최신 snapshot만 반환)
      */
     List<GlobalIndicator> findLatestHistoryByIndicatorType(GlobalEconomicIndicatorType indicatorType);
+
+    /**
+     * 단일 지표 시계열 조회: (countryName, indicatorType) 기준 최근 limit개 snapshotDate 오름차순 반환
+     */
+    List<GlobalIndicator> findHistory(String countryName, GlobalEconomicIndicatorType indicatorType, int limit);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/EcosIndicatorJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/EcosIndicatorJpaRepository.java
@@ -26,4 +26,22 @@ public interface EcosIndicatorJpaRepository extends JpaRepository<EcosIndicatorE
             ORDER BY t.class_name, t.keystat_name, t.cycle
             """, nativeQuery = true)
     List<EcosIndicatorEntity> findLatestHistoryByClassNames(@Param("classNames") Set<String> classNames);
+
+    @Query(value = """
+            SELECT t.id, t.class_name, t.keystat_name, t.data_value, t.cycle, t.unit_name, t.snapshot_date, t.created_at
+            FROM (
+                SELECT e.*,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY e.class_name, e.keystat_name
+                           ORDER BY e.snapshot_date DESC
+                       ) AS rn
+                FROM ecos_indicator e
+                WHERE e.class_name = :className AND e.keystat_name = :keystatName
+            ) t
+            WHERE t.rn <= :limit
+            ORDER BY t.snapshot_date ASC
+            """, nativeQuery = true)
+    List<EcosIndicatorEntity> findHistory(@Param("className") String className,
+                                          @Param("keystatName") String keystatName,
+                                          @Param("limit") int limit);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/EcosIndicatorRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/EcosIndicatorRepositoryImpl.java
@@ -40,4 +40,11 @@ public class EcosIndicatorRepositoryImpl implements EcosIndicatorRepository {
                 .map(mapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public List<EcosIndicator> findHistory(String className, String keystatName, int limit) {
+        return jpaRepository.findHistory(className, keystatName, limit).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorJpaRepository.java
@@ -25,4 +25,22 @@ public interface GlobalIndicatorJpaRepository extends JpaRepository<GlobalIndica
             ORDER BY t.country_name, t.cycle
             """, nativeQuery = true)
     List<GlobalIndicatorEntity> findLatestHistoryByIndicatorType(@Param("indicatorType") String indicatorType);
+
+    @Query(value = """
+            SELECT t.id, t.country_name, t.indicator_type, t.data_value, t.cycle, t.unit, t.snapshot_date, t.created_at
+            FROM (
+                SELECT e.*,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY e.country_name, e.indicator_type
+                           ORDER BY e.snapshot_date DESC
+                       ) AS rn
+                FROM global_indicator e
+                WHERE e.country_name = :countryName AND e.indicator_type = :indicatorType
+            ) t
+            WHERE t.rn <= :limit
+            ORDER BY t.snapshot_date ASC
+            """, nativeQuery = true)
+    List<GlobalIndicatorEntity> findHistory(@Param("countryName") String countryName,
+                                            @Param("indicatorType") String indicatorType,
+                                            @Param("limit") int limit);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorRepositoryImpl.java
@@ -40,4 +40,11 @@ public class GlobalIndicatorRepositoryImpl implements GlobalIndicatorRepository 
                 .map(mapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public List<GlobalIndicator> findHistory(String countryName, GlobalEconomicIndicatorType indicatorType, int limit) {
+        return jpaRepository.findHistory(countryName, indicatorType.name(), limit).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoriteIndicatorService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoriteIndicatorService.java
@@ -5,13 +5,16 @@ import com.thlee.stock.market.stockmarket.economics.application.EcosIndicatorSer
 import com.thlee.stock.market.stockmarket.economics.application.GlobalIndicatorCacheService;
 import com.thlee.stock.market.stockmarket.economics.application.GlobalIndicatorQueryService;
 import com.thlee.stock.market.stockmarket.economics.domain.model.CountryIndicatorSnapshot;
+import com.thlee.stock.market.stockmarket.economics.domain.model.EcosIndicator;
 import com.thlee.stock.market.stockmarket.economics.domain.model.EcosIndicatorLatest;
 import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalEconomicIndicatorType;
+import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalIndicator;
 import com.thlee.stock.market.stockmarket.economics.domain.model.IndicatorCategory;
 import com.thlee.stock.market.stockmarket.economics.infrastructure.global.tradingeconomics.exception.TradingEconomicsFetchException;
 import com.thlee.stock.market.stockmarket.economics.infrastructure.global.tradingeconomics.exception.TradingEconomicsParseException;
 import com.thlee.stock.market.stockmarket.favorite.application.exception.FavoriteRefreshForbiddenException;
 import com.thlee.stock.market.stockmarket.favorite.application.exception.RefreshRateLimitExceededException;
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicator;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
 import com.thlee.stock.market.stockmarket.favorite.domain.repository.FavoriteIndicatorRepository;
@@ -22,6 +25,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -40,6 +44,8 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class FavoriteIndicatorService {
+
+    private static final int HISTORY_LIMIT = 30;
 
     private final FavoriteIndicatorRepository favoriteIndicatorRepository;
     private final EcosIndicatorService ecosIndicatorService;
@@ -85,6 +91,17 @@ public class FavoriteIndicatorService {
         }
     }
 
+    /**
+     * 관심 지표 표시 모드 변경 (INDICATOR ↔ GRAPH)
+     */
+    @Transactional
+    public void changeDisplayMode(Long userId,
+                                  FavoriteIndicatorSourceType sourceType,
+                                  String indicatorCode,
+                                  FavoriteDisplayMode displayMode) {
+        favoriteIndicatorRepository.updateDisplayMode(userId, sourceType, indicatorCode, displayMode);
+    }
+
     @Transactional(readOnly = true)
     public List<FavoriteIndicator> findByUserId(Long userId) {
         return favoriteIndicatorRepository.findByUserId(userId);
@@ -92,6 +109,7 @@ public class FavoriteIndicatorService {
 
     /**
      * 관심 지표 + Latest 데이터 통합 조회 (대시보드용)
+     * GRAPH 모드 항목들에는 시계열 history 포함.
      */
     @Transactional(readOnly = true)
     public EnrichedFavorites findEnrichedByUserId(Long userId) {
@@ -108,7 +126,10 @@ public class FavoriteIndicatorService {
         List<EnrichedEcosFavorite> enrichedEcos = enrichEcosFavorites(ecosFavorites);
         List<EnrichedGlobalFavorite> enrichedGlobal = enrichGlobalFavorites(globalFavorites);
 
-        return new EnrichedFavorites(enrichedEcos, enrichedGlobal);
+        List<EnrichedEcosFavorite> withEcosHistory = attachHistoryToEcos(enrichedEcos);
+        List<EnrichedGlobalFavorite> withGlobalHistory = attachHistoryToGlobal(enrichedGlobal);
+
+        return new EnrichedFavorites(withEcosHistory, withGlobalHistory);
     }
 
     /**
@@ -177,7 +198,7 @@ public class FavoriteIndicatorService {
             .collect(Collectors.toMap(EcosIndicatorLatest::toCompareKey, l -> l, (a, b) -> a));
 
         return ecosFavorites.stream()
-            .map(fav -> new EnrichedEcosFavorite(fav, latestMap.get(fav.getIndicatorCode())))
+            .map(fav -> new EnrichedEcosFavorite(fav, latestMap.get(fav.getIndicatorCode()), List.of()))
             .toList();
     }
 
@@ -265,6 +286,62 @@ public class FavoriteIndicatorService {
         return result;
     }
 
+    /**
+     * GRAPH 모드 ECOS 항목에 한해 시계열을 조회해 history 를 채운 새 리스트 반환.
+     * INDICATOR 모드 항목은 history 비어있는 상태로 통과.
+     */
+    private List<EnrichedEcosFavorite> attachHistoryToEcos(List<EnrichedEcosFavorite> enriched) {
+        if (enriched.isEmpty()) {
+            return enriched;
+        }
+        return enriched.stream()
+            .map(this::attachEcosHistoryIfGraph)
+            .toList();
+    }
+
+    private EnrichedEcosFavorite attachEcosHistoryIfGraph(EnrichedEcosFavorite item) {
+        if (item.favorite().getDisplayMode() != FavoriteDisplayMode.GRAPH) {
+            return item;
+        }
+        String[] parts = item.favorite().getIndicatorCode().split("::", 2);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            return item;
+        }
+        List<EcosIndicator> rows = ecosIndicatorService.findHistory(parts[0], parts[1], HISTORY_LIMIT);
+        List<HistoryPoint> points = rows.stream()
+            .map(r -> new HistoryPoint(r.getSnapshotDate(), r.getDataValue()))
+            .toList();
+        return item.withHistory(points);
+    }
+
+    /**
+     * GRAPH 모드 GLOBAL 항목에 한해 시계열을 조회해 history 를 채운 새 리스트 반환.
+     */
+    private List<EnrichedGlobalFavorite> attachHistoryToGlobal(List<EnrichedGlobalFavorite> enriched) {
+        if (enriched.isEmpty()) {
+            return enriched;
+        }
+        return enriched.stream()
+            .map(this::attachGlobalHistoryIfGraph)
+            .toList();
+    }
+
+    private EnrichedGlobalFavorite attachGlobalHistoryIfGraph(EnrichedGlobalFavorite item) {
+        if (item.favorite().getDisplayMode() != FavoriteDisplayMode.GRAPH) {
+            return item;
+        }
+        ParsedGlobalFavorite parsed = ParsedGlobalFavorite.of(item.favorite());
+        if (parsed.indicatorType() == null) {
+            return item;
+        }
+        List<GlobalIndicator> rows = globalIndicatorQueryService.findHistory(
+            parsed.countryName(), parsed.indicatorType(), HISTORY_LIMIT);
+        List<HistoryPoint> points = rows.stream()
+            .map(r -> new HistoryPoint(r.getSnapshotDate(), r.getDataValue()))
+            .toList();
+        return item.withHistory(points);
+    }
+
     private static String snapshotKey(CountryIndicatorSnapshot snap) {
         return snap.getCountryName() + "::" + snap.getIndicatorType().name();
     }
@@ -314,22 +391,34 @@ public class FavoriteIndicatorService {
         private FailureReason() {}
     }
 
-    public record EnrichedEcosFavorite(FavoriteIndicator favorite, EcosIndicatorLatest latest) {}
+    public record HistoryPoint(LocalDate snapshotDate, String dataValue) {}
+
+    public record EnrichedEcosFavorite(FavoriteIndicator favorite,
+                                       EcosIndicatorLatest latest,
+                                       List<HistoryPoint> history) {
+        public EnrichedEcosFavorite withHistory(List<HistoryPoint> newHistory) {
+            return new EnrichedEcosFavorite(favorite, latest, newHistory);
+        }
+    }
 
     public record EnrichedGlobalFavorite(
         FavoriteIndicator favorite,
         CountryIndicatorSnapshot snapshot,
         String failureReason,
-        boolean refreshable
+        boolean refreshable,
+        List<HistoryPoint> history
     ) {
         public static EnrichedGlobalFavorite success(FavoriteIndicator favorite, CountryIndicatorSnapshot snapshot) {
-            return new EnrichedGlobalFavorite(favorite, snapshot, null, true);
+            return new EnrichedGlobalFavorite(favorite, snapshot, null, true, List.of());
         }
         public static EnrichedGlobalFavorite noData(FavoriteIndicator favorite) {
-            return new EnrichedGlobalFavorite(favorite, null, null, true);
+            return new EnrichedGlobalFavorite(favorite, null, null, true, List.of());
         }
         public static EnrichedGlobalFavorite failed(FavoriteIndicator favorite, String failureReason, boolean refreshable) {
-            return new EnrichedGlobalFavorite(favorite, null, failureReason, refreshable);
+            return new EnrichedGlobalFavorite(favorite, null, failureReason, refreshable, List.of());
+        }
+        public EnrichedGlobalFavorite withHistory(List<HistoryPoint> newHistory) {
+            return new EnrichedGlobalFavorite(favorite, snapshot, failureReason, refreshable, newHistory);
         }
         public boolean isFailed() {
             return failureReason != null;

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteDisplayMode.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteDisplayMode.java
@@ -1,0 +1,9 @@
+package com.thlee.stock.market.stockmarket.favorite.domain.model;
+
+/**
+ * 관심 지표 표시 모드 (INDICATOR: 단순 지표, GRAPH: 시계열 그래프)
+ */
+public enum FavoriteDisplayMode {
+    INDICATOR,
+    GRAPH
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java
@@ -14,23 +14,31 @@ public class FavoriteIndicator {
     private final Long userId;
     private final FavoriteIndicatorSourceType sourceType;
     private final String indicatorCode;
+    private final FavoriteDisplayMode displayMode;
     private final LocalDateTime createdAt;
 
     public FavoriteIndicator(Long id,
                              Long userId,
                              FavoriteIndicatorSourceType sourceType,
                              String indicatorCode,
+                             FavoriteDisplayMode displayMode,
                              LocalDateTime createdAt) {
         this.id = id;
         this.userId = userId;
         this.sourceType = sourceType;
         this.indicatorCode = indicatorCode;
+        this.displayMode = displayMode;
         this.createdAt = createdAt;
     }
 
     public static FavoriteIndicator create(Long userId,
                                            FavoriteIndicatorSourceType sourceType,
                                            String indicatorCode) {
-        return new FavoriteIndicator(null, userId, sourceType, indicatorCode, LocalDateTime.now());
+        return new FavoriteIndicator(null, userId, sourceType, indicatorCode,
+                FavoriteDisplayMode.INDICATOR, LocalDateTime.now());
+    }
+
+    public FavoriteIndicator changeDisplayMode(FavoriteDisplayMode newDisplayMode) {
+        return new FavoriteIndicator(id, userId, sourceType, indicatorCode, newDisplayMode, createdAt);
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/repository/FavoriteIndicatorRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/repository/FavoriteIndicatorRepository.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.favorite.domain.repository;
 
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicator;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
 
@@ -19,4 +20,9 @@ public interface FavoriteIndicatorRepository {
     List<FavoriteIndicator> findByUserId(Long userId);
 
     List<FavoriteIndicator> findByUserIdAndSourceType(Long userId, FavoriteIndicatorSourceType sourceType);
+
+    int updateDisplayMode(Long userId,
+                          FavoriteIndicatorSourceType sourceType,
+                          String indicatorCode,
+                          FavoriteDisplayMode displayMode);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence;
 
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicator;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
 import com.thlee.stock.market.stockmarket.favorite.domain.repository.FavoriteIndicatorRepository;
@@ -40,5 +41,13 @@ public class FavoriteIndicatorRepositoryImpl implements FavoriteIndicatorReposit
         return jpaRepository.findByUserIdAndSourceType(userId, sourceType).stream()
             .map(mapper::toDomain)
             .toList();
+    }
+
+    @Override
+    public int updateDisplayMode(Long userId,
+                                 FavoriteIndicatorSourceType sourceType,
+                                 String indicatorCode,
+                                 FavoriteDisplayMode displayMode) {
+        return jpaRepository.updateDisplayMode(userId, sourceType, indicatorCode, displayMode);
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence;
 
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -36,6 +37,15 @@ public class UserFavoriteIndicatorEntity {
     @Column(name = "indicator_code", nullable = false, length = 310)
     private String indicatorCode;
 
+    @Enumerated(EnumType.STRING)
+    @Column(
+            name = "display_mode",
+            nullable = false,
+            length = 10,
+            columnDefinition = "VARCHAR(10) NOT NULL DEFAULT 'INDICATOR'"
+    )
+    private FavoriteDisplayMode displayMode;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -46,11 +56,13 @@ public class UserFavoriteIndicatorEntity {
                                        Long userId,
                                        FavoriteIndicatorSourceType sourceType,
                                        String indicatorCode,
+                                       FavoriteDisplayMode displayMode,
                                        LocalDateTime createdAt) {
         this.id = id;
         this.userId = userId;
         this.sourceType = sourceType;
         this.indicatorCode = indicatorCode;
+        this.displayMode = displayMode;
         this.createdAt = createdAt;
     }
 
@@ -58,6 +70,9 @@ public class UserFavoriteIndicatorEntity {
     protected void onCreate() {
         if (createdAt == null) {
             createdAt = LocalDateTime.now();
+        }
+        if (displayMode == null) {
+            displayMode = FavoriteDisplayMode.INDICATOR;
         }
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence;
 
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -20,4 +21,13 @@ public interface UserFavoriteIndicatorJpaRepository extends JpaRepository<UserFa
     int deleteByUserIdAndSourceTypeAndIndicatorCode(@Param("userId") Long userId,
                                                      @Param("sourceType") FavoriteIndicatorSourceType sourceType,
                                                      @Param("indicatorCode") String indicatorCode);
+
+    @Modifying
+    @Query("UPDATE UserFavoriteIndicatorEntity e " +
+           "SET e.displayMode = :displayMode " +
+           "WHERE e.userId = :userId AND e.sourceType = :sourceType AND e.indicatorCode = :indicatorCode")
+    int updateDisplayMode(@Param("userId") Long userId,
+                          @Param("sourceType") FavoriteIndicatorSourceType sourceType,
+                          @Param("indicatorCode") String indicatorCode,
+                          @Param("displayMode") FavoriteDisplayMode displayMode);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java
@@ -13,6 +13,7 @@ public class FavoriteIndicatorMapper {
             domain.getUserId(),
             domain.getSourceType(),
             domain.getIndicatorCode(),
+            domain.getDisplayMode(),
             domain.getCreatedAt()
         );
     }
@@ -23,6 +24,7 @@ public class FavoriteIndicatorMapper {
             entity.getUserId(),
             entity.getSourceType(),
             entity.getIndicatorCode(),
+            entity.getDisplayMode(),
             entity.getCreatedAt()
         );
     }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/FavoriteIndicatorController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/FavoriteIndicatorController.java
@@ -7,6 +7,7 @@ import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicator
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicator;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.EnrichedFavoriteResponse;
+import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteDisplayModeRequest;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteIndicatorResponse;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteToggleRequest;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.GlobalRefreshResponse;
@@ -84,6 +85,17 @@ public class FavoriteIndicatorController {
         GlobalEconomicIndicatorType type = GlobalEconomicIndicatorType.valueOf(indicatorType);
         List<EnrichedGlobalFavorite> refreshed = favoriteIndicatorService.refreshGlobalIndicator(userId, type);
         return ResponseEntity.ok(GlobalRefreshResponse.of(type, refreshed));
+    }
+
+    /**
+     * 관심 지표 표시 모드 변경 (INDICATOR ↔ GRAPH)
+     */
+    @PutMapping("/display-mode")
+    public ResponseEntity<Void> changeDisplayMode(@Valid @RequestBody FavoriteDisplayModeRequest request) {
+        Long userId = getCurrentUserId();
+        favoriteIndicatorService.changeDisplayMode(
+            userId, request.sourceType(), request.indicatorCode(), request.displayMode());
+        return ResponseEntity.noContent().build();
     }
 
     private Long getCurrentUserId() {

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/EnrichedFavoriteResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/EnrichedFavoriteResponse.java
@@ -6,7 +6,9 @@ import com.thlee.stock.market.stockmarket.economics.domain.model.IndicatorValue;
 import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.EnrichedEcosFavorite;
 import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.EnrichedFavorites;
 import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.EnrichedGlobalFavorite;
+import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.HistoryPoint;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record EnrichedFavoriteResponse(
@@ -33,9 +35,14 @@ public record EnrichedFavoriteResponse(
         String dataValue,
         String previousDataValue,
         String cycle,
-        boolean hasData
+        boolean hasData,
+        String displayMode,
+        List<EnrichedHistoryPoint> history
     ) {
         public static EcosItem from(EnrichedEcosFavorite enriched) {
+            String displayMode = enriched.favorite().getDisplayMode().name();
+            List<EnrichedHistoryPoint> history = toHistoryPoints(enriched.history());
+
             EcosIndicatorLatest latest = enriched.latest();
             if (latest == null) {
                 String[] parts = enriched.favorite().getIndicatorCode().split("::", 2);
@@ -43,7 +50,8 @@ public record EnrichedFavoriteResponse(
                     enriched.favorite().getIndicatorCode(),
                     parts.length > 0 ? parts[0] : "",
                     parts.length > 1 ? parts[1] : "",
-                    null, null, null, false
+                    null, null, null, false,
+                    displayMode, history
                 );
             }
             return new EcosItem(
@@ -53,7 +61,8 @@ public record EnrichedFavoriteResponse(
                 latest.getDataValue(),
                 latest.getPreviousDataValue(),
                 latest.getCycle(),
-                true
+                true,
+                displayMode, history
             );
         }
     }
@@ -69,19 +78,24 @@ public record EnrichedFavoriteResponse(
         boolean hasData,
         boolean failed,
         String failureReason,
-        boolean refreshable
+        boolean refreshable,
+        String displayMode,
+        List<EnrichedHistoryPoint> history
     ) {
         public static GlobalItem from(EnrichedGlobalFavorite enriched) {
             String[] parts = enriched.favorite().getIndicatorCode().split("::", 2);
             String parsedCountry = parts.length > 0 ? parts[0] : "";
             String parsedType = parts.length > 1 ? parts[1] : "";
+            String displayMode = enriched.favorite().getDisplayMode().name();
+            List<EnrichedHistoryPoint> history = toHistoryPoints(enriched.history());
 
             if (enriched.isFailed()) {
                 return new GlobalItem(
                     enriched.favorite().getIndicatorCode(),
                     parsedCountry, parsedType,
                     null, null, null, null,
-                    false, true, enriched.failureReason(), enriched.refreshable()
+                    false, true, enriched.failureReason(), enriched.refreshable(),
+                    displayMode, history
                 );
             }
 
@@ -91,7 +105,8 @@ public record EnrichedFavoriteResponse(
                     enriched.favorite().getIndicatorCode(),
                     parsedCountry, parsedType,
                     null, null, null, null,
-                    false, false, null, true
+                    false, false, null, true,
+                    displayMode, history
                 );
             }
 
@@ -106,8 +121,20 @@ public record EnrichedFavoriteResponse(
                 snap.getReferenceText(),
                 last != null ? last.getUnit() : null,
                 last != null,
-                false, null, true
+                false, null, true,
+                displayMode, history
             );
         }
+    }
+
+    public record EnrichedHistoryPoint(LocalDate snapshotDate, String dataValue) {}
+
+    private static List<EnrichedHistoryPoint> toHistoryPoints(List<HistoryPoint> points) {
+        if (points == null || points.isEmpty()) {
+            return List.of();
+        }
+        return points.stream()
+            .map(p -> new EnrichedHistoryPoint(p.snapshotDate(), p.dataValue()))
+            .toList();
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/FavoriteDisplayModeRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/FavoriteDisplayModeRequest.java
@@ -1,0 +1,12 @@
+package com.thlee.stock.market.stockmarket.favorite.presentation.dto;
+
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FavoriteDisplayModeRequest(
+    @NotNull FavoriteIndicatorSourceType sourceType,
+    @NotBlank String indicatorCode,
+    @NotNull FavoriteDisplayMode displayMode
+) {}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -400,29 +400,83 @@
                             </div>
                         </template>
 
-                        <!-- 관심 지표 슬라이드 -->
-                        <template x-if="homeSummary.enrichedFavorites?.ecos?.length > 0">
-                            <div>
+                        <!-- 관심 지표 — 그래프 영역 -->
+                        <template x-if="homeSummary.enrichedFavorites?.ecos?.filter(c => c.displayMode === 'GRAPH').length > 0">
+                            <div class="mb-4">
                                 <div class="flex items-center justify-between mb-2">
                                     <p class="text-sm font-semibold text-gray-600 flex items-center gap-1">
-                                        <span class="text-yellow-400">&#9733;</span> 관심 지표
+                                        <span class="text-yellow-400">&#9733;</span> 관심 지표 — 그래프
                                     </p>
                                     <div class="flex gap-1">
-                                        <button @click="scrollFavorites(-1, 'ecos-fav-scroll')"
+                                        <button @click="scrollFavorites(-1, 'ecos-fav-graph-scroll')"
                                                 class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9664;</button>
-                                        <button @click="scrollFavorites(1, 'ecos-fav-scroll')"
+                                        <button @click="scrollFavorites(1, 'ecos-fav-graph-scroll')"
                                                 class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9654;</button>
                                     </div>
                                 </div>
-                                <div id="ecos-fav-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
-                                    <template x-for="card in homeSummary.enrichedFavorites.ecos" :key="card.indicatorCode">
+                                <div id="ecos-fav-graph-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
+                                    <template x-for="card in homeSummary.enrichedFavorites.ecos.filter(c => c.displayMode === 'GRAPH')" :key="card.indicatorCode">
                                         <div class="snap-start flex-shrink-0 w-[280px] sm:w-[300px]">
                                             <div class="spread-card rounded-xl p-4 shadow-sm relative"
                                                  :class="card.hasData ? 'status-normal' : ''">
                                                 <!-- 해제 버튼 -->
                                                 <button @click="removeDashboardFavorite('ECOS', card.indicatorCode)"
                                                         class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
-                                                <div class="mb-2 pr-6">
+                                                <!-- 표시 모드 토글 버튼 -->
+                                                <button @click="toggleDisplayMode(card, 'ECOS')"
+                                                        :disabled="card._displayModePending"
+                                                        title="지표로 보기"
+                                                        class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">지표</button>
+                                                <div class="mb-2 pr-16">
+                                                    <span class="text-sm font-semibold text-gray-700" x-text="card.keystatName"></span>
+                                                    <p class="text-[11px] text-gray-400 mt-0.5" x-text="card.className"></p>
+                                                </div>
+                                                <div class="h-20">
+                                                    <template x-if="card.history && card.history.length > 0">
+                                                        <canvas x-init="$nextTick(() => renderFavoriteChart($el, card.history, card.indicatorCode))"></canvas>
+                                                    </template>
+                                                    <template x-if="!card.history || card.history.length === 0">
+                                                        <p class="text-gray-300 text-sm">시계열 데이터 없음</p>
+                                                    </template>
+                                                </div>
+                                                <template x-if="card.cycle">
+                                                    <p class="text-[10px] text-gray-400 mt-2" x-text="card.cycle"></p>
+                                                </template>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+
+                        <!-- 관심 지표 — 단순 지표 영역 -->
+                        <template x-if="homeSummary.enrichedFavorites?.ecos?.filter(c => c.displayMode !== 'GRAPH').length > 0">
+                            <div>
+                                <div class="flex items-center justify-between mb-2">
+                                    <p class="text-sm font-semibold text-gray-600 flex items-center gap-1">
+                                        <span class="text-yellow-400">&#9733;</span> 관심 지표 — 지표
+                                    </p>
+                                    <div class="flex gap-1">
+                                        <button @click="scrollFavorites(-1, 'ecos-fav-indicator-scroll')"
+                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9664;</button>
+                                        <button @click="scrollFavorites(1, 'ecos-fav-indicator-scroll')"
+                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9654;</button>
+                                    </div>
+                                </div>
+                                <div id="ecos-fav-indicator-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
+                                    <template x-for="card in homeSummary.enrichedFavorites.ecos.filter(c => c.displayMode !== 'GRAPH')" :key="card.indicatorCode">
+                                        <div class="snap-start flex-shrink-0 w-[280px] sm:w-[300px]">
+                                            <div class="spread-card rounded-xl p-4 shadow-sm relative"
+                                                 :class="card.hasData ? 'status-normal' : ''">
+                                                <!-- 해제 버튼 -->
+                                                <button @click="removeDashboardFavorite('ECOS', card.indicatorCode)"
+                                                        class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
+                                                <!-- 표시 모드 토글 버튼 -->
+                                                <button @click="toggleDisplayMode(card, 'ECOS')"
+                                                        :disabled="card._displayModePending"
+                                                        title="그래프로 보기"
+                                                        class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">그래프</button>
+                                                <div class="mb-2 pr-16">
                                                     <span class="text-sm font-semibold text-gray-700" x-text="card.keystatName"></span>
                                                     <p class="text-[11px] text-gray-400 mt-0.5" x-text="card.className"></p>
                                                 </div>
@@ -479,37 +533,96 @@
                             </div>
                         </template>
 
-                        <!-- 관심 지표 슬라이드 -->
-                        <template x-if="homeSummary.enrichedFavorites?.global?.length > 0">
-                            <div>
+                        <!-- 관심 지표 — 그래프 영역 -->
+                        <template x-if="homeSummary.enrichedFavorites?.global?.filter(c => c.displayMode === 'GRAPH').length > 0">
+                            <div class="mb-4">
                                 <div class="flex items-center justify-between mb-2">
                                     <p class="text-sm font-semibold text-gray-600 flex items-center gap-1">
-                                        <span class="text-yellow-400">&#9733;</span> 관심 지표
+                                        <span class="text-yellow-400">&#9733;</span> 관심 지표 — 그래프
                                     </p>
                                     <div class="flex gap-1">
-                                        <button @click="scrollFavorites(-1, 'global-fav-scroll')"
+                                        <button @click="scrollFavorites(-1, 'global-fav-graph-scroll')"
                                                 class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9664;</button>
-                                        <button @click="scrollFavorites(1, 'global-fav-scroll')"
+                                        <button @click="scrollFavorites(1, 'global-fav-graph-scroll')"
                                                 class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9654;</button>
                                     </div>
                                 </div>
-                                <div id="global-fav-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
-                                    <template x-for="card in homeSummary.enrichedFavorites.global" :key="card.indicatorCode">
+                                <div id="global-fav-graph-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
+                                    <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode === 'GRAPH')" :key="card.indicatorCode">
                                         <div class="snap-start flex-shrink-0 w-[280px] sm:w-[300px]">
                                             <div class="spread-card rounded-xl p-4 shadow-sm relative"
                                                  :class="!card.failed && card.hasData ? 'status-normal' : ''">
                                                 <!-- 해제 버튼 -->
                                                 <button @click="removeDashboardFavorite('GLOBAL', card.indicatorCode)"
                                                         class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
+                                                <!-- 표시 모드 토글 버튼 -->
+                                                <button @click="toggleDisplayMode(card, 'GLOBAL')"
+                                                        :disabled="card._displayModePending"
+                                                        title="지표로 보기"
+                                                        class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">지표</button>
+                                                <div class="mb-2 pr-16">
+                                                    <span class="text-sm font-semibold text-gray-700" x-text="card.countryName"></span>
+                                                    <p class="text-[11px] text-gray-400 mt-0.5" x-text="card.indicatorType.replace(/_/g, ' ')"></p>
+                                                </div>
+                                                <template x-if="card.failed">
+                                                    <p class="text-red-400 text-sm" x-text="globalFailureMessage(card)"></p>
+                                                </template>
+                                                <template x-if="!card.failed">
+                                                    <div class="h-20">
+                                                        <template x-if="card.history && card.history.length > 0">
+                                                            <canvas x-init="$nextTick(() => renderFavoriteChart($el, card.history, card.indicatorCode))"></canvas>
+                                                        </template>
+                                                        <template x-if="!card.history || card.history.length === 0">
+                                                            <p class="text-gray-300 text-sm">시계열 데이터 없음</p>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                                <template x-if="card.cycle">
+                                                    <p class="text-[10px] text-gray-400 mt-2" x-text="card.cycle"></p>
+                                                </template>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+
+                        <!-- 관심 지표 — 단순 지표 영역 -->
+                        <template x-if="homeSummary.enrichedFavorites?.global?.filter(c => c.displayMode !== 'GRAPH').length > 0">
+                            <div>
+                                <div class="flex items-center justify-between mb-2">
+                                    <p class="text-sm font-semibold text-gray-600 flex items-center gap-1">
+                                        <span class="text-yellow-400">&#9733;</span> 관심 지표 — 지표
+                                    </p>
+                                    <div class="flex gap-1">
+                                        <button @click="scrollFavorites(-1, 'global-fav-indicator-scroll')"
+                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9664;</button>
+                                        <button @click="scrollFavorites(1, 'global-fav-indicator-scroll')"
+                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9654;</button>
+                                    </div>
+                                </div>
+                                <div id="global-fav-indicator-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
+                                    <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode !== 'GRAPH')" :key="card.indicatorCode">
+                                        <div class="snap-start flex-shrink-0 w-[280px] sm:w-[300px]">
+                                            <div class="spread-card rounded-xl p-4 shadow-sm relative"
+                                                 :class="!card.failed && card.hasData ? 'status-normal' : ''">
+                                                <!-- 해제 버튼 -->
+                                                <button @click="removeDashboardFavorite('GLOBAL', card.indicatorCode)"
+                                                        class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
+                                                <!-- 표시 모드 토글 버튼 -->
+                                                <button @click="toggleDisplayMode(card, 'GLOBAL')"
+                                                        :disabled="card._displayModePending"
+                                                        title="그래프로 보기"
+                                                        class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">그래프</button>
                                                 <!-- 재조회 버튼: 실시간 조회 실패 시 표시 -->
                                                 <template x-if="card.failed">
                                                     <button @click="refreshGlobal(card)"
                                                             :disabled="!card.refreshable || card.refreshing"
                                                             :title="card.refreshable ? '다시 조회' : '현재 재조회로 해결되지 않는 실패입니다'"
-                                                            class="absolute top-2 right-9 text-gray-500 hover:text-gray-700 disabled:text-gray-300 disabled:cursor-not-allowed cursor-pointer text-base"
+                                                            class="absolute top-2 right-[5.5rem] text-gray-500 hover:text-gray-700 disabled:text-gray-300 disabled:cursor-not-allowed cursor-pointer text-base"
                                                             :class="card.refreshing ? 'animate-spin' : ''">&#10227;</button>
                                                 </template>
-                                                <div class="mb-2 pr-16">
+                                                <div class="mb-2 pr-24">
                                                     <span class="text-sm font-semibold text-gray-700" x-text="card.countryName"></span>
                                                     <p class="text-[11px] text-gray-400 mt-0.5" x-text="card.indicatorType.replace(/_/g, ' ')"></p>
                                                 </div>

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -169,6 +169,10 @@ const API = {
         return this.request('POST', `/api/favorites/global/refresh/${indicatorType}`);
     },
 
+    changeFavoriteDisplayMode(sourceType, indicatorCode, displayMode) {
+        return this.request('PUT', '/api/favorites/display-mode', { sourceType, indicatorCode, displayMode });
+    },
+
     getRecentUpdates() {
         return this.request('GET', '/api/economics/indicators/recent-updates');
     },

--- a/src/main/resources/static/js/components/favorite.js
+++ b/src/main/resources/static/js/components/favorite.js
@@ -143,5 +143,92 @@ const FavoriteComponent = {
             case 'INVALID_CODE': return '알 수 없는 지표 코드입니다. 관심 지표에서 제거해주세요';
             default: return '실시간 조회 실패. 잠시 후 재조회해주세요';
         }
+    },
+
+    /**
+     * 관심 지표 표시 모드 토글 (INDICATOR ↔ GRAPH).
+     * 토글 후 enriched 재조회로 history 동기화.
+     */
+    async toggleDisplayMode(card, sourceType) {
+        if (!this.checkLoggedIn()) return;
+        if (!card || card._displayModePending) return;
+        card._displayModePending = true;
+
+        const oldMode = card.displayMode || 'INDICATOR';
+        const newMode = oldMode === 'GRAPH' ? 'INDICATOR' : 'GRAPH';
+
+        try {
+            await API.changeFavoriteDisplayMode(sourceType, card.indicatorCode, newMode);
+
+            const fresh = await API.getEnrichedFavorites();
+            if (fresh && this.homeSummary) {
+                this.homeSummary.enrichedFavorites = fresh;
+            }
+        } catch (e) {
+            console.error('표시 모드 변경 실패:', e);
+            alert('표시 모드 변경에 실패했어요. 잠시 후 다시 시도해주세요');
+        } finally {
+            card._displayModePending = false;
+        }
+    },
+
+    /**
+     * 카드 안 canvas 에 시계열 라인 차트 렌더.
+     * 동일 indicatorCode 의 기존 차트는 destroy 후 재생성한다.
+     */
+    renderFavoriteChart(canvasEl, history, indicatorCode) {
+        if (!canvasEl) return;
+        if (!this.favorites._charts) this.favorites._charts = {};
+
+        const prev = this.favorites._charts[indicatorCode];
+        if (prev) {
+            try { prev.destroy(); } catch (_) { /* noop */ }
+            delete this.favorites._charts[indicatorCode];
+        }
+
+        if (!history || history.length === 0) return;
+
+        const labels = history.map(p => p.snapshotDate);
+        const values = history.map(p => {
+            const num = parseFloat(String(p.dataValue || '').replace(/,/g, ''));
+            return Number.isFinite(num) ? num : null;
+        });
+
+        const chart = new Chart(canvasEl, {
+            type: 'line',
+            data: {
+                labels,
+                datasets: [{
+                    data: values,
+                    borderColor: '#3b82f6',
+                    backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                    borderWidth: 1.5,
+                    tension: 0.3,
+                    pointRadius: 0,
+                    spanGaps: true,
+                    fill: true
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            title: (items) => items[0]?.label || '',
+                            label: (item) => item.formattedValue
+                        }
+                    }
+                },
+                scales: {
+                    x: { display: false },
+                    y: { display: false }
+                }
+            }
+        });
+
+        this.favorites._charts[indicatorCode] = chart;
     }
 };


### PR DESCRIPTION
## Summary
- 관심지표 항목별로 **그래프 / 단순 지표** 표시 방식을 선택하는 기능 추가 (이슈 #38)
- 사용자 선택은 DB(`user_favorite_indicator.display_mode`)에 영속화, 마지막 선택 유지
- 대시보드에서 ECOS/GLOBAL 각 섹션 안에 **그래프 영역 / 단순 지표 영역**을 분리해 표시

## 변경 영역
- **Domain**: `FavoriteDisplayMode` enum (INDICATOR, GRAPH), `FavoriteIndicator`에 displayMode 필드 + `changeDisplayMode()` 메서드
- **Infrastructure**: `UserFavoriteIndicatorEntity`에 `display_mode` 컬럼 추가 (`columnDefinition` 으로 ddl-auto 가 `NOT NULL DEFAULT 'INDICATOR'` 자동 적용 → 별도 SQL 마이그레이션 불필요), `updateDisplayMode` 쿼리 구현
- **Economics 모듈**: 단일 지표 시계열 조회 메서드 신규 (`findHistory(...)`) — 기존 `findLatestHistory*`는 cycle별 1행만 반환하여 그래프용으로 부적합. PostgreSQL native ROW_NUMBER 쿼리로 최근 N개 snapshot 반환.
- **Application**: `changeDisplayMode(...)` 추가, `findEnrichedByUserId(...)` 가 GRAPH 모드 항목에 한해 시계열 history 첨부 (limit 30)
- **Presentation**: `PUT /api/favorites/display-mode` 신규 API, `EnrichedFavoriteResponse`의 EcosItem/GlobalItem에 `displayMode`/`history` 필드 추가
- **Frontend**: `index.html` 두 영역 분리, 카드별 토글 버튼, Chart.js 라인 차트 (인스턴스 destroy 관리), `api.js`/`favorite.js` 핸들러

## Test plan
- [ ] 관심지표를 등록 후 카드에 "그래프" 버튼이 보이는지 확인 (기본 모드 INDICATOR)
- [ ] "그래프" 클릭 시 카드가 그래프 영역으로 이동하고 라인 차트가 렌더되는지 확인
- [ ] "지표" 클릭 시 단순 지표 영역으로 복귀하는지 확인
- [ ] 페이지 새로고침 후 마지막 선택 모드가 유지되는지 확인 (DB 저장 검증)
- [ ] 시계열 데이터가 없는 지표는 "시계열 데이터 없음" 표시되는지 확인
- [ ] 토글 연타 시 race condition 없는지 (`_displayModePending` 디바운스)
- [ ] ddl-auto 가 `display_mode` 컬럼을 NOT NULL DEFAULT 'INDICATOR' 로 자동 추가하는지 확인 (운영 배포 시)

## 관련
- Closes #38

https://claude.ai/code/session_011KLjDTSsmCH5xbGdJc8chu

---
_Generated by [Claude Code](https://claude.ai/code/session_011KLjDTSsmCH5xbGdJc8chu)_