### PR TITLE
fix(favorite): displayMode null 안전 처리로 NPE 방지 (#38)

### DIFF
--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java
@@ -27,7 +27,7 @@ public class FavoriteIndicator {
         this.userId = userId;
         this.sourceType = sourceType;
         this.indicatorCode = indicatorCode;
-        this.displayMode = displayMode;
+        this.displayMode = displayMode != null ? displayMode : FavoriteDisplayMode.INDICATOR;
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence.mapper;
 
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicator;
 import com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence.UserFavoriteIndicatorEntity;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,7 @@ public class FavoriteIndicatorMapper {
             domain.getUserId(),
             domain.getSourceType(),
             domain.getIndicatorCode(),
-            domain.getDisplayMode(),
+            domain.getDisplayMode() != null ? domain.getDisplayMode() : FavoriteDisplayMode.INDICATOR,
             domain.getCreatedAt()
         );
     }
@@ -24,7 +25,7 @@ public class FavoriteIndicatorMapper {
             entity.getUserId(),
             entity.getSourceType(),
             entity.getIndicatorCode(),
-            entity.getDisplayMode(),
+            entity.getDisplayMode() != null ? entity.getDisplayMode() : FavoriteDisplayMode.INDICATOR,
             entity.getCreatedAt()
         );
     }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/EnrichedFavoriteResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/EnrichedFavoriteResponse.java
@@ -7,6 +7,7 @@ import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicator
 import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.EnrichedFavorites;
 import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.EnrichedGlobalFavorite;
 import com.thlee.stock.market.stockmarket.favorite.application.FavoriteIndicatorService.HistoryPoint;
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -40,7 +41,8 @@ public record EnrichedFavoriteResponse(
         List<EnrichedHistoryPoint> history
     ) {
         public static EcosItem from(EnrichedEcosFavorite enriched) {
-            String displayMode = enriched.favorite().getDisplayMode().name();
+            FavoriteDisplayMode mode = enriched.favorite().getDisplayMode();
+            String displayMode = (mode != null ? mode : FavoriteDisplayMode.INDICATOR).name();
             List<EnrichedHistoryPoint> history = toHistoryPoints(enriched.history());
 
             EcosIndicatorLatest latest = enriched.latest();
@@ -86,7 +88,8 @@ public record EnrichedFavoriteResponse(
             String[] parts = enriched.favorite().getIndicatorCode().split("::", 2);
             String parsedCountry = parts.length > 0 ? parts[0] : "";
             String parsedType = parts.length > 1 ? parts[1] : "";
-            String displayMode = enriched.favorite().getDisplayMode().name();
+            FavoriteDisplayMode mode = enriched.favorite().getDisplayMode();
+            String displayMode = (mode != null ? mode : FavoriteDisplayMode.INDICATOR).name();
             List<EnrichedHistoryPoint> history = toHistoryPoints(enriched.history());
 
             if (enriched.isFailed()) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -534,7 +534,7 @@
                         </template>
 
                         <!-- 관심 지표 — 그래프 영역 -->
-                        <template x-if="homeSummary.enrichedFavorites?.global?.filter(c => c.displayMode === 'GRAPH').length > 0">
+                        <template x-if="homeSummary.enrichedFavorites?.global?.filter(c => c.displayMode === 'GRAPH' && !c.failed).length > 0">
                             <div class="mb-4">
                                 <div class="flex items-center justify-between mb-2">
                                     <p class="text-sm font-semibold text-gray-600 flex items-center gap-1">
@@ -548,7 +548,7 @@
                                     </div>
                                 </div>
                                 <div id="global-fav-graph-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
-                                    <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode === 'GRAPH')" :key="card.indicatorCode">
+                                    <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode === 'GRAPH' && !c.failed)" :key="card.indicatorCode">
                                         <div class="snap-start flex-shrink-0 w-[280px] sm:w-[300px]">
                                             <div class="spread-card rounded-xl p-4 shadow-sm relative"
                                                  :class="!card.failed && card.hasData ? 'status-normal' : ''">
@@ -588,7 +588,7 @@
                         </template>
 
                         <!-- 관심 지표 — 단순 지표 영역 -->
-                        <template x-if="homeSummary.enrichedFavorites?.global?.filter(c => c.displayMode !== 'GRAPH').length > 0">
+                        <template x-if="homeSummary.enrichedFavorites?.global?.filter(c => c.displayMode !== 'GRAPH' || c.failed).length > 0">
                             <div>
                                 <div class="flex items-center justify-between mb-2">
                                     <p class="text-sm font-semibold text-gray-600 flex items-center gap-1">
@@ -602,7 +602,7 @@
                                     </div>
                                 </div>
                                 <div id="global-fav-indicator-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
-                                    <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode !== 'GRAPH')" :key="card.indicatorCode">
+                                    <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode !== 'GRAPH' || c.failed)" :key="card.indicatorCode">
                                         <div class="snap-start flex-shrink-0 w-[280px] sm:w-[300px]">
                                             <div class="spread-card rounded-xl p-4 shadow-sm relative"
                                                  :class="!card.failed && card.hasData ? 'status-normal' : ''">

