### PR TITLE
fix(frontend): iPad 채팅창 잔존 + 4개 메뉴 placeholder 누락 회귀 복구

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -61,6 +61,22 @@
             <div data-partial="portfolio-sale" aria-busy="true" aria-live="polite"></div>
             <div data-partial="portfolio-deposit-financial" aria-busy="true" aria-live="polite"></div>
 
+
+            <!-- ========== SALARY USAGE RATIO (partial) ========== -->
+            <div data-partial="salary" aria-busy="true" aria-live="polite"></div>
+
+
+            <!-- ========== STOCK NOTE (partial) ========== -->
+            <div data-partial="stocknote" aria-busy="true" aria-live="polite"></div>
+
+
+            <!-- ========== NEWS JOURNAL (partial) ========== -->
+            <div data-partial="news-journal" aria-busy="true" aria-live="polite"></div>
+
+
+            <!-- ========== ADMIN LOGS (partial, secured) ========== -->
+            <div data-partial="admin-logs" data-secured="true" aria-busy="true" aria-live="polite"></div>
+
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

partial 분리 배포 이후 발견된 두 회귀 수정.

- **iPad 채팅창 잔존**: `_chat.html` 의 bubble + panel 을 `<template x-if="currentPage === 'portfolio' || currentPage === 'ecos'">` 로 감싸 비대상 페이지에서 DOM 에서 완전히 제거. iPad Safari 에서 `x-show + x-transition` leave 가 inline `display:none` 을 적용하지 못하던 케이스 우회.
- **4개 메뉴 placeholder 누락**: portfolio 5-way 분리(`30c2a7d`) 시 함께 삭제됐던 `salary` / `stocknote` / `news-journal` / `admin-logs` placeholder 를 `index.html` 에 복구. partial-loader 가 host element 를 못 찾아 mount 를 skip 하던 4개 메뉴 정상 표시.

## Changes

- `src/main/resources/static/partials/_chat.html`: bubble + panel `<template x-if>` 래핑, panel `x-show` 단순화 (`chat.isOpen`)
- `src/main/resources/static/index.html`: salary / stocknote / news-journal / admin-logs `<div data-partial>` placeholder 추가 (admin-logs 는 `data-secured="true"`)

## Test plan

- [ ] iPad portrait 에서 portfolio → home 이동 시 채팅 패널 사라지는지
- [ ] portfolio 안에서 채팅 X 버튼 닫기 동작
- [ ] 사이드바에서 투자 노트 / 뉴스 기록 / 운영자 로그 / 월급 사용 비율 진입 시 정상 표시
- [ ] hash direct (`#stocknote`, `#news-journal`, `#admin-logs`, `#salary`) 진입 시 정상 표시
- [ ] admin 권한 없는 계정에서 `#admin-logs` 진입 시 host 가 비워진 채 inline 에러 없이 다른 메뉴 정상 동작

---
_Generated by [Claude Code](https://claude.ai/code/session_011V5NFfrHjjMpPcT5Bv42z1)_