### PR TITLE
fix(frontend): iPad 페이지 이동 시 채팅창 잔존 회귀 수정

### DIFF
--- a/src/main/resources/static/partials/_chat.html
+++ b/src/main/resources/static/partials/_chat.html
@@ -1,7 +1,11 @@
     <!-- ==================== 챗봇 버블 + 패널 ==================== -->
+    <!-- partial 분리 후 iPad Safari 에서 x-show + x-transition leave 가 -->
+    <!-- inline display:none 을 적용하지 못해 다른 페이지에서 잔존하던 회귀를 -->
+    <!-- 방지하기 위해 portfolio/ecos 외 페이지에서는 DOM 에서 완전히 제거. -->
+    <template x-if="currentPage === 'portfolio' || currentPage === 'ecos'">
+    <div>
     <!-- 챗봇 버블 버튼 -->
     <button @click="toggleChat()"
-            x-show="currentPage === 'portfolio' || currentPage === 'ecos'"
             x-cloak
             class="fixed bottom-6 right-6 w-14 h-14 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full shadow-lg flex items-center justify-center z-40 transition-all duration-200">
         <svg x-show="!chat.isOpen" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -14,7 +18,7 @@
     </button>
 
     <!-- 챗 패널 -->
-    <div x-show="chat.isOpen && (currentPage === 'portfolio' || currentPage === 'ecos')"
+    <div x-show="chat.isOpen"
          x-transition:enter="transition ease-out duration-200"
          x-transition:enter-start="opacity-0 translate-y-4"
          x-transition:enter-end="opacity-100 translate-y-0"
@@ -195,3 +199,5 @@
             </div>
         </div>
     </div>
+    </div>
+    </template>


### PR DESCRIPTION
partial 분리 후 _chat.html 이 Alpine.initTree 경로로 마운트되면서 iPad Safari 에서 x-show + x-transition leave 가 inline display:none 을 적용하지 못해 portfolio/ecos 외 페이지에서도 채팅 패널이 잔존하던 회귀를 수정. bubble + panel 을 currentPage 기반 template x-if 로 감싸 비대상 페이지에서는 DOM 에서 완전히 제거.