--- a/src/main/resources/static/js/components/favorite.js
+++ b/src/main/resources/static/js/components/favorite.js
@@ -148,6 +148,7 @@ const FavoriteComponent = {
     /**
      * 관심 지표 표시 모드 토글 (INDICATOR ↔ GRAPH).
      * 토글 후 enriched 재조회로 history 동기화.
+     * GRAPH → INDICATOR 전환 시 차트 인스턴스 정리.
      */
     async toggleDisplayMode(card, sourceType) {
         if (!this.checkLoggedIn()) return;
@@ -160,6 +161,10 @@ const FavoriteComponent = {
         try {
             await API.changeFavoriteDisplayMode(sourceType, card.indicatorCode, newMode);
 
+            if (oldMode === 'GRAPH') {
+                this.destroyFavoriteChart(card.indicatorCode);
+            }
+
             const fresh = await API.getEnrichedFavorites();
             if (fresh && this.homeSummary) {
                 this.homeSummary.enrichedFavorites = fresh;
@@ -169,6 +174,18 @@ const FavoriteComponent = {
             alert('표시 모드 변경에 실패했어요. 잠시 후 다시 시도해주세요');
         } finally {
             card._displayModePending = false;
+        }
+    },
+
+    /**
+     * 단일 indicatorCode 의 차트 인스턴스를 destroy 하고 캐시에서 제거한다.
+     */
+    destroyFavoriteChart(indicatorCode) {
+        if (!this.favorites._charts) return;
+        const chart = this.favorites._charts[indicatorCode];
+        if (chart) {
+            try { chart.destroy(); } catch (_) { /* noop */ }
+            delete this.favorites._charts[indicatorCode];
         }
     },
 

--- a/src/main/resources/static/js/components/home.js
+++ b/src/main/resources/static/js/components/home.js
@@ -101,6 +101,8 @@ const HomeComponent = {
      */
     async removeDashboardFavorite(sourceType, indicatorCode) {
         await this.toggleFavorite(sourceType, indicatorCode);
+        // 차트 인스턴스 메모리 정리 (GRAPH 모드 카드였을 수 있음)
+        this.destroyFavoriteChart(indicatorCode);
         // enrichedFavorites에서도 즉시 제거
         if (this.homeSummary.enrichedFavorites) {
             if (sourceType === 'ECOS') {


### PR DESCRIPTION
## Summary
이슈 #38 구현 후, `EnrichedFavoriteResponse.from()` 에서 `favorite.getDisplayMode().name()` 호출 시 **NullPointerException** 발생 가능 → enriched API 500 → 화면에 관심지표 카드 자체가 안 뜨는 문제를 수정.

## 원인
`ddl-auto: update` 가 `display_mode` 컬럼을 추가할 때, 일부 환경에서 `columnDefinition` 의 `DEFAULT 'INDICATOR'` 가 기존 row 에 적용되지 않아 `display_mode = NULL` row 가 존재할 수 있음. 이 경우 매퍼·도메인·DTO 모두 null 가정 없이 `.name()` 을 호출해 NPE 발생.

## Fix — 3중 방어
1. **`FavoriteIndicator` 도메인 생성자**: `displayMode == null` → `INDICATOR` fallback (도메인 invariant 보장)
2. **`FavoriteIndicatorMapper`**: Entity ↔ Domain 양방향 매핑 시 null → `INDICATOR`
3. **`EnrichedFavoriteResponse` EcosItem/GlobalItem.from()**: `.name()` 직전에도 null 방어

이로써 어느 한 경로에서 null 이 들어와도 항상 `INDICATOR` 로 안전 변환됨.

## Test plan
- [ ] 배포 후 enriched API 200 정상 응답 확인
- [ ] 응답 JSON 의 `displayMode` 필드가 모두 `INDICATOR` / `GRAPH` 중 하나인지 확인
- [ ] 관심지표 카드에 "그래프" 토글 버튼이 정상 표시되는지 확인
- [ ] DB 에 NULL row 가 있다면 점진적으로 사용자가 토글하면서 채워짐. 한 번에 정리하려면 `UPDATE user_favorite_indicator SET display_mode = 'INDICATOR' WHERE display_mode IS NULL;` 실행

## 관련
- Follow-up of #39

https://claude.ai/code/session_011KLjDTSsmCH5xbGdJc8chu

---
_Generated by [Claude Code](https://claude.ai/code/session_011KLjDTSsmCH5xbGdJc8chu)_