### PR TITLE
feat(favorite): 관심지표 우선순위 + GRAPH 그리드 레이아웃 (#42)

### DIFF
--- a/docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md
+++ b/docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md
@@ -1,0 +1,99 @@
+---
+date: 2026-05-06
+topic: watchlist-priority-and-graph-layout
+issue: 42
+branch: feat/issue-42-watchlist-priority-and-layout
+---
+
+# 관심지표 우선순위 및 그래프 레이아웃 개선
+
+## Problem Frame
+
+현재 사용자의 관심지표는 별도 정렬 컬럼이 없어 화면에 그려지는 순서가 일관되지 않다. 또한 GRAPH 표시 모드에서 다수의 관심지표가 한 행에 가로로 나열되어 한눈에 비교하기 어렵다. 사용자가 관심지표 표시 순서를 직접 제어하고, 그래프 표시도 화면 폭에 맞춰 여러 줄로 나뉘어 한눈에 보이도록 개선한다.
+
+## Requirements
+
+**우선순위 모델**
+- R1. 관심지표 항목은 사용자별·`source_type`별로 정렬 우선순위를 갖는다. (전역 단일 정렬이 아님)
+- R2. 새로 추가되는 관심지표는 동일 `source_type` 그룹의 맨 뒤에 위치한다.
+- R3. `GET /api/favorites` 및 `GET /api/favorites/enriched` 응답은 `source_type` 그룹 내에서 우선순위 오름차순으로 정렬되어 반환된다.
+
+**우선순위 편집 UX**
+- R4. 사용자는 관심지표 영역에서 "순서 편집" 모드를 진입/종료할 수 있다.
+- R5. 편집 모드는 같은 `source_type` × 같은 `displayMode` 컨테이너 단위로 진입한다. INDICATOR(카드) 컨테이너의 편집과 GRAPH 컨테이너의 편집은 서로 독립이다. 우선순위 컬럼은 두 모드가 공유하지만, 일괄 저장 페이로드에 포함되는 항목은 현재 편집 중인 컨테이너의 보이는 항목들로 한정된다.
+- R6. 편집 모드는 "저장" 또는 "취소" 액션으로 종료한다. 저장 시 페이로드 항목들의 새 순서가 서버에 일괄 반영되고, 취소 시 드래그로 변경된 순서만 편집 진입 시점으로 되돌린다. 편집 중 다른 액션으로 변경된 멤버십(아래 R8)은 취소로 되돌리지 않는다.
+- R7. 일괄 저장 시 동시성 정책은 "서버 결과 우선 + 보이는 항목들의 상대 순서만 갱신"으로 적용한다. 구체:
+  - (a) 클라이언트 페이로드 내 ID 중 서버에 더 이상 존재하지 않는 것은 무시한다.
+  - (b) 같은 `source_type`이지만 *다른 `displayMode`* 항목의 우선순위는 본 저장 호출로 변경하지 않는다. 구현 알고리즘: 트랜잭션 내에서 (i) 해당 `(user_id, source_type)`의 모든 행을 `SELECT ... FOR UPDATE`로 잠그고, (ii) 편집 컨테이너에 속한 항목들이 현재 점유한 priority 슬롯 집합 S를 수집한 뒤 (iii) 페이로드 순서대로 S의 값을 ASC 정렬하여 재할당하고 (iv) 다른 displayMode 항목의 priority는 그대로 유지. 결과적으로 `(user_id, source_type)` 그룹의 dense 0..N-1 invariant는 그룹 전체 집합 단위로 유지되며 per-displayMode 연속성은 보장되지 않는다.
+  - (c) 같은 컨테이너인데 페이로드에 없으나 서버에 존재하는 항목(다른 탭에서 추가됨)은 해당 컨테이너의 맨 뒤로 부여한다.
+  - (d) 두 사용자/탭이 같은 컨테이너의 같은 항목들을 다른 순서로 동시 저장하면 ordering intent는 last-writer-wins이다 (item membership은 항상 보존되지만 순서 충돌은 거부하지 않는다).
+  - 일괄 적용은 트랜잭션 단위로 원자적이어야 한다.
+- R8. 관심지표 추가·해제는 편집 모드 활성화와 무관하게 *즉시* 서버에 반영된다 (기존 동작 유지). 편집 모드 안에서 발생한 추가/해제도 즉시 서버에 반영되며 취소 액션의 영향을 받지 않는다 — 취소는 드래그한 순서 변경만 되돌린다. 표시 모드 전환은 편집 모드 종료(취소와 동일) 시도를 트리거하되, **dirty 상태(드래그로 변경된 미저장 순서가 존재)일 경우 confirm 다이얼로그로 사용자 확인을 받는다**. 사용자가 확인하면 미저장분 폐기 + 모드 전환, 거부하면 편집 모드 유지(모드 전환 취소). 페이지 이탈/새로고침에도 동일 패턴이 적용되어야 한다(deferred 항목과 일관 처리).
+
+**그래프 모드 레이아웃**
+- R9. GRAPH 표시 모드의 관심지표는 화면 폭에 따라 한 행에 최대 4개 항목까지 배치되는 반응형 그리드를 사용한다. 본 규칙은 ECOS·글로벌 등 모든 `source_type`의 GRAPH 영역에 동일하게 적용된다. INDICATOR(카드) 모드의 기존 레이아웃은 본 작업으로 변경하지 않는다.
+- R10. 5번째 항목부터는 자동으로 다음 행으로 줄바꿈되어 다중 행 비교가 가능해야 한다 (행 수가 뷰포트를 넘는 경우 일반 페이지 스크롤 허용).
+
+## Success Criteria
+
+- 관심지표 목록의 표시 순서가 새로고침/재진입 후에도 사용자가 지정한 순서를 유지한다.
+- 사용자가 편집 모드에서 드래그로 순서를 변경하고 저장하면 다음 조회부터 변경된 순서로 표시된다.
+- 다른 탭에서 신규 관심지표가 추가된 상태로 일괄 저장이 발생해도, 신규 항목이 사라지지 않고 컨테이너의 맨 뒤에 보존된다.
+- 두 사용자/탭이 같은 컨테이너의 항목들을 다른 순서로 동시 저장한 경우, 마지막 저장의 순서가 서버 상태로 남는다 (의도적 last-writer-wins; 데이터 손실은 발생하지 않으나 ordering intent는 후입자 우선).
+- GRAPH 모드에서 관심지표가 5개 이상일 때 자동으로 다음 행으로 줄바꿈되어 다중 행 비교가 가능하다.
+- 화면 폭을 좁혔을 때 GRAPH 그리드가 4 → 3 → 2 → 1열로 자연스럽게 축소된다.
+
+## Scope Boundaries
+
+- 비목표: `source_type`을 가로지르는 전역 단일 정렬은 제공하지 않는다.
+- 비목표: priority 컬럼은 `(user_id, source_type)` 단위로 displayMode 간 *공유*되며, GET 응답은 displayMode와 무관하게 priority ASC로 단일 시퀀스를 반환한다 (클라이언트가 displayMode로 split). 비목표: 한 화면에서 displayMode가 다른 항목들을 가로질러 *직접* reorder하는 인터랙션은 지원하지 않는다 — 사용자는 각 컨테이너에 진입해 별도 편집 세션으로 정렬하며, 컨테이너 편집의 결과는 R7(b)의 슬롯 보존 알고리즘에 의해 다른 displayMode 항목들의 priority를 변경하지 않는 범위로 한정된다.
+- 비목표: 우선순위 자동 추천(예: 변동성 큰 순) 또는 Pin 방식 대체안은 본 작업에서 도입하지 않는다.
+- 비목표: 모바일 전용 별도 인터랙션 패턴은 본 작업 범위 밖이며, 기본 드래그 앤 드롭 라이브러리의 터치 지원 수준만 따른다.
+- 비목표: INDICATOR(카드) 모드의 가로 스크롤 레이아웃은 본 작업에서 변경하지 않는다 (현재 마크업이 `flex overflow-x-auto snap-x` 기반이며 본 작업은 GRAPH 모드의 그리드 도입에만 한정).
+
+## Key Decisions
+
+- 정렬 단위는 `source_type`별: 화면 영역이 이미 그룹별로 분리되어 있어 그룹 경계를 넘는 정렬이 의미가 없음.
+- 신규 항목 기본 위치는 그룹 맨 뒤(priority 큰 쪽): `created_at` 기반 backfill도 ASC 매핑으로 priority 작은 값 = 오래된 것, 큰 값 = 최신.
+- 일괄 저장 + 서버 결과 우선 동시성: 다중 탭에서 멤버십 데이터 손실은 절대 발생하지 않음. ordering intent는 last-writer-wins로 의도적으로 단순화 (G1) — ETag/version 거부보다 사용자 흐름이 부드럽고, ordering intent 충돌은 매우 드문 시나리오로 판단.
+- 컨테이너 단위 편집 (G3): R5 결정. 두 displayMode가 같은 priority 컬럼을 공유하지만 편집 UI는 컨테이너별로 진입하며, 일괄 저장은 보이는 항목들의 상대 순서만 갱신. 사용자가 한 번에 보이지 않는 항목과의 상대 위치를 의도적으로 조작하는 시나리오는 비목표.
+- 추가/해제는 편집 모드와 독립 (G2): 즉시 서버 반영. 취소는 드래그 순서만 되돌림. R8과 R7로 자연 수렴.
+- 출시 시점은 단일 — 머지 단위는 분리 가능: 사용자 시나리오상 우선순위와 그래프 다중 행 비교가 같은 화면에서 함께 체감되어야 하므로 사용자에게 노출되는 시점은 동기화한다 (예: feature flag 또는 동시 머지). 단 PR 단위는 GRAPH 그리드(R9~R10) PR과 priority(R1~R8) PR로 분리해도 무방 — 리뷰 부담을 줄이고 GRAPH 그리드 PR이 priority 컬럼 의존 없이 독립적으로 검증 가능하다는 이점이 있음.
+- DnD 방식 채택(Pin 대체안 거부): 이슈 #42 본문이 명시적으로 "우선순위를 지정하여 순서를 지정"하는 것을 요구하고, "관심지표 추가 순서가 의도와 다르다"는 점이 핵심 불편이므로 직접 정렬이 가장 직관적.
+- Entity 변경(priority 컬럼 추가)은 Approval Gate 대상 → planning 단계 시작 시 사용자에게 별도 승인 요청 필요. 잠정 타입: `INT NOT NULL DEFAULT 0` (단, 본 코드베이스 컨벤션상 default 부여 후 backfill은 nullable 단계 거쳐 NOT NULL 마이그레이션이 안전).
+
+## Dependencies / Assumptions
+
+- `user_favorite_indicator` 테이블에 우선순위 컬럼 추가가 필요하다는 가정 (실제 컬럼 명칭/타입은 planning에서 확정).
+- 본 repo의 schema 관리는 `spring.jpa.hibernate.ddl-auto=update` + `src/main/resources/db/migration/*.sql` 하이브리드 패턴이다 (Flyway/Liquibase 자동 실행기 없음 — 운영자가 수동으로 SQL 실행). 권장 흐름: (1) 우선순위 컬럼을 nullable 또는 default 0 으로 Entity에 추가 → ddl-auto가 컬럼 생성, (2) 운영자가 `db/migration/`의 backfill SQL을 실행해 `created_at` 기준 우선순위 부여, (3) 필요 시 NOT NULL 제약 추가. backfill 전 짧은 시간 동안 기존 행이 priority 동률 상태가 되며 이때 R3 정렬은 tiebreaker(예: id ASC)로 결정된다.
+- 기존 `displayMode` 컬럼과는 독립적으로 동작.
+- 프론트엔드는 Alpine.js + CDN 스크립트 로드 방식이므로 (npm 빌드 파이프라인 없음), DnD 라이브러리 선택 시 UMD/CDN 배포 가능 여부와 Alpine 반응성과의 공존(예: SortableJS onEnd → underlying array splice)을 충족해야 함.
+- 가설 ("5+ 보유 사용자가 의미 있는 비율로 존재") 검증은 dev DB 표본 부족(2026-05-07: user 1·favorites 3)으로 본 brainstorm 단계에서 수행하지 못함. 가설은 수용하되 R9~R10이 출시된 후 prod DB 또는 사용자 행동 로그로 검증할 것 (후행 조치 — 본 작업 범위 밖). 검증 결과가 가설을 지지하지 않을 경우 R9~R10의 4열 상한 재산정 또는 단순화를 별도 이슈로 다룸.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- (없음 — 보유 분포 spike는 dev DB에 표본이 없어(2026-05-07 시점 user 1명·favorites 3건) 통계적 검증 불가. 사용자 결정으로 가설을 수용하고 진행. 후행 조치는 Dependencies/Assumptions 참조.)
+
+### Deferred to Planning
+- [Affects R1, R6, R7][Technical] 우선순위 컬럼 타입은 정수 인덱스(`priority INT`, `(user_id, source_type, priority)` 단위로 0..N-1)로 잠정 채택. planning 첫 단계에서 Entity Approval Gate 진입 시 최종 확정. 동률 발생 시 tiebreaker는 `id ASC`.
+- [Affects R2, R7][Technical] 신규 항목 추가(`POST /api/favorites`)의 priority 부여 동시성: `INSERT ... SELECT COALESCE(MAX(priority),-1)+1 ... WHERE user_id=? AND source_type=?`를 단일 statement로 실행 + Postgres `UNIQUE(user_id, source_type, priority) DEFERRABLE INITIALLY DEFERRED` 제약 + 23505 충돌 시 1회 재시도 패턴으로 잠정. R7 일괄 저장의 swap-update에서도 동일 제약이 DEFERRABLE이어야 mid-transaction 위반이 허용됨. 최종 형태는 planning에서 확정.
+- [Affects R7][Technical] R7 일괄 저장 페이로드의 엣지 케이스: 빈 페이로드(no-op vs 400), 중복 ID(첫 항목 채택 vs 400), 다른 source_type ID 혼입, 인증 사용자와 ID 소유자 불일치 — 각각의 거부/수용 정책 명시 필요.
+- [Affects R3][Technical] `created_at` ASC 기준 backfill SQL 작성 (`db/migration/`).
+- [Affects R5][Needs research] Alpine.js + CDN 환경에서 동작하는 DnD 라이브러리 선정 (SortableJS UMD 잠정). **Planning 진입 전 30분 spike 권장**: 현 `favorite.js`에 SortableJS를 1개 그룹에 붙여 reactive splice가 깜박임 없이 동작하는지 검증 (Alpine x-for + SortableJS DOM mutation 충돌은 알려진 함정).
+- [Affects R7][Technical] 일괄 저장 엔드포인트 설계: `PUT /api/favorites/order` 신규 vs 기존 컬렉션 PUT. 페이로드 형태(전체 목록 vs 변경분).
+- [Affects R6, R7][UX] 일괄 저장 실패 시 회복 흐름: 편집 모드 유지 + 재시도 vs 폐기 후 종료. 토스트 메시지 문구.
+- [Affects R8][UX] 편집 중 페이지 이탈/새로고침 시 미저장 변경분 처리: R8 dirty-state confirm과 동일 패턴(beforeunload 경고) 적용. 다이얼로그 문구 확정만 planning에서.
+- [Affects R5][UX] 드래그 핸들 위치(카드 전체 vs 전용 핸들). 카드 전체일 경우 기존 클릭 액션과의 충돌 해소 방안.
+- [Affects R5][UX] 모바일/터치에서 일반 스크롤과 드래그 시작 구분(long-press, 전용 핸들 등).
+- [Affects R5, R6][Needs research, a11y] 키보드 접근성: 드래그 진행/완료/실패의 aria-live announce, 편집 모드 진입 시 포커스 이동 정책. DnD 라이브러리 기본 지원 수준에 따라 본 작업 범위 vs 별도 이슈 분리 결정.
+- [Affects R5][UX] 그룹 항목이 0~1개일 때 편집 모드 진입 가능 여부 (1개일 땐 진입 가능하지만 드래그 불가, 0개는 진입 불가가 자연스러움).
+- [Affects R9][Technical] CSS 그리드 vs Flexbox 접근. 현재 GRAPH 모드 마크업은 별도 CSS 파일이 아니라 `static/partials/home.html`과 `static/js/components/favorite.js` 인라인 스타일에 분포함이 확인됨 (`flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory` 패턴). 그리드 적용 시 기존 클래스 교체 필요.
+- [Affects R9, R10][Technical] GRAPH 그리드 도입 시 기존 `snap-x snap-mandatory` / `overflow-x-auto` 클래스 처리: 그리드는 가로 오버플로가 없으므로 snap이 무의미 — 제거가 자연스러움. 단, 카드 내부에 가로 시계열 등이 있다면 셀 내부 snap은 별도 결정.
+- [Affects R5][UX] 글로벌 영역에서 `failed=true` 상태의 GRAPH displayMode 항목이 INDICATOR 컨테이너에 fallback 렌더링되는 기존 동작(`home.html` 확인)과 컨테이너 단위 편집 정의 충돌: 해당 항목이 INDICATOR 편집 페이로드에 포함될지 제외될지 명시 필요. 잠정 권장: 편집 페이로드에서 제외(R7(a) "서버에서 다른 컨테이너에 속함"으로 무시 처리).
+- [Affects R5, R7][UX] 컨테이너 편집이 다른 displayMode 표시 순서에 미치는 결과를 사용자에게 surfacing할지 여부: 편집 진입 시 헤더 힌트 vs 저장 후 토스트 vs 표시 안 함 — R7(b) 슬롯 보존으로 영향이 minimal하나 0은 아님.
+- [Affects R9][Technical] 구체 브레이크포인트(예: <640px 1열, <960px 2열, <1280px 3열, ≥1280px 4열) 확정.
+- [Affects R4~R8][UX] 편집 모드 UI 트리거 위치(컨테이너별 헤더 옆 버튼), 저장/취소 버튼 배치(sticky 푸터 vs 인라인), 드래그 중 placeholder, 저장 진행/실패 시 시각 피드백.
+
+## Next Steps
+→ `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md
+++ b/docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md
@@ -1,0 +1,666 @@
+---
+title: "feat: 관심지표 우선순위 및 GRAPH 그리드 레이아웃"
+type: feat
+status: active
+date: 2026-05-07
+deepened: 2026-05-07
+issue: 42
+branch: feat/issue-42-watchlist-priority-and-layout
+origin: docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md
+---
+
+# feat: 관심지표 우선순위 및 GRAPH 그리드 레이아웃
+
+## Overview
+
+관심지표(`user_favorite_indicator`)에 사용자 지정 우선순위를 도입하고, GRAPH 표시 모드 컨테이너의 가로 스크롤 레이아웃을 1~4열 반응형 그리드로 전환한다. 우선순위 편집은 SortableJS UMD 기반 드래그 앤 드롭으로 컨테이너 단위로 진입하며, 일괄 저장 시점에 서버가 슬롯 보존 알고리즘으로 일관성을 보장한다.
+
+본 plan은 origin 요구사항 문서의 R1~R10을 그대로 수용하며 plan은 `HOW`만 다룬다.
+
+## Problem Frame
+
+현재 관심지표는 정렬 컬럼이 없어 화면 표시 순서가 일관되지 않고, GRAPH 모드는 가로 스크롤+snap 구조라 5개 이상 항목을 한눈에 비교하기 어렵다. (origin: Problem Frame 참조)
+
+## Requirements Trace
+
+origin의 R1~R10을 본 plan이 충족한다.
+- R1~R3: 우선순위 모델 — Unit 1, Unit 1.5, Unit 3
+- R2 (신규 추가는 그룹 맨 뒤): 신규 추가 시 priority 부여 — Unit 1.5
+- R4: 편집 모드 진입/종료 UI — Unit 5
+- R5: 컨테이너 단위 DnD — Unit 5
+- R6: 저장/취소 의미 — Unit 4 (서버), Unit 5 (클라이언트)
+- R7(a)~(d): 슬롯 보존 동시성 알고리즘 — Unit 4
+- R8: 추가/해제 즉시 반영 + 표시 모드 전환 시 dirty confirm — Unit 5
+- R9~R10: GRAPH 그리드 + 줄바꿈 + 스크롤 — Unit 6
+
+## Scope Boundaries
+
+origin의 비목표를 그대로 계승. 추가로 본 plan에서 명시:
+- 비목표: 키보드 접근성(↑/↓ 키 이동, aria-live announce)은 별도 이슈로 분리. 본 plan은 SortableJS의 마우스/터치 동작만 제공.
+- 비목표: 토스트/다이얼로그 라이브러리 도입 — 기존 `alert()`/`confirm()` 패턴(`favorite.js`, `portfolio.js` 사례)을 그대로 사용.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Backend hexagonal 패턴**: `favorite/{presentation,application,domain.{model,repository},infrastructure.{persistence,mapper}}` 구조 그대로 따름.
+- **컨트롤러**: `favorite/presentation/FavoriteIndicatorController.java` — `@RestController @RequestMapping("/api/favorites")`, `getCurrentUserId()` private helper, `ResponseEntity<...>` 반환. 기존 `PUT /api/favorites/display-mode`가 batch가 아닌 single-item PUT의 선례.
+- **DTO**: `favorite/presentation/dto/FavoriteDisplayModeRequest.java` — Java `record` + `jakarta.validation.constraints` (`@NotNull`).
+- **서비스**: `favorite/application/FavoriteIndicatorService.java` — `@Transactional` write / `@Transactional(readOnly=true)` read 분리. `DataIntegrityViolationException` 캐치 패턴.
+- **JPA 리포지토리**: `UserFavoriteIndicatorJpaRepository.java` — derived query + `@Modifying @Query` JPQL. 현재 `findByUserId`는 정렬 없음 → `OrderBy` 추가 필요.
+- **3-phase 마이그레이션 패턴**: `db/migration/news_event_impact_rename.sql`, `news_event_category_not_null.sql`이 기준. (1) Java entity가 nullable 컬럼 추가 + bootstrap backfill, (2) NULL=0 검증, (3) SQL ALTER NOT NULL, (4) Java entity nullable=false 격상. Flyway/Liquibase 자동 실행기 없음 — 운영자가 `psql`로 수동 적용.
+- **프론트 컴포넌트**: `static/js/components/favorite.js` — Alpine `x-data` 컴포넌트. 옵티미스틱 업데이트 + 실패 시 rollback + `alert()` 패턴이 라인 50–77, 131, 174에 있음 → 그대로 미러링.
+- **Alpine x-for 키**: `static/partials/home.html`의 `<template x-for="card in ..." :key="card.indicatorCode">` — 본 plan에서 그대로 유지(Sortable 호환에 필수).
+- **Tailwind 그리드 패턴**: `home.html:8`, `home.html:160` — `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4`. Tailwind 유틸리티 전용, custom.css 혼용 금지(see learnings).
+- **API 헬퍼**: `static/js/api.js`에 `reorderFavorites(...)` 추가. 기존 `displayMode` 변경 헬퍼(라인 153–173)가 미러 대상.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md` — NOT NULL 컬럼 추가 시 ddl-auto silent skip 함정. `columnDefinition`으로 default 강제. 본 plan의 3-phase 마이그레이션 적용으로 회피.
+- `docs/solutions/ui-bugs/responsive-design-tailwind-alpine.md` — Tailwind 유틸리티 전용, `x-show + x-transition`(x-if 회피). 본 plan은 Tailwind grid utility로 진행.
+- `docs/solutions/architecture-patterns/global-indicator-history-mirroring.md` — `@Transactional` self-invocation 미적용 함정. 본 plan은 동일 클래스 내 호출이 없어 영향 없음.
+- `docs/solutions/architecture-patterns/deposit-history-n-plus-one-batch-pattern.md` — bulk save: `WHERE IN (...)` + `groupingBy`. Request DTO Bean Validation. 본 plan의 `FavoriteOrderRequest`에 적용.
+
+### External References
+
+- Postgres `DEFERRABLE INITIALLY DEFERRED` 동작: `SET CONSTRAINTS` 문서, Christian Emmer "Deferrable Constraints in PostgreSQL". 핵심: Hibernate `@UniqueConstraint`는 DEFERRABLE 생성 불가 → SQL로만 관리, Entity에 `unique=true` 절대 두지 말 것.
+- Alpine 3 + SortableJS UMD 통합: `:key`는 stable string(`indicatorCode`)이어야 reconciliation 충돌 없음. `onEnd`에서 `e.item.remove()` 후 `arr.splice(...)` 패턴(revert-then-splice)이 깜박임 회피의 canonical pattern.
+- 모바일 터치: `delay: 200, delayOnTouchOnly: true, touchStartThreshold: 5` 설정으로 일반 스크롤과 드래그 시작 분리.
+
+## Key Technical Decisions
+
+- **컬럼 타입**: `priority INT` — `(user_id, source_type)` 단위 dense 0..N-1 시퀀스. 잠정 채택을 확정. (origin Key Decisions, see origin: docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md)
+- **UNIQUE 제약**: `UNIQUE(user_id, source_type, priority) DEFERRABLE INITIALLY DEFERRED` — 운영자 수동 SQL로 추가. Entity에 `@UniqueConstraint`/`unique=true` 일체 두지 않음 (Hibernate가 NOT DEFERRABLE 중복 생성 함정 회피).
+- **3-phase 마이그레이션**: 본 repo의 기존 패턴 그대로. 마이그레이션 SQL 파일명을 통일한다 — 단일 파일 `db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql`(NOT NULL + UNIQUE DEFERRABLE INITIALLY DEFERRED 통합). 단계: (1) Entity가 `priority INT NULL` + bootstrap backfill 호출, (2) 배포 후 backfill runner가 NULL 행을 dense 0..N-1로 채움(Unit 1), (3) 운영자가 위 단일 SQL 적용, (4) 다음 배포에서 Entity의 priority를 nullable=false로 격상.
+- **일괄 저장 엔드포인트**: 신규 `PUT /api/favorites/order`. 페이로드: `record FavoriteOrderRequest(@NotNull FavoriteIndicatorSourceType sourceType, @NotNull FavoriteDisplayMode displayMode, @NotEmpty List<@NotBlank String> indicatorCodes)`. 기존 컬렉션 PUT 확장이 아닌 신규 endpoint이며 컨테이너 스코프(`sourceType` × `displayMode`)를 페이로드에 명시.
+- **R7(b) 해석 — 그룹 전체 dense 재할당 (Option B)**: deepening 결과 채택. R7(b) "본 호출로 변경하지 않는다"는 *상대 순서* 보존으로 해석하며 priority *정수* 자체는 그룹 전체를 0..N-1로 재할당하는 단순 안전 변형을 사용한다. 사유: ① group-wide dense 0..N-1 invariant는 그룹 단위 속성이며 sub-slice 보존은 normalize 단계 추가로 결국 동일 형태로 수렴, ② 엣지 케이스(R7(c) 슬롯 부족, NULL priority 잔존, 페이로드 cross-displayMode 항목)가 단일 파이프라인으로 처리됨, ③ 사용자 가시 동작은 *상대 순서* 보존만 보장하면 R7(b) 의도 충족. 코드 주석에 본 결정 근거를 한국어로 명시.
+- **알고리즘 위치**: `FavoriteIndicatorService.reorder(...)` 내부. 트랜잭션 안에서 `repository.findForReorderUpdate(...)`(`PESSIMISTIC_WRITE`)로 그룹 전체 잠금 → 순수 함수 `computeNewOrder(rows, mode, codes)` → `denseAssign(0..N-1)` → `applyIfChanged`로 변경된 행만 bulk update. CASE WHEN chunking은 repository 계층 책임(서비스는 알고리즘 순수성 유지). `@Modifying(clearAutomatically=true, flushAutomatically=true)` 필수.
+- **Post-write invariant assertion (load-bearing 검증)**: `reorder` 트랜잭션 commit 직전, 같은 그룹을 재조회해 `priorities == 0..N-1 contiguous` 및 `|priorities| == |rows|`를 검증. 위반 시 `IllegalStateException` 던져 트랜잭션 롤백. 테스트가 없는 이번 배포에서 알고리즘 정확성을 보장하는 핵심 안전망. 비용은 `SELECT` 1회.
+- **NULL priority tie-break**: R3 정렬은 `priority ASC NULLS LAST, id ASC`. NOT NULL 격상(3-phase 완료) 전 backfill 실패 행이 남으면 ASC 끝에 위치. Unit 2의 repository 쿼리에 명시.
+- **중복 코드 dedup 정책**: `FavoriteOrderRequest.indicatorCodes`에 같은 코드가 두 번 이상 들어오면 첫 occurrence 채택, 이후는 silent skip. 400 거부 대신 last-writer-wins 정책과 일관된 방어적 수용. `FavoriteOrderRequest` Javadoc에 명시.
+- **DnD 라이브러리**: SortableJS 1.15.x UMD via CDN. Alpine `@alpinejs/sort` 플러그인은 추상화로 인해 revert-then-splice 제어가 어려워 미채택. 별도 의존성 추가는 `index.html` script 한 줄.
+- **그리드 클래스**: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4`. 기존 `flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory` 클래스 4곳(ECOS GRAPH, ECOS INDICATOR, GLOBAL GRAPH, GLOBAL INDICATOR) 중 GRAPH 컨테이너 2곳만 교체. INDICATOR는 origin 비목표로 변경 없음.
+- **고정 폭 카드 처리**: 그리드 도입에 따라 GRAPH 카드의 `w-[400px] sm:w-[440px]` 고정 폭은 제거 — 그리드 셀이 폭을 결정. 카드 높이는 기존 유지.
+- **Approval Gate 인지**: Entity 추가 + 신규 API + 비즈니스 로직 변경(GET 응답 정렬) 3건 모두 트리거 — 본 plan을 사용자에게 명시적으로 승인받은 뒤 Unit 1부터 시작.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: dense 0..N-1 invariant와 R7(b) gap 보존이 양립 가능한가?** A: 양립한다. invariant는 `(user_id, source_type)` 그룹 *전체* 집합 단위이며 displayMode별 contiguity는 비요구. 슬롯 재할당 알고리즘으로 자연 충족.
+- **Q: `@UniqueConstraint`로 DEFERRABLE 가능?** A: 불가능. SQL로만 관리.
+- **Q: ddl-auto가 SQL 마이그레이션 자동 실행?** A: 안 함(Flyway/Liquibase 없음). 운영자 수동 적용.
+- **Q: Tailwind 브레이크포인트?** A: 기본 사용 — `sm:640`, `lg:1024`, `xl:1280`. 별도 커스텀 없음.
+- **Q: snap-x 처리?** A: GRAPH 컨테이너에서는 그리드 도입과 함께 제거. INDICATOR는 그대로.
+- **Q: 일괄 저장 페이로드 형태?** A: `(sourceType, displayMode, indicatorCodes[])` — 컨테이너 스코프 명시 + 정렬된 코드 목록.
+- **Q: bulk update vs 개별 update?** A: `@Modifying @Query` JPQL `UPDATE ... CASE id WHEN ... END WHERE id IN (...)` 단일 statement 우선, fallback으로 개별 update. DEFERRABLE 제약 덕에 swap-update 안전.
+
+### Deferred to Implementation
+
+- 편집 모드 트리거 버튼의 정확한 위치/아이콘/문구, 드래그 핸들 표시 방식(카드 전체 vs 전용 핸들), 저장/취소 버튼 배치(sticky vs inline) — 디자인 반복으로 결정.
+- `confirm()` 다이얼로그 문구 — 구현 시 한국어 어조 결정.
+- failed 상태의 GLOBAL GRAPH 항목이 INDICATOR 컨테이너에 fallback 렌더링되는 기존 동작과 편집 페이로드 처리 — Unit 4의 R7(a) "서버에서 다른 컨테이너에 속함" 케이스로 무시 처리(implementation 시 동작 확인).
+- 컨테이너 그룹 항목 0~1개일 때 편집 모드 진입 가능 여부 — Unit 5에서 트리거 버튼 disabled 조건으로 처리.
+- bulk update JPQL에서 CASE 식이 길어질 때(예: 항목 100+) 가독성/성능 검토 — 현실적으로 한 사용자가 동일 source_type에 30+ 관심지표 가질 가능성 낮으므로 실측 후 결정.
+
+## High-Level Technical Design
+
+> *이 단면은 의도된 접근의 형태를 보여주기 위한 directional 가이드이며 구현 사양은 아니다. 구현자는 각 Unit의 Files/Approach를 기준으로 작성한다.*
+
+데이터 모델·API·UX 흐름의 관계:
+
+```mermaid
+flowchart TB
+    subgraph DB[user_favorite_indicator]
+      C1["+ priority INT (NOT NULL DEFAULT 0)"]
+      C2["UNIQUE user_id source_type priority<br/>DEFERRABLE INITIALLY DEFERRED"]
+    end
+
+    subgraph BE[Backend]
+      EN[UserFavoriteIndicatorEntity<br/>priority 추가, NOT unique]
+      DM[FavoriteIndicator<br/>priority 필드 + withPriority]
+      SVC[FavoriteIndicatorService.reorder<br/>SELECT FOR UPDATE → 슬롯 재할당]
+      CTRL[POST/GET 기존 + PUT /api/favorites/order]
+      JPA[Repository<br/>OrderByPriorityAscIdAsc]
+      MIG[db/migration/<br/>3-phase SQL]
+    end
+
+    subgraph FE[Frontend]
+      JS[favorite.js<br/>editMode 상태기계]
+      SORT[SortableJS UMD CDN]
+      GRID[home.html<br/>GRAPH grid grid-cols-1..4]
+      API[api.js<br/>reorderFavorites]
+    end
+
+    DB --> EN
+    EN --> DM
+    DM --> SVC
+    JPA --> SVC
+    SVC --> CTRL
+    MIG -. 운영자 수동 적용 .- DB
+    JS --> SORT
+    JS --> GRID
+    JS --> API
+    API --> CTRL
+```
+
+저장 흐름 (R7 슬롯 보존):
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as favorite.js
+    participant API as PUT /order
+    participant SVC as Service.reorder
+    participant DB as Postgres
+
+    U->>FE: 편집 모드 진입 (sourceType, displayMode)
+    U->>FE: 카드 드래그 (SortableJS onEnd)
+    Note over FE: revert-then-splice<br/>로컬 배열 갱신
+    U->>FE: "저장" 클릭
+    FE->>API: PUT {sourceType, displayMode, indicatorCodes[]}
+    API->>SVC: reorder(userId, ...)
+    SVC->>DB: SELECT FOR UPDATE (user, source_type)
+    Note over SVC: computeNewOrder(rows, mode, codes)<br/>edited는 페이로드 순서, others는 기존 상대 순서 유지<br/>group dense 0..N-1로 재할당 (Option B)
+    SVC->>DB: bulk UPDATE (변경된 행만, chunk 분할)
+    SVC->>DB: SELECT priorities — invariant 검증
+    DB-->>SVC: COMMIT (DEFERRABLE 검증)
+    SVC-->>API: void
+    API-->>FE: 204
+    FE->>U: 편집 모드 종료
+```
+
+## Implementation Units
+
+본 plan은 8개 unit으로 구성. Unit 0는 Approval Gate 체크포인트, Unit 1·1.5·2·3·4는 백엔드, Unit 5·6은 프론트엔드. Unit 1이 모든 후속 코드 작업의 선행 조건이며 Unit 6은 Unit 5와 독립적으로 진행 가능.
+
+```mermaid
+flowchart TB
+  U0["Unit 0<br/>Approval Gate 체크포인트<br/>(이슈/PR 코멘트 승인)"]
+  U1["Unit 1<br/>Entity priority 컬럼 + bootstrap backfill"]
+  U15["Unit 1.5<br/>신규 추가 시 priority 부여<br/>(toggle insert path)"]
+  U2["Unit 2<br/>Repository 정렬 + bulk reorder query"]
+  U3["Unit 3<br/>도메인 모델 + Mapper priority 전파"]
+  U4["Unit 4<br/>Service.reorder + Controller PUT /order"]
+  U5["Unit 5<br/>Frontend 편집 모드 + SortableJS"]
+  U6["Unit 6<br/>GRAPH 그리드 레이아웃"]
+  M["Migration SQL<br/>NOT NULL + UNIQUE DEFERRABLE"]
+
+  U0 --> U1
+  U1 --> U15
+  U1 --> U2
+  U1 --> U3
+  U15 --> U4
+  U2 --> U4
+  U3 --> U4
+  U4 --> U5
+  U1 -. 후행 적용 .- M
+  U6 -. 독립 .- U5
+```
+
+---
+
+- [x] **Unit 0: Approval Gate 체크포인트**
+
+**Goal:** 코드 작업 시작 전, Entity 추가 + 신규 API + 비즈니스 로직 변경(GET 정렬) 3건의 Approval Gate를 명시적으로 통과한다.
+
+**Requirements:** 모든 R (작업 시작 전 게이트)
+
+**Dependencies:** plan 작성 완료
+
+**Files:** (코드 변경 없음)
+
+**Approach:**
+- 본 plan 파일과 origin requirements 문서 링크를 이슈 #42 또는 새 PR description에 게재한다.
+- 사용자(@TaeHyung 또는 위임자)가 다음 3건을 명시적으로 승인:
+  1. `user_favorite_indicator`에 `priority INT` 컬럼 추가 (Entity 변경)
+  2. `PUT /api/favorites/order` 신규 엔드포인트 (public API 추가)
+  3. `GET /api/favorites`(+`/enriched`) 응답 정렬 기준이 priority ASC + id ASC로 변경 (비즈니스 로직 동작 변경)
+- 승인 받기 전 Unit 1 시작 금지. CLAUDE.md Approval Gates 섹션 준수.
+
+**Verification:**
+- 이슈 #42 또는 PR에 사용자 승인 코멘트 존재.
+- 본 unit 체크박스 완료 후 Unit 1 진입.
+
+---
+
+- [x] **Unit 1: Entity priority 컬럼 추가 + bootstrap backfill**
+
+**Goal:** `user_favorite_indicator`에 `priority` INT 컬럼을 nullable로 추가하고, 애플리케이션 부팅 시 NULL 값을 `created_at` ASC, `id` ASC 기준 dense 0..N-1로 채우는 bootstrap backfill을 한 번 실행한다.
+
+**Requirements:** R1, R3
+
+**Dependencies:** Unit 0
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java`
+- Create: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/config/FavoritePriorityBackfillRunner.java`
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java` (NULL 행 조회 쿼리)
+
+**Approach:**
+- Entity에 `@Column(name="priority", nullable=true) private Integer priority;` 추가. **`unique=true`/`@UniqueConstraint` 절대 두지 않음** (Hibernate가 NOT DEFERRABLE 중복 생성). `columnDefinition` 미지정 — backfill을 코드에서 명시적으로 수행.
+- `FavoritePriorityBackfillRunner`: `@Component @RequiredArgsConstructor implements ApplicationRunner` (`@PostConstruct` 사용 안 함 — 트랜잭션 인프라 준비 시점이 늦고 본 repo의 기존 `EcosIndicatorMetadataInitializer`/`GlobalIndicatorMetadataInitializer` 패턴이 ApplicationRunner임).
+  - `@Transactional`로 `(user_id, source_type)` 그룹별 NULL priority 행을 `created_at ASC, id ASC`로 조회 → 0부터 순번 부여 → bulk update.
+  - 모든 행이 NOT NULL이면 즉시 종료 (idempotent — 첫 부팅 후 후속 부팅에서 no-op).
+- 도메인 모델에는 아직 priority 노출 안 함 (Unit 3에서).
+
+**Patterns to follow:**
+- `UserFavoriteIndicatorEntity.java`의 기존 `displayMode` 패턴 (Lombok `@Getter`, 생성자, `@PrePersist`).
+- `economics/.../config/EcosIndicatorMetadataInitializer.java` 및 `GlobalIndicatorMetadataInitializer.java` (ApplicationRunner + idempotency 가드 패턴).
+- `docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md` 가이드.
+
+**Test scenarios:**
+- 테스트 작성 안 함 — CLAUDE.md "테스트는 명시적 요청 시에만 작성". 단 backfill runner는 NULL 행이 없을 때 no-op 동작을 코드로 보장.
+
+**Verification:**
+- 애플리케이션 부팅 후 `SELECT COUNT(*) FROM user_favorite_indicator WHERE priority IS NULL;` = 0.
+- `SELECT user_id, source_type, priority, created_at FROM user_favorite_indicator ORDER BY user_id, source_type, priority;`이 dense 0..N-1 시퀀스를 보임.
+- `GET /api/favorites` 응답이 변하지 않음(Unit 2 적용 전).
+
+---
+
+- [x] **Unit 1.5: 신규 추가 시 priority 부여 (toggle insert path)**
+
+**Goal:** `POST /api/favorites`(현 `toggle` 메서드의 INSERT 분기)에서 신규 행이 priority NULL로 저장되어 R3 정렬을 깨뜨리지 않도록, 동일 트랜잭션·단일 SQL로 `MAX(priority)+1`을 부여한다.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoriteIndicatorService.java` (toggle insert 분기)
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java` (`create(...)` 시그니처 확장)
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/repository/FavoriteIndicatorRepository.java` (port에 `insertWithNextPriority` 추가)
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java`
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java` (native `INSERT ... SELECT COALESCE(MAX(priority),-1)+1` 쿼리 추가)
+
+**Approach:**
+- 본 repo의 `READ_COMMITTED` 기본 isolation에서는 `SELECT MAX` 후 별도 INSERT가 race를 막지 못한다 → 단일 native SQL `INSERT ... SELECT COALESCE(MAX(priority),-1)+1 FROM user_favorite_indicator WHERE user_id=? AND source_type=?`로 atomicity 확보.
+- Native 쿼리 형태(re-SELECT 패턴 채택): `@Modifying @Query(value = "INSERT INTO user_favorite_indicator (user_id, source_type, indicator_code, display_mode, priority, created_at) SELECT :userId, :sourceType, :code, 'INDICATOR', COALESCE(MAX(priority),-1)+1, NOW() FROM user_favorite_indicator WHERE user_id = :userId AND source_type = :sourceType", nativeQuery = true)`. INSERT 후 별도 SELECT로 산출된 priority/id를 도메인에 매핑(Spring `@Modifying`는 row count만 반환하므로 RETURNING 절은 사용하지 않음). 본 repo `NewsJpaRepository.java:21-32`의 `nativeQuery=true` 패턴을 미러.
+- `FavoriteIndicator.create(userId, sourceType, indicatorCode)` 시그니처는 그대로 유지(도메인 순수성). priority는 SQL이 산출하므로 INSERT 후 후속 SELECT로 도메인에 반영.
+- 동시 두 트랜잭션이 같은 priority를 도출하면 DEFERRABLE UNIQUE가 commit 시 SQLSTATE `23505` (`unique_violation`)로 거부 → 기존 `DataIntegrityViolationException` catch(`FavoriteIndicatorService.toggle()` 내)를 확장. 단순 type 매칭 대신 root cause를 `PSQLException.getSQLState()`로 검사해 `23505`만 retry 대상으로 제한 (다른 무결성 위반은 즉시 500).
+- Retry 정책: 최대 3회, 짧은 randomized backoff(예: 50ms±25ms)로 thundering retry 회피. 초과 시 `log.error` + 500 응답.
+- Unit 4 reorder가 같은 (user_id, source_type) 그룹에 PESSIMISTIC_WRITE를 잡고 있으면 본 INSERT는 lock 대기 후 진행 — race window가 자연스럽게 줄어듬. 이 의존을 코드 주석으로 명시.
+
+**Patterns to follow:**
+- `NewsJpaRepository.java:21-32` (native INSERT, `@Modifying` + `nativeQuery=true`).
+- `EcosIndicatorJpaRepository.java:14-46` (native aggregate query 선례).
+- `FavoriteIndicatorService.toggle()` 라인 79~92의 기존 `@Transactional` + `DataIntegrityViolationException` catch.
+
+**Test scenarios:**
+- 테스트 작성 안 함 — CLAUDE.md 정책. retry 로직은 inline private helper로 분해해 향후 테스트 가능 구조 유지.
+
+**Verification:**
+- `POST /api/favorites`로 새 항목 추가 후 즉시 `SELECT priority FROM user_favorite_indicator WHERE user_id=? AND source_type=? ORDER BY id DESC LIMIT 1`이 그룹 내 최댓값과 일치.
+- 동시 추가 시 (dev에서 두 요청 동시 발사) 두 행 모두 성공 + 서로 다른 priority + retry 카운터 ≤ 1회.
+- 기존 toggle remove 동작은 변하지 않음.
+
+---
+
+- [x] **Unit 2: Repository 정렬 변경 + bulk reorder 쿼리 추가**
+
+**Goal:** 관심지표 조회 시 priority ASC + id ASC 정렬을 적용하고, `(user_id, source_type)` 컨테이너 단위 일괄 priority 갱신을 위한 bulk update 쿼리를 추가한다.
+
+**Requirements:** R3, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java`
+
+**Approach:**
+- 기존 `findByUserId`/`findByUserIdAndSourceType`를 새 메서드 `findByUserIdOrderByPriorityAscIdAsc` 등으로 교체(또는 신규 메서드 추가 + 호출처 점진 교체). 정렬은 `priority ASC NULLS LAST, id ASC`. 호출처(`FavoriteIndicatorService` 등)도 동시 수정.
+- 컨테이너 단위 priority 슬롯 lock과 invariant 검증용 projection을 위해 다음 메서드 추가:
+  - `List<UserFavoriteIndicatorEntity> findForReorderUpdate(Long userId, FavoriteIndicatorSourceType sourceType)` — `@Query("SELECT e FROM UserFavoriteIndicatorEntity e WHERE e.userId = :userId AND e.sourceType = :sourceType ORDER BY e.priority ASC NULLS LAST, e.id ASC")` + `@Lock(LockModeType.PESSIMISTIC_WRITE)`. 트랜잭션 내 `SELECT ... FOR UPDATE` 효과. 본 repo 첫 PESSIMISTIC_WRITE 사용처 — PR description에 명시.
+  - `List<Integer> findPrioritiesByUserIdAndSourceType(Long userId, FavoriteIndicatorSourceType sourceType)` — Unit 4 invariant assertion 전용 projection. `@Query("SELECT e.priority FROM UserFavoriteIndicatorEntity e WHERE e.userId = :userId AND e.sourceType = :sourceType ORDER BY e.priority ASC")`. lock 없이 read-only.
+- **Bulk update는 JPA `@Modifying @Query`로 직접 표현 불가**: `CASE id WHEN ... END`는 가변 항목 수에 따라 SQL 자체가 변하므로 static `@Query`로 못 적음. 대신 본 repo에 *최초로* custom-impl fragment 패턴을 도입한다:
+  - 인터페이스 `UserFavoriteIndicatorJpaRepositoryCustom` (`int bulkUpdatePriority(Map<Long,Integer> idToPriority)`) 추가.
+  - 구현체 `UserFavoriteIndicatorJpaRepositoryImpl` 에서 `EntityManager.createNativeQuery`로 `UPDATE user_favorite_indicator SET priority = CASE id WHEN ? THEN ? ... END WHERE id IN (...)` 동적 빌드. 50개 초과 시 chunk 분할(`setParameter` 인덱스 한계 회피). DEFERRABLE 제약 덕에 mid-tx 중복 priority 허용.
+  - 작은 그룹(≤5)은 개별 update fallback (단순성 우선).
+  - 호출 후 `entityManager.flush(); entityManager.clear();`로 L1 cache 동기화 → 후속 invariant 재조회가 stale 결과를 반환하지 않도록 보장.
+- 기존 JPQL 패턴은 본 repo 내 다수 존재하지만 custom-impl + EntityManager 패턴은 *최초* 도입 — 코드 리뷰 시 패턴 정착에 주의.
+
+**Patterns to follow:**
+- `UserFavoriteIndicatorJpaRepository.java`의 기존 `@Modifying @Query` 패턴.
+- `docs/solutions/architecture-patterns/deposit-history-n-plus-one-batch-pattern.md` (bulk save 패턴).
+
+**Test scenarios:**
+- 테스트 작성 안 함.
+
+**Verification:**
+- `GET /api/favorites` 응답 순서가 priority ASC + id ASC를 따름.
+- 단위 service 호출(Unit 4 완료 후)에서 동시성 race 없음을 dev 환경 수동 확인.
+
+---
+
+- [x] **Unit 3: 도메인 모델 + Mapper priority 전파**
+
+**Goal:** `FavoriteIndicator` 도메인 모델과 매퍼에 priority 필드를 추가하고 응답 DTO 파이프라인에 전파한다.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java`
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java`
+
+**Approach:**
+- `FavoriteIndicator`에 `private final Integer priority;` 추가. 생성자/factory `create(...)`는 priority `null`로 둠(Unit 1.5의 native INSERT가 SQL에서 산출). `withPriority(int)` 메서드 추가(immutable record-like 패턴 유지).
+- Mapper의 `toEntity`/`toDomain` 양방향에 priority 전달.
+- **응답 DTO에는 priority를 노출하지 않는다**: 클라이언트는 정렬된 결과만 사용하고 priority 정수 자체는 사용처가 없음 (`FavoriteOrderRequest` 페이로드도 `indicatorCodes`만 담음). public API surface는 최소 유지가 Approval Gate 정신과 부합.
+
+**Patterns to follow:**
+- `FavoriteIndicator.java`의 immutable + `withDisplayMode` 패턴.
+- `FavoriteIndicatorMapper.java` 기존 매핑 함수 형태.
+
+**Test scenarios:**
+- 테스트 작성 안 함.
+
+**Verification:**
+- 도메인 ↔ entity 매핑 시 priority 손실 없음 (코드 리뷰 + dev 환경 수동 확인).
+- `GET /api/favorites` 응답 contract는 변경 없음 (priority 비노출).
+
+---
+
+- [x] **Unit 4: Service.reorder + Controller PUT /api/favorites/order**
+
+**Goal:** R7(a)~(d) 슬롯 보존 알고리즘을 구현한 service 메서드와 신규 endpoint를 추가한다.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 2, Unit 3
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoriteIndicatorService.java`
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/FavoriteIndicatorController.java`
+- Create: `src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/FavoriteOrderRequest.java`
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/repository/FavoriteIndicatorRepository.java` (port에 `reorder`/`findForReorderUpdate` 노출)
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java`
+
+**Approach:**
+- `FavoriteOrderRequest` (Java record + Javadoc 명시):
+  - `@NotNull FavoriteIndicatorSourceType sourceType`
+  - `@NotNull FavoriteDisplayMode displayMode`
+  - `@NotEmpty List<@NotBlank String> indicatorCodes` — Javadoc: "중복된 코드는 첫 occurrence만 채택, 이후는 silent skip"
+- Controller `@PutMapping("/order")` → `service.reorder(userId, sourceType, displayMode, indicatorCodes)` → `ResponseEntity.noContent()`.
+- Service `@Transactional public void reorder(...)`는 짧은 orchestrator(≤5 lines): repo lock → 순수 함수로 새 순서 계산 → bulk update → invariant assertion.
+- **알고리즘 (Option B 확정 — group-wide dense reassignment)**:
+  1. `repository.findForReorderUpdate(userId, sourceType)` — `@Lock(PESSIMISTIC_WRITE)`로 그룹 전체 잠금. ORDER BY `priority ASC NULLS LAST, id ASC`.
+  2. 순수 함수 `computeNewOrder(rows, displayMode, codes)`:
+     - `edited = rows where r.displayMode == displayMode`
+     - `others = rows where r.displayMode != displayMode` (priority ASC 정렬 유지)
+     - `byCode = edited.indexBy(indicatorCode)` (중복은 putIfAbsent로 첫 occurrence만)
+     - `fromPayload = codes.distinct().map(byCode::get).filterNonNull()` — R7(a) cross-source/missing-id 자동 누락
+     - `appended = edited - fromPayload` (기존 priority ASC 안정 정렬) — R7(c) 다른 탭 신규
+     - `orderedEdited = fromPayload ++ appended`
+     - `combined = interleave(others, orderedEdited)` — others의 *상대 순서* 보존하며 dense 0..N-1로 위치 부여 (others의 기존 priority index가 새 인덱스 결정)
+     - return `combined` (List<UserFavoriteIndicatorEntity>)
+  3. `denseAssign(combined)` → `Map<Long, Integer>` (id → 0..N-1).
+  4. `applyIfChanged(rows, assignments)`: priority가 *바뀐* 행만 추출(`rows.priority != assignments[id]`) → 비어있으면 즉시 return(no-op idempotent re-save), 아니면 `repository.bulkUpdatePriority(diff)`.
+  5. **Post-write invariant assertion** (commit 직전): 같은 그룹 재조회 → `priorities == 0..N-1 contiguous` + `|priorities| == |rows|` 검증. 위반 시 `IllegalStateException` → 트랜잭션 롤백.
+  6. `@Transactional` commit 시 DEFERRABLE UNIQUE 자동 검증.
+- 모든 helper(`filterByMode`, `indexByCode`, `orderEdited`, `interleave`, `denseAssign`, `applyIfChanged`)는 `private static` 순수 함수로 분해. code-convention.md ≤5-line rule 준수.
+- 에러 매핑(원인별 분리 — 사용자 retry로 해소될 수 있는 transient race vs 코드 버그):
+  - Bean Validation 실패 → 400.
+  - 인증 실패 → 401.
+  - `DataIntegrityViolationException`(SQLSTATE 23505, UNIQUE 위반) — *transient race* 신호로 가정하고 1회만 retry. 재발 시 `log.error("FAVORITE_REORDER_RACE_RETRY_EXHAUSTED")` + 409 응답("순서 저장 충돌, 다시 시도해주세요"). 클라이언트는 자동 재시도 가능.
+  - `IllegalStateException`(post-write invariant 위반 — 알고리즘 버그) — `log.error("FAVORITE_REORDER_INVARIANT_VIOLATION")` 구조화 로그 + 500 응답("내부 오류, 관리자에게 문의"). 사용자 retry는 동일 결과를 낳을 가능성이 높으므로 메시지를 분리.
+  - 그 외 예상 못한 예외 → `log.error` + 500. PR description에 운영 모니터링 권장 키워드 명시: 두 로그 키워드는 모니터링 대시보드의 escalation 트리거.
+- 페이로드 엣지 케이스:
+  - 빈 List → `@NotEmpty`로 400.
+  - 중복 코드 → 첫 occurrence만 채택, silent skip (Javadoc 명시).
+  - 다른 source_type 코드 혼입 → `findForReorderUpdate` lock 범위 밖이라 R7(a)로 자동 무시.
+  - 페이로드 ID 모두 누락 → `applyIfChanged`가 no-op으로 처리 후 204.
+  - 다른 탭에서 displayMode 토글로 같은 source_type 내 다른 컨테이너로 이동한 항목 → `edited` 집합에 포함 안 됨 → R7(a)로 누락 → 페이로드 결과에서 빠진 채 다른 컨테이너 priority 유지.
+- **Bulk update 청크 분할**은 repository 계층 책임. CASE WHEN이 50개 초과 시 chunk(예: 50개 단위)로 다중 statement 발행 — DEFERRABLE 덕에 mid-tx 중복 허용. 작은 그룹(≤5)은 개별 update fallback. 서비스는 일관된 `bulkUpdatePriority` 인터페이스로 호출.
+- **관측성**:
+  - `log.info` 구조화 1줄: `userId, sourceType, displayMode, payloadSize, rowsUpdated, priorityRangeBefore, priorityRangeAfter`.
+  - Micrometer 카운터 권장(별도 단위로 분리 가능): `favorite.reorder.success`, `favorite.reorder.constraint_violation`. 본 plan에서는 우선 구조화 로그까지만 의무.
+
+**Execution note:** 알고리즘은 helper로 분해된 순수 함수이므로 dev 환경 수동 시나리오 + post-write invariant assertion이 1차 검증선. SQL invariant 쿼리는 운영 runbook으로 문서화.
+
+**Technical design:** *(directional, Option B 확정)*
+
+```text
+reorder(userId, source, mode, codes):              # ≤5 lines, orchestrator
+  rows = repo.findForReorderUpdate(userId, source)   // PESSIMISTIC_WRITE
+  combined = computeNewOrder(rows, mode, codes)
+  diff = applyIfChanged(rows, denseAssign(combined))
+  assertGroupInvariant(repo, userId, source)         // post-write check
+
+computeNewOrder(rows, mode, codes):                # pure
+  edited  = filterByMode(rows, mode)
+  others  = filterOtherModes(rows, mode)
+  byCode  = indexByCode(edited)                    // putIfAbsent
+  fromPay = codes.distinct().mapNonNull(byCode::get)
+  append  = edited.minus(fromPay).sortedByPriority()  // R7(c)
+  ordered = fromPay ++ append
+  return interleave(others, ordered)               // others' relative order preserved, group dense 0..N-1
+
+assertGroupInvariant(repo, userId, source):
+  ps = repo.priorities(userId, source) sorted ASC
+  if ps != 0..ps.size-1: throw IllegalStateException
+```
+
+**Patterns to follow:**
+- 기존 `FavoriteIndicatorService.toggle()`의 `@Transactional` + `DataIntegrityViolationException` 패턴.
+- 기존 `FavoriteIndicatorController.changeDisplayMode()`의 controller 형태.
+- `FavoriteDisplayModeRequest.java` DTO record 형태.
+- code-convention.md 5-line rule: alg 단계를 private helper로 분해.
+
+**Test scenarios:**
+- 테스트 작성 안 함 (CLAUDE.md). 단 알고리즘은 small private helpers로 분해해 향후 테스트 가능 구조 유지.
+
+**Verification:**
+- `PUT /api/favorites/order` 200/204 응답.
+- 동일 컨테이너 항목들 reorder 후 `GET /api/favorites` 응답이 새 순서를 반영.
+- 다른 displayMode 항목의 *상대* 표시 순서가 그대로 유지된다 (Option B 슬롯 보존).
+- 다른 탭에서 추가된 신규 항목은 R7(c)에 따라 편집 컨테이너 맨 뒤로 부여된다.
+- 두 탭에서 같은 컨테이너 항목들을 다른 순서로 동시 저장 시 마지막 저장이 이김(SC R7(d)).
+
+---
+
+- [x] **Unit 5: 프론트 편집 모드 + SortableJS DnD**
+
+**Goal:** 각 (sourceType × displayMode) 컨테이너에 편집 모드 토글, 드래그 앤 드롭, 저장/취소 액션, dirty-state confirm UX를 추가한다.
+
+**Requirements:** R4, R5, R6, R8
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `src/main/resources/static/index.html` (SortableJS UMD `<script>` 추가, Chart.js 다음 / 컴포넌트 스크립트 이전)
+- Modify: `src/main/resources/static/partials/home.html` (각 컨테이너 헤더에 편집 토글, 컨테이너 wrapper에 편집 모드 시 저장/취소 버튼 표시)
+- Modify: `src/main/resources/static/js/components/favorite.js` (state machine + SortableJS lifecycle)
+- Modify: `src/main/resources/static/js/api.js` (`reorderFavorites` 헬퍼 추가)
+
+**Approach:**
+- `index.html`에 `<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>` 추가 (Chart.js 이후, `app.js`/컴포넌트 스크립트 이전).
+- `favorite.js` Alpine 컴포넌트에 상태 추가:
+  - `editingContainer: null | {sourceType, displayMode}` — 동시에 한 컨테이너만 편집.
+  - `editSnapshot: List<indicatorCode>` — 편집 진입 시 현재 순서 백업(취소 복원용).
+  - `dirty: bool` — 드래그 발생 시 true, 저장/취소 시 false.
+  - `sortableInstance: Sortable | null`.
+- 메서드:
+  - `enterEditMode(sourceType, displayMode)` — 다른 컨테이너 편집 중이면 dirty confirm 후 종료. 컨테이너 항목이 0~1개면 disabled (가드 클리어). SortableJS init: `delay: 200, delayOnTouchOnly: true, touchStartThreshold: 5, animation: 150, onEnd: handleSortEnd`.
+  - `handleSortEnd(evt)` — `oldIndex === newIndex` bail. **revert-then-splice 패턴**: `evt.item.remove()` → 로컬 array에서 splice → Alpine 재렌더 시 정확한 순서로 복원. `dirty = true`.
+  - `saveOrder()` — `api.reorderFavorites(...)` 호출 → 성공 시 `editingContainer = null` + Sortable destroy + `dirty = false`. 실패 시 `alert('순서 저장에 실패했습니다. 잠시 후 다시 시도해주세요.')` + 편집 모드 유지(deferred 항목 "저장 실패 회복"의 잠정 결정 — 편집 모드 유지 + 사용자 재시도).
+  - `cancelOrder()` — `editSnapshot`으로 로컬 array 복원(드래그 결과만 되돌림, 편집 중 추가/해제는 R8 즉시 반영이라 영향 없음) → Sortable destroy → `dirty = false`.
+  - `attemptModeSwitch(sourceType, newDisplayMode)` — R8: dirty이면 `confirm('저장하지 않은 순서 변경이 있습니다. 폐기하시겠습니까?')` → 확인 시 cancelOrder() 후 모드 전환, 거부 시 모드 전환 취소.
+  - `beforeunload` 리스너 — dirty이면 표준 브라우저 confirm 트리거.
+- `home.html` 수정:
+  - 각 (sourceType, displayMode) 컨테이너 헤더에 "순서 편집" 버튼 (편집 중이면 "저장"/"취소" 두 개로 교체).
+  - 컨테이너 항목 0~1개일 때 버튼 disabled(tooltip "항목이 2개 이상일 때 사용 가능").
+  - 표시 모드 토글 버튼은 `@click`이 직접 모드 변경하던 것을 `@click="attemptModeSwitch(...)"`로 변경.
+  - `:key="card.indicatorCode"` 유지 — Sortable 호환에 필수.
+- `api.js`에 `reorderFavorites(sourceType, displayMode, indicatorCodes)` — `PUT /api/favorites/order`.
+
+**Execution note:** SortableJS + Alpine 통합은 본 repo 전례 없음. Unit 5 시작 시 spike(예산 ~90분, 최대 2시간):
+- **Go 기준**: favorite.js 한 컨테이너(예: ECOS GRAPH)에 SortableJS init + revert-then-splice 패턴을 붙여 (a) 5개 카드를 드래그 재배치 시 깜박임 없음, (b) `:key="card.indicatorCode"` 보존, (c) Chrome + iOS Safari에서 long-press 후 정상 드래그 시작이 모두 충족.
+- **No-Go 시 Plan B (선택지, 사용자 합의 후 진행)**:
+  1. Alpine 공식 Sort 플러그인(`@alpinejs/sort`) 채택 — 추상화 비용 수용, 깜박임 가능성 낮음.
+  2. native HTML5 Drag and Drop API 직접 사용 — 더 많은 코드, IE/모바일 한계.
+  3. Unit 5의 DnD 부분만 후속 이슈로 분리 — 본 PR은 R1~R8 서버 측 + Unit 6 그리드만 머지하고 R4~R8 UI는 보류.
+
+**Technical design:** *(state machine — directional)*
+```text
+state: idle | editing(sourceType, displayMode, snapshot, dirty)
+
+transitions:
+  idle --enterEditMode--> editing
+  editing --drag(item)--> editing(dirty=true)
+  editing --saveOrder--> idle (api PUT, on success)
+  editing --cancelOrder--> idle (restore snapshot)
+  editing --attemptModeSwitch dirty=false--> idle (mode flip)
+  editing --attemptModeSwitch dirty=true + confirm--> idle (cancelOrder + mode flip)
+  editing --attemptModeSwitch dirty=true + reject--> editing (no flip)
+  editing --beforeunload dirty=true--> browser confirm
+```
+
+**Patterns to follow:**
+- `favorite.js` 라인 50–77, 131, 174의 옵티미스틱 업데이트 + `alert()` 패턴.
+- `home.html` 기존 `<template x-for>` 형태 + Tailwind 버튼 클래스.
+- Alpine `x-show + x-transition` (learnings 문서 권장 — `x-if` 회피).
+
+**Test scenarios:**
+- 테스트 작성 안 함.
+- dev 환경 수동 시나리오(implementation 시 직접 확인): (1) 편집 진입→드래그→저장→재진입 시 순서 유지, (2) 편집 진입→드래그→취소→원래 순서, (3) 편집 진입→드래그→다른 displayMode 토글 시 confirm, (4) 편집 진입→드래그→새로고침 시 brower beforeunload, (5) 0~1개 컨테이너 편집 버튼 disabled, (6) 모바일 사파리에서 long-press 후 드래그.
+
+**Verification:**
+- 모든 dev 시나리오 통과.
+- Chrome devtools 콘솔 에러 없음.
+- Alpine 재렌더 시 카드 위치 깜박임 없음.
+
+---
+
+- [x] **Unit 6: GRAPH 모드 1~4열 반응형 그리드**
+
+**Goal:** ECOS·글로벌 두 GRAPH 컨테이너의 가로 스크롤 + snap을 1~4열 반응형 그리드로 전환한다. INDICATOR 컨테이너는 변경하지 않음.
+
+**Requirements:** R9, R10
+
+**Dependencies:** 없음 (Unit 5와 독립적으로 진행 가능)
+
+**Files:**
+- Modify: `src/main/resources/static/partials/home.html`
+
+**Approach:**
+- ECOS GRAPH 컨테이너(home.html:220 부근) + GLOBAL GRAPH 컨테이너(home.html:351 이후) 두 곳:
+  - 클래스 변경: `flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory` → `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4`.
+  - `snap-x snap-mandatory`, `overflow-x-auto`는 그리드와 충돌하므로 제거. 셀 내부 별도 가로 스크롤 콘텐츠는 없음(Chart.js 캔버스는 셀 폭에 맞게 자동 리사이즈됨).
+- 카드 고정 폭 클래스 `w-[400px] sm:w-[440px]` 제거 — 그리드 셀이 폭을 결정.
+- INDICATOR 컨테이너(`displayMode === 'INDICATOR'` 분기)는 기존 `flex overflow-x-auto snap-x` 클래스 그대로 유지.
+- `home.html:8`, `home.html:160`에 이미 비슷한 그리드 패턴이 있어 시각 일관성 확보됨.
+
+**Patterns to follow:**
+- `home.html:8`, `home.html:160`의 기존 Tailwind 그리드 패턴.
+- learnings 문서 `responsive-design-tailwind-alpine.md` — Tailwind 유틸리티 전용, custom.css 혼용 금지.
+
+**Test scenarios:**
+- 테스트 작성 안 함.
+- dev 환경 수동: (1) 1280px 이상 4열, (2) 1024px대 3열, (3) 640px대 2열, (4) 모바일 1열, (5) 5개 이상 항목 시 다음 행 줄바꿈, (6) 차트 폭이 셀 폭에 맞게 리사이즈.
+
+**Verification:**
+- Chrome devtools responsive mode에서 4→3→2→1 자연 축소.
+- 7개 항목 GRAPH 컨테이너에서 4·4·... → 데스크톱에서 4-3 두 행, 모바일에서 7행.
+
+---
+
+## System-Wide Impact
+
+- **인터랙션 그래프**:
+  - GET `/api/favorites`, `/api/favorites/enriched` 응답 정렬 변경 — 기존 클라이언트(없음, 본 앱 한정)는 영향 없음.
+  - `displayMode` 변경 endpoint(`PUT /api/favorites/display-mode`)와 신규 `PUT /order`는 같은 컨테이너 정의를 공유 — Unit 5에서 두 액션이 편집 모드 상태와 어떻게 상호작용하는지 R8 정책 준수.
+- **에러 전파**:
+  - 서버: `DataIntegrityViolationException` (UNIQUE 위반) → service 내 catch 후 500/409 응답. 클라이언트는 `alert()` + 편집 모드 유지.
+  - 클라이언트: 네트워크 실패 → `alert()` + 편집 모드 유지 + dirty 상태 보존(사용자 재시도 가능).
+- **상태 lifecycle 리스크**:
+  - 부분 backfill 실패 시 NULL priority 행이 남아 R3 정렬에서 NULL이 ASC 끝 또는 시작에 위치(Postgres 기본). Unit 1의 backfill runner는 idempotent이므로 다음 부팅에서 자동 재시도. NOT NULL 격상(3-phase 완료) 전까지 정렬 안정성을 위해 GET 응답에 `ORDER BY priority ASC NULLS LAST, id ASC` 명시 검토.
+  - DEFERRABLE 제약이 commit 시점에서 위반 검출 → 트랜잭션 전체 롤백. 사용자에게는 `alert('순서 저장에 실패했습니다')`.
+- **API surface parity**: 본 PR이 변경하는 `/api/favorites` 응답 형태는 priority 필드 추가뿐 — 기존 필드 미삭제, 호환성 유지.
+- **Integration coverage**: 본 plan은 명시적 테스트 비작성. dev 환경 수동 시나리오로 검증.
+- **Unchanged invariants**:
+  - 관심지표 해제 endpoint(`DELETE /api/favorites`) 동작은 변경 없음. 추가 endpoint(`POST /api/favorites`)는 Unit 1.5에서 priority 자동 부여 로직이 추가되지만 기존 응답 contract는 동일.
+  - INDICATOR 컨테이너 가로 스크롤 레이아웃 — 변경 없음.
+  - displayMode toggle endpoint(`PUT /api/favorites/display-mode`) 동작은 변경 없음.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Hibernate가 ddl-auto=update에서 NOT DEFERRABLE UNIQUE를 자동 추가할 위험 | Entity에 `@UniqueConstraint`/`unique=true` 절대 두지 않음. 코드 리뷰에서 확인. 마이그레이션 SQL에서 `DROP CONSTRAINT IF EXISTS ... ADD CONSTRAINT ... DEFERRABLE INITIALLY DEFERRED` 패턴 사용 |
+| SortableJS + Alpine 깜박임 | Unit 5 시작 시 30분 spike. revert-then-splice 패턴 + `:key=indicatorCode`(stable) 유지. fallback: Alpine `@alpinejs/sort` 플러그인 |
+| Unit 4 알고리즘 버그가 dense 0..N-1 invariant를 깨뜨릴 가능성 | Post-write invariant assertion이 commit 직전 검증해 트랜잭션 롤백. DB invariant 쿼리(`HAVING MAX(priority) <> COUNT(*) - 1 OR MIN(priority) <> 0`)를 운영 runbook에 등록 |
+| `bulk update CASE WHEN` JPQL이 항목 수 가변에 대응 어려움 | Repository 계층에서 chunk(50개 단위) 분할. DEFERRABLE 제약 덕에 mid-tx 중복 허용. 항목 ≤5는 개별 update fallback |
+| 운영 마이그레이션 절차 누락 — 운영자가 SQL을 까먹고 적용 안 하면 NOT NULL 격상 단계에서 부팅 실패 | 마이그레이션 SQL 헤더에 적용 순서 주석 + Unit 1 PR description에 절차 명시. 다음 배포 PR(NOT NULL 격상)은 별도 PR로 분리 가능 |
+| 편집 중 다른 탭에서 같은 항목 displayMode 토글 → 페이로드 ID가 다른 컨테이너로 이동 | R7(a) "서버에 없음" 케이스로 자연 흡수(편집 컨테이너 기준으로는 사라진 항목). 사용자에게는 이 케이스에서 해당 카드가 저장 후 결과에서 빠져있을 수 있음. dev 시나리오로 확인 |
+| 모바일 long-press 200ms 동안 일반 스크롤이 막히는 듯한 UX | `delayOnTouchOnly: true, touchStartThreshold: 5`로 시작 threshold 분리. dev 시나리오 6번에서 검증 |
+| Unit 1.5 신규 추가 priority 부여 race가 23505 retry를 초과해 사용자에게 500 노출 | retry 상한(예: 3회) + 구조화 로그. 동일 사용자가 동시에 동일 source_type에 추가하는 경우는 매우 드묾(브라우저 한 탭에서 단일 클릭) — retry 1회로 충분 |
+
+## Documentation / Operational Notes
+
+- 운영 배포 절차:
+  1. Unit 0 사용자 승인 → Unit 1~Unit 6 PR 머지(머지 단위는 분리 가능, 출시 시점 동기화).
+  2. 배포 → `FavoritePriorityBackfillRunner`가 NULL priority 행을 dense 0..N-1로 채움 (idempotent).
+  3. 운영자가 `psql`로 `db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql` 적용:
+     - `ALTER TABLE user_favorite_indicator ALTER COLUMN priority SET NOT NULL;`
+     - `ALTER TABLE user_favorite_indicator DROP CONSTRAINT IF EXISTS user_favorite_indicator_priority_unique, ADD CONSTRAINT user_favorite_indicator_priority_unique UNIQUE (user_id, source_type, priority) DEFERRABLE INITIALLY DEFERRED;`
+     - 본 repo는 Postgres 14 기준이므로 `NULLS DISTINCT` 키워드는 사용하지 않으며 기본 distinct 동작에 의존(다중 NULL 허용은 backfill 미완 단계에서만 의미). Postgres 15+ 환경으로 업그레이드 시 `NULLS NOT DISTINCT`를 도입하지 않도록 SQL 헤더 코멘트로 명시.
+  4. (선택) 다음 PR에서 Entity의 priority를 nullable=false로 격상.
+- `index.html`에 SortableJS UMD CDN 의존성 추가 — `DEPENDENCIES.md`(있다면) 또는 PR description에 명시.
+- 별도 후속 이슈 생성 권장:
+  - 키보드 접근성(↑/↓ + Space / aria-live announce) — origin Deferred 항목.
+  - 차후 prod DB에서 5+ 보유 사용자 분포 검증 — origin Dependencies/Assumptions 후행 조치.
+
+### 롤백 시나리오별 절차
+
+| 시나리오 | 단계 | 조치 |
+|---|---|---|
+| A — Phase 1 자바 배포 직후 backfill 실패 | runner가 advisory lock 획득 못 하거나 예외로 NULL 행이 남음 | 직전 main 커밋(`53ca036`)으로 코드 롤백 배포. DB 손대지 않음(이전 코드는 priority 컬럼 무시). 필요 시 `ALTER TABLE user_favorite_indicator DROP COLUMN IF EXISTS priority;`로 컬럼 제거 |
+| B — Phase 2 verification gate 실패 | V1(NULL=0) / V2(invariant) / V5(중복=0) / V6(Hibernate auto-add 부재) 중 1건 이상 FAIL | Phase 3 SQL 실행 안 함. V6 FAIL 시 자동 생성된 NOT DEFERRABLE constraint를 `ALTER TABLE user_favorite_indicator DROP CONSTRAINT <auto_name>;`로 제거. V2 FAIL 시 그룹별 강제 dense 재할당 SQL 적용 후 재검증 |
+| C — Phase 3 SQL 실행 도중/직후 실패 | NOT NULL 적용은 됐는데 UNIQUE 추가 실패, 또는 condeferrable=false 발견 | SQL이 단일 트랜잭션(`BEGIN; ... COMMIT;`)으로 묶여 자동 롤백됨. 일부만 적용된 경우: `ALTER TABLE user_favorite_indicator ALTER COLUMN priority DROP NOT NULL; ALTER TABLE user_favorite_indicator DROP CONSTRAINT IF EXISTS user_favorite_indicator_priority_unique;` 후 시나리오 B로 |
+| D — 운영 중 invariant 위반/race retry exhausted 다발 | 모니터링 키워드 alert 발생 | (1) `/api/favorites/order` feature flag 차단 또는 nginx에서 일시 거부. (2) V2/V5 SQL 수동 실행해 데이터 무결성 점검. (3) 코드만 직전 main으로 롤백 가능(DB schema는 forward compatible — 이전 코드는 priority 무시). (4) 데이터 손상 의심 시 백업으로 행 단위 복원 |
+
+### Down SQL (Phase 3 강화 되돌리기)
+
+운영자가 NOT NULL + UNIQUE DEFERRABLE을 되돌려야 할 때:
+
+```sql
+BEGIN;
+ALTER TABLE user_favorite_indicator
+    DROP CONSTRAINT IF EXISTS user_favorite_indicator_priority_unique;
+ALTER TABLE user_favorite_indicator
+    ALTER COLUMN priority DROP NOT NULL;
+COMMIT;
+```
+
+이후 자바 배포는 priority 컬럼이 nullable로 동작하며 backfill runner는 idempotent하게 재시도된다.
+
+### 운영 모니터링 키워드 alert 등록 권장
+
+| Keyword | Severity | Threshold |
+|---|---|---|
+| `FAVORITE_PRIORITY_BACKFILL_APPLIED` | INFO | 부팅마다 0 또는 1회 (rows>0 이면 점검) |
+| `FAVORITE_PRIORITY_BACKFILL_SKIPPED` | INFO | 다른 replica가 lock 보유 — 정상 |
+| `FAVORITE_PRIORITY_BACKFILL_FAILED` | ERROR | 1회라도 발생 시 backfill 미완료 점검 |
+| `FAVORITE_INSERT_UNIQUE_RETRY_EXHAUSTED` | ERROR | 5분 내 3회 이상 |
+| `FAVORITE_REORDER_INVARIANT_VIOLATION` | ERROR | 1회라도 발생 시 데이터 무결성 사고 |
+| `FAVORITE_REORDER_INVARIANT_SKIPPED` | WARN | transition window 한정. backfill 완료 후에도 발생하면 점검 |
+| `FAVORITE_REORDER_OK` | INFO | trend 모니터 (rowsUpdated=0 비율) |
+
+## Sources & References
+
+- **Origin document**: [docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md](../brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md)
+- **Issue**: #42 관심지표 우선순위 기능 및 화면 조정
+- 관련 코드:
+  - `src/main/java/com/thlee/stock/market/stockmarket/favorite/**`
+  - `src/main/resources/static/partials/home.html`
+  - `src/main/resources/static/js/components/favorite.js`, `static/js/api.js`, `static/index.html`
+  - `src/main/resources/db/migration/news_event_impact_rename.sql`, `news_event_category_not_null.sql` (3-phase 마이그레이션 선례)
+- 관련 prior 작업: `docs/plans/2026-04-15-002-feat-favorite-indicator-dashboard-plan.md` (테이블 신규 생성), `docs/plans/2026-04-21-001-fix-global-favorite-realtime-indicator-plan.md`
+- 외부 참고:
+  - PostgreSQL DEFERRABLE constraints (Christian Emmer, postgresql.org SET CONSTRAINTS)
+  - Alpine.js x-for + SortableJS 통합 패턴 (alpinejs/alpine#1635, alpinejs/alpine#3856)
+  - SortableJS README, 1.15.x UMD
+- 관련 학습: `docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md`, `docs/solutions/ui-bugs/responsive-design-tailwind-alpine.md`, `docs/solutions/architecture-patterns/global-indicator-history-mirroring.md`, `docs/solutions/architecture-patterns/deposit-history-n-plus-one-batch-pattern.md`

--- a/docs/solutions/architecture-patterns/alpine-sortablejs-umd-slot-based-reorder-2026-05-10.md
+++ b/docs/solutions/architecture-patterns/alpine-sortablejs-umd-slot-based-reorder-2026-05-10.md
@@ -1,0 +1,166 @@
+---
+title: "Alpine.js x-for + SortableJS UMD — revert-then-splice가 아닌 slot-based 갱신 패턴"
+category: architecture-patterns
+date: 2026-05-10
+module: favorite, frontend
+problem_type: best_practice
+component: frontend_stimulus
+severity: high
+tags:
+  - alpine-js
+  - sortablejs
+  - drag-and-drop
+  - umd-cdn
+  - reactive-array
+  - x-for-key
+  - revert-then-splice
+  - slot-based-reorder
+applies_when:
+  - "Alpine.js v3 + Tailwind CDN 환경(npm 빌드 파이프라인 없음)에 드래그 앤 드롭 reorder UI를 추가할 때"
+  - "한 reactive 배열에 여러 컨테이너(필터링된 view)를 렌더링하면서 한 컨테이너만 reorder해야 할 때"
+  - "SortableJS DOM mutation과 Alpine x-for 재렌더가 충돌해 카드가 깜박이거나 잘못된 위치로 splice될 때"
+---
+
+# Alpine.js x-for + SortableJS UMD — revert-then-splice가 아닌 slot-based 갱신 패턴
+
+## Context
+
+본 repo는 npm 빌드 파이프라인이 없는 정적 HTML + Tailwind CDN + Alpine.js v3 환경이다. 관심지표 컨테이너에 드래그 앤 드롭 reorder UI를 추가하면서 SortableJS 1.15.x UMD를 CDN script로 도입했다 — 본 repo의 첫 DnD 사용처.
+
+핵심 trap 두 가지가 있다:
+
+1. **Alpine `x-for` reactive 재렌더 vs SortableJS DOM mutation 충돌**: SortableJS는 onEnd 콜백에서 DOM을 *이미 변경*한 상태로 호출하지만, Alpine은 reactive 배열을 source-of-truth로 보고 재렌더한다. 두 흐름이 충돌하면 카드가 깜박이거나 잘못된 위치로 떨어진다. 표준 회피책 "revert-then-splice"는 SortableJS oldIndex/newIndex의 의미와 splice 후 인덱스 보정 수식이 미묘해 dead ternary(`fromAbs < toAbs ? toAbs : toAbs`) 같은 silent bug를 부른다.
+
+2. **단일 reactive 배열 + 다중 컨테이너 렌더**: 같은 `enrichedFavorites.ecos` 배열을 displayMode로 필터링해 두 개의 `<template x-for>`로 렌더링한다. 한 컨테이너만 reorder하더라도 bucket의 절대 인덱스를 직접 splice하면 다른 컨테이너 항목이 의도치 않게 뒤로 밀린다.
+
+## Guidance
+
+### 1. SortableJS UMD 로드 순서
+
+```html
+<!-- index.html, Chart.js 다음 / 컴포넌트 스크립트 이전 -->
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+...
+<script src="/js/components/favorite.js"></script>
+<script src="/js/app.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+```
+
+Alpine은 마지막에 로드되며 `x-data` 컴포넌트가 마운트된 직후 SortableJS가 사용 가능하도록 컴포넌트 스크립트 이전에 SortableJS를 둔다.
+
+### 2. `:key`는 stable string identifier
+
+```html
+<template x-for="card in homeSummary.enrichedFavorites.ecos.filter(c => c.displayMode === 'GRAPH')"
+          :key="card.indicatorCode">
+  ...
+</template>
+```
+
+- `:key="index"`는 절대 사용 금지. reorder 시 키가 충돌해 Alpine reconciliation이 노드를 재사용하면서 깜박임 또는 destructive re-render 발생.
+- `card.indicatorCode`처럼 **immutable + unique**한 도메인 식별자를 키로 사용하면 SortableJS DOM mutation과 Alpine x-for diff가 무리 없이 동작.
+
+### 3. SortableJS init 옵션 — 모바일 long-press 분리
+
+```javascript
+this.favoriteEdit.sortable = Sortable.create(container, {
+    animation: 150,
+    delay: 200,
+    delayOnTouchOnly: true,    // 데스크톱은 즉시, 터치만 long-press
+    touchStartThreshold: 5,    // 5px 이내 움직임은 일반 스크롤로 처리
+    ghostClass: 'opacity-40',
+    onEnd: (evt) => this.handleSortEnd(evt),
+});
+```
+
+`delay: 200 + delayOnTouchOnly: true`는 모바일에서 일반 페이지 스크롤과 드래그 시작을 명확히 분리한다. 이 설정 없이 터치 디바이스에 SortableJS를 붙이면 사용자가 페이지를 스크롤하려 할 때마다 카드가 잡혀 페이지 스크롤이 깨진다.
+
+### 4. revert-then-splice가 아닌 **slot-based 갱신**
+
+다중 컨테이너 환경에서 절대 인덱스 splice의 인덱스 보정(`fromAbs < toAbs ? toAbs - 1 : toAbs`)은 동일 컨테이너만 있을 때만 동작하며, 다른 displayMode 항목과 인터리브된 bucket에서는 미묘한 off-by-one을 유발한다. 더 안전한 패턴:
+
+```javascript
+handleSortEnd(evt) {
+    if (evt.oldIndex === evt.newIndex) return;
+    const a = this.favoriteEdit.active;
+    if (!a) return;
+
+    // (1) SortableJS가 옮긴 DOM을 즉시 되돌린다 — Alpine이 reactive array를 source-of-truth로 다시 그리도록.
+    const parent = evt.from;
+    const children = Array.from(parent.children);
+    if (evt.oldIndex < children.length) {
+        parent.insertBefore(
+            evt.item,
+            children[evt.oldIndex] === evt.item ? children[evt.oldIndex + 1] : children[evt.oldIndex]
+        );
+    }
+
+    // (2) 컨테이너 카드들의 새 순서 계산 — splice on copy, 인덱스 보정 불필요.
+    const enriched = this.homeSummary?.enrichedFavorites;
+    if (!enriched) return;
+    const bucket = a.sourceType === 'ECOS' ? enriched.ecos : enriched.global;
+    const items = this.containerCards(a.sourceType, a.displayMode);
+    if (evt.oldIndex >= items.length || evt.newIndex >= items.length) return;
+    const reordered = items.slice();
+    const [moving] = reordered.splice(evt.oldIndex, 1);
+    reordered.splice(evt.newIndex, 0, moving);
+
+    // (3) bucket 내 컨테이너 슬롯 절대 인덱스 수집 후 새 순서로 채워 넣기.
+    //     다른 displayMode 항목의 절대 위치는 변경되지 않는다 — 인덱스 보정 불필요.
+    const slots = items.map(card => bucket.indexOf(card)).filter(idx => idx >= 0);
+    if (slots.length !== items.length) return;
+    slots.forEach((slot, i) => { bucket[slot] = reordered[i]; });
+    this.favoriteEdit.dirty = true;
+},
+```
+
+**왜 slot-based가 더 안전한가**:
+- (2)에서 *items 배열의 카피* 위에 splice를 적용하므로 bucket 내 다른 항목과 무관하게 컨테이너 순서를 정확히 산출.
+- (3)에서 bucket의 컨테이너 슬롯 인덱스(절대 위치)만 수집해 그 슬롯들에 새 순서를 *그대로* 채워 넣는다. 다른 displayMode 항목의 절대 인덱스는 건드리지 않는다 → 인덱스 보정 수식이 필요 없음.
+- cancel 시 snapshot 복원도 같은 패턴(`slots.forEach` 슬롯에 snapshot 카드 채워 넣기)으로 일관 처리 가능.
+
+### 5. `x-show + x-transition` 권장, `x-if` 회피
+
+본 repo의 `responsive-design-tailwind-alpine.md` 가이드와 일관 — 편집 모드 토글에서 `x-if`로 DOM을 통째로 추가/제거하면 SortableJS 인스턴스가 detach되어 다음 진입 시 다시 attach 비용이 든다. `x-show`는 DOM을 유지하므로 SortableJS lifecycle 관리가 단순.
+
+## Why This Matters
+
+- **Silent client bug 회피**: dead ternary(`fromAbs < toAbs ? toAbs : toAbs`) 같은 미묘한 인덱스 버그는 컴파일·린트로 잡히지 않고 reorder 시나리오 일부에서만 한 칸 어긋남으로 나타난다. 사용자에게 "내가 옮긴 카드가 한 칸 더 갔다" 같은 모호한 불만으로 환원되어 디버깅이 늦어진다.
+- **재사용성**: 본 repo의 다른 화면(포트폴리오, 주식 노트 등)에 reorder UI를 도입할 때 동일 패턴 그대로 적용 가능.
+- **모바일 페이지 스크롤 보존**: `delayOnTouchOnly + touchStartThreshold` 조합 미설정 시 모바일 사용성이 즉시 깨진다.
+
+## When to Apply
+
+- Alpine.js v3 환경에 드래그 앤 드롭 reorder UI를 추가할 때
+- 한 reactive 배열을 여러 필터로 분기 렌더하면서 한 분기만 reorder해야 할 때
+- 모바일 터치 디바이스에서 일반 페이지 스크롤과 드래그 시작을 분리해야 할 때
+
+## Examples
+
+### 함정 시나리오 — revert-then-splice의 dead ternary
+
+```javascript
+// 잘못된 패턴
+const fromAbs = bucket.findIndex(c => c === moving);
+const toAbs = bucket.findIndex(c => c === target);
+bucket.splice(fromAbs, 1);
+const adjusted = fromAbs < toAbs ? toAbs : toAbs;  // dead ternary
+bucket.splice(adjusted, 0, moving);
+```
+
+`fromAbs < toAbs`일 때 `toAbs - 1`이 정답이지만 두 분기 모두 `toAbs`를 반환 → 한 칸 어긋남. 다른 displayMode 항목이 fromAbs와 toAbs 사이에 있으면 그 보정이 우연히 정답과 같아져 일부 시나리오에서만 문제 발견.
+
+### 본 작업 적용 사례
+
+- 변경 파일: `src/main/resources/static/js/components/favorite.js`(편집 모드 상태기계 + handleSortEnd + restoreSnapshot 모두 slot-based), `src/main/resources/static/index.html`(SortableJS UMD 추가), `src/main/resources/static/partials/home.html`(편집 진입/저장/취소 버튼)
+- containerCards 헬퍼: 같은 `enrichedFavorites.ecos`를 sourceType×displayMode 컨테이너 단위로 필터링해 SortableJS attach 대상 결정
+- restoreSnapshot도 동일 slot-based 패턴 — bucket 통째 재구성을 회피해 다른 컨테이너 cosmetic 영향 차단
+
+## Related
+
+- `docs/solutions/ui-bugs/responsive-design-tailwind-alpine.md` — Alpine v3 + Tailwind CDN 컨벤션 (key/x-show/matchMedia)
+- `docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md` — 같은 PR의 backend 트랜잭션 격리 패턴 (frontend reorder의 서버 측 페어)
+- `docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md` — Issue #42 plan, Unit 5 (편집 모드 + SortableJS DnD)
+- 외부 참고: alpinejs/alpine#1635 (x-for + SortableJS V3 regression), alpinejs/alpine#3856 (Sortable touch fallback + x-ignore), SortableJS README 1.15.x UMD

--- a/docs/solutions/architecture-patterns/application-runner-backfill-multi-replica-safety-2026-05-10.md
+++ b/docs/solutions/architecture-patterns/application-runner-backfill-multi-replica-safety-2026-05-10.md
@@ -1,0 +1,152 @@
+---
+title: "Spring ApplicationRunner backfill — Postgres advisory lock + 부팅 차단 회피로 multi-replica 안전성 확보"
+category: architecture-patterns
+date: 2026-05-10
+module: favorite, common-bootstrap
+problem_type: best_practice
+component: database
+severity: high
+tags:
+  - spring-application-runner
+  - bootstrap-backfill
+  - multi-replica
+  - postgres-advisory-lock
+  - pg-try-advisory-xact-lock
+  - boot-failure-isolation
+  - idempotent-backfill
+applies_when:
+  - "ApplicationRunner로 부팅 시 1회 backfill을 실행해 nullable 신규 컬럼을 채울 때"
+  - "rolling/blue-green 배포로 같은 시점에 여러 replica가 동시에 부팅될 때"
+  - "ddl-auto + 수동 SQL 마이그레이션 하이브리드에서 phase 1~2 윈도우 동안 UNIQUE 제약 부재 상태로 backfill해야 할 때"
+---
+
+# Spring ApplicationRunner backfill — Postgres advisory lock + 부팅 차단 회피로 multi-replica 안전성 확보
+
+## Context
+
+본 PR은 `user_favorite_indicator`에 nullable `priority` 컬럼을 추가하고, 부팅 시 1회 ApplicationRunner로 NULL 행을 dense 0..N-1로 채우는 3-phase 마이그레이션을 채택했다. Phase 1(자바 배포 + backfill) ~ Phase 3(수동 SQL로 NOT NULL + UNIQUE DEFERRABLE 추가) 사이의 윈도우는 UNIQUE 제약 자체가 존재하지 않아, 다음 두 trap이 함께 발생할 수 있다:
+
+1. **Multi-replica race** — rolling 배포로 두 replica가 동시에 부팅하면 둘 다 같은 NULL 행을 SELECT하고 동일 priority를 부여한다. UNIQUE가 없으니 둘 다 silent commit, phase 3 ALTER ADD CONSTRAINT가 중복 priority 발견으로 실패.
+2. **부팅 차단** — `@Transactional` ApplicationRunner가 예외를 raise하면 Spring Boot의 `SpringApplication.run`이 `IllegalStateException`으로 감싸 부팅을 abort. 한 replica가 일시적 lock timeout/네트워크 문제로 실패하면 그 인스턴스는 unhealthy, 다른 replica가 정상이라도 LB가 절반의 트래픽을 거부한다.
+
+본 패턴은 두 trap을 모두 차단한다.
+
+## Guidance
+
+### 1. `pg_try_advisory_xact_lock`으로 단일 replica에서만 backfill
+
+Postgres advisory lock은 트랜잭션 단위로 `bigint` 키에 대해 mutex를 제공한다. 여러 replica가 같은 키로 동시에 시도하면 한 replica만 true 반환, 나머지는 false 반환 → 즉시 skip.
+
+```java
+private static final long ADVISORY_LOCK_KEY = 4242042001L;  // 본 backfill 작업 전용 상수
+
+private boolean tryAcquireAdvisoryLock() {
+    Object result = entityManager
+        .createNativeQuery("SELECT pg_try_advisory_xact_lock(:key)")
+        .setParameter("key", ADVISORY_LOCK_KEY)
+        .getSingleResult();
+    return Boolean.TRUE.equals(result);
+}
+
+@Transactional
+protected void backfillWithLock() {
+    if (!tryAcquireAdvisoryLock()) {
+        log.info("FAVORITE_PRIORITY_BACKFILL_SKIPPED reason=advisory-lock-held-by-another-replica");
+        return;
+    }
+    // ... NULL 행 조회 + dense 0..N-1 부여 + bulk update ...
+}
+```
+
+핵심:
+- **`pg_try_advisory_xact_lock`은 non-blocking** — 즉시 true/false 반환. 다른 replica가 lock 보유 시 대기 없이 skip해 부팅 시간 보장.
+- **트랜잭션 단위 자동 해제** — `_xact_` 접미사가 transaction-scoped. commit/rollback 시 자동 해제. session-scoped(`pg_try_advisory_lock`)는 명시적 unlock 필요해 함정.
+- **상수 키 충돌 방지** — 본 backfill 전용 키를 정해 다른 advisory lock(다른 모듈, 다른 backfill)과 충돌 회피. 키 영역 분리 정책을 코멘트로 명시.
+
+### 2. try/catch로 부팅 차단 회피 + 다음 부팅 재시도
+
+```java
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FavoritePriorityBackfillRunner implements ApplicationRunner {
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            backfillWithLock();
+        } catch (Exception e) {
+            log.error("FAVORITE_PRIORITY_BACKFILL_FAILED next-boot-will-retry", e);
+        }
+    }
+
+    @Transactional
+    protected void backfillWithLock() {
+        // ... advisory lock + backfill 로직 ...
+    }
+}
+```
+
+- **`run()`에 try/catch** — 어떤 예외가 raise되어도 ERROR 로그만 남기고 부팅 자체는 진행. 실패한 replica가 unhealthy로 전체 배포가 멈추는 사고 회피.
+- **`@Transactional`을 inner method에 두기** — `run()` 자체에 `@Transactional`을 두면 try/catch가 트랜잭션 인터셉터 *외부*에 위치해 commit 단계 예외(예: DEFERRED constraint check, ConstraintViolation at flush)가 catch에 도달하지 못할 수 있다. inner protected method에 `@Transactional`을 두면 Spring AOP 프록시가 그 경계에서 commit을 처리하고, 발생 예외를 호출자(`run()`)에서 정상 catch.
+- **idempotent 보장이 전제** — 다음 부팅 재시도가 안전하려면 backfill 자체가 idempotent해야 한다. `WHERE priority IS NULL`로 입력을 한정하고 모두 채워지면 즉시 종료하는 패턴이 표준.
+
+### 3. inner method 가시성 — `protected` + non-final
+
+`@Transactional`을 inner method에 두려면 Spring AOP가 프록시를 만들 수 있어야 하므로 `private`은 안 됨(self-invocation은 프록시를 거치지 않음). `protected`(또는 package-private/public)이고 non-final이어야 한다. 본 repo의 다른 ApplicationRunner들도 동일 패턴.
+
+### 4. 운영 가시성 — 명확한 로그 키워드
+
+```text
+FAVORITE_PRIORITY_BACKFILL_APPLIED rows=N         # 정상 적용
+FAVORITE_PRIORITY_BACKFILL_SKIPPED reason=...     # 다른 replica가 처리 중 (정상)
+FAVORITE_PRIORITY_BACKFILL_FAILED ...             # 실패 — 다음 부팅 재시도
+```
+
+각 키워드는 운영 모니터링(ELK/Loki)의 별도 alert 룰로 등록한다. APPLIED는 INFO trend 모니터, SKIPPED는 INFO 정상 신호, FAILED는 ERROR alert로 즉시 escalation.
+
+## Why This Matters
+
+- **Rolling 배포 안전성**: blue/green 또는 multi-replica 환경에서 backfill race로 데이터 무결성이 깨지면 phase 3 SQL이 실패하고 운영자가 수동 정리해야 한다. 본 패턴으로 race 자체를 차단.
+- **부팅 가용성 보존**: 한 replica의 일시적 backfill 실패가 LB의 절반을 잘라먹지 않도록 보장. ApplicationRunner 예외가 부팅을 abort한다는 점을 모르고 try/catch를 빠뜨리면 이 trap이 발생.
+- **3-phase 마이그레이션의 첫 phase 안전성**: 본 repo의 `jpa-version-passthrough-...` 패턴이 phase 1 entity-side 함정을 다룬다면, 본 문서는 phase 1 runtime-side(부팅 시 backfill 동작 안전성)를 다룬다 — 함께 적용해야 phase 1이 완성.
+
+## When to Apply
+
+- ApplicationRunner로 부팅 시 1회 backfill을 실행해야 할 때
+- rolling/blue-green 배포로 같은 시점에 여러 replica가 동시에 부팅할 가능성이 있을 때
+- backfill 도중 일시적 장애(lock timeout, 네트워크 일시 단절)에 대해 부팅 차단보다 next-boot 재시도가 합리적일 때
+- ddl-auto + 수동 SQL 하이브리드 마이그레이션의 phase 1 ~ phase 3 윈도우 동안 UNIQUE 제약 부재 상태로 backfill해야 할 때
+
+## Examples
+
+### 함정 시나리오 — try/catch 누락 + advisory lock 누락
+
+```java
+// 잘못된 패턴
+@Override
+@Transactional
+public void run(ApplicationArguments args) {
+    List<Entity> nullRows = repo.findAllWithNullPriority();
+    if (nullRows.isEmpty()) return;
+    // 두 replica가 같은 NULL 행을 동시에 본다 → 같은 priority 부여 → silent 중복
+    repo.assignDensePriority(nullRows);
+}
+```
+
+- replica A와 B가 동시 부팅 시 둘 다 nullRows의 같은 행 리스트를 받음 → 같은 priority 부여 → phase 3 ALTER UNIQUE가 중복 발견으로 실패
+- 만약 A가 lock timeout으로 실패하면 `@Transactional` rollback + 예외가 부팅을 abort → A는 unhealthy, LB의 절반이 트래픽을 거부
+
+### 본 작업 적용 사례
+
+- 변경 파일: `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/config/FavoritePriorityBackfillRunner.java`
+- advisory lock 키: `4242042001L` (favorite priority backfill 전용 상수)
+- inner method: `protected void backfillWithLock()` — `@Transactional` + Spring AOP 프록시 호환
+- 부팅 시 ERROR 발생해도 LB-down 회피 → 다음 부팅에서 idempotent 재시도
+
+## Related
+
+- `docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md` — 같은 3-phase 마이그레이션의 entity-side 함정 (NOT NULL silent skip)
+- `docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md` — 본 PR의 retry semantics (phase 3 이후의 동시성 패턴)
+- `docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md` — Issue #42 plan, Unit 1 (backfill runner) + Documentation/Operational Notes (롤백 시나리오)
+- 외부 참고: PostgreSQL `pg_try_advisory_xact_lock` 문서, Spring `Propagation.REQUIRES_NEW` + AOP self-invocation 제약

--- a/docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md
+++ b/docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md
@@ -1,0 +1,192 @@
+---
+title: "Postgres DEFERRABLE INITIALLY DEFERRED + Spring @Transactional retry — REQUIRES_NEW로 격리해야 retry가 살아있다"
+category: architecture-patterns
+date: 2026-05-10
+module: favorite, common-persistence
+problem_type: best_practice
+component: database
+severity: high
+tags:
+  - postgres
+  - deferrable-constraint
+  - initially-deferred
+  - sqlstate-23505
+  - sqlstate-25p02
+  - spring-transactional
+  - propagation-requires-new
+  - retry-pattern
+applies_when:
+  - "Postgres `UNIQUE ... DEFERRABLE INITIALLY DEFERRED` 제약을 가진 테이블에 INSERT/UPDATE 실패 시 retry를 시도할 때"
+  - "Spring `@Transactional` 안에서 try-catch + 동일 statement 재실행 패턴을 도입할 때"
+  - "Hibernate `ddl-auto=update` + 수동 SQL 마이그레이션 하이브리드 환경에서 DEFERRABLE 제약을 SQL로만 관리할 때"
+---
+
+# Postgres DEFERRABLE INITIALLY DEFERRED + Spring @Transactional retry — REQUIRES_NEW로 격리해야 retry가 살아있다
+
+## Context
+
+본 repo는 `user_favorite_indicator` 테이블에 사용자 지정 우선순위(`priority` INT) 컬럼을 도입하고, 동시 swap-update를 안전하게 처리하기 위해 Postgres `UNIQUE (user_id, source_type, priority) DEFERRABLE INITIALLY DEFERRED` 제약을 채택했다. 동시 INSERT race(같은 그룹의 `MAX(priority)+1`을 두 트랜잭션이 동시에 산출하는 상황)에 대비해 단일 `@Transactional` 안에서 SQLState 23505 발생 시 retry하는 코드를 작성했다.
+
+```java
+// 잘못된 패턴 — retry 루프가 사실상 dead code
+@Transactional
+public boolean toggle(Long userId, ...) {
+    if (deleted > 0) return false;
+    insertWithRetry(userId, ...);   // 같은 트랜잭션 안에서 retry 시도
+    return true;
+}
+
+private void insertWithRetry(...) {
+    for (int attempt = 1; attempt <= 3; attempt++) {
+        try {
+            repo.insertWithNextPriority(...);  // INSERT ... SELECT MAX(priority)+1
+            return;
+        } catch (DataIntegrityViolationException e) {
+            if (!isUniqueViolation(e) || attempt == 3) throw e;
+            Thread.sleep(50L * attempt);  // backoff
+        }
+    }
+}
+```
+
+이 패턴은 **DEFERRABLE INITIALLY DEFERRED 제약의 검증 시점을 잘못 가정한 dead code**다. 1차 attempt 실패 시 트랜잭션이 rollback-only 상태로 마킹되어 후속 attempt가 25P02(`current transaction is aborted`)로 즉시 거부되며, 그 결과 23505는 단 한 번도 다시 raise되지 않는다.
+
+## Guidance
+
+### DEFERRABLE INITIALLY DEFERRED 제약은 **commit 시점에 검증된다**
+
+- `INITIALLY IMMEDIATE`: INSERT/UPDATE statement 직후 검증 → catch 가능
+- `INITIALLY DEFERRED`: 트랜잭션 commit 시점에 한 번만 검증 → 메서드 본문 내 catch 불가능
+
+본 repo의 swap-update(reorder) 시나리오는 mid-transaction에 priority 정수가 일시적으로 중복되는 상태를 허용해야 하므로 DEFERRED가 필요. 그러나 INSERT race retry는 IMMEDIATE-style 동작이 필요해 두 요구가 충돌한다.
+
+### 해결책 — INSERT만 별도 빈으로 분리해 `REQUIRES_NEW`로 격리
+
+```java
+@Service
+@RequiredArgsConstructor
+public class FavoritePriorityInserter {
+
+    private final FavoriteIndicatorRepository repo;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void insert(Long userId, FavoriteIndicatorSourceType sourceType, String code) {
+        repo.insertWithNextPriority(userId, sourceType, code);
+    }
+}
+```
+
+```java
+// 호출자 — outer @Transactional 안에서 별도 트랜잭션 호출
+private void insertWithRetry(Long userId, ...) {
+    for (int attempt = 1; attempt <= 3; attempt++) {
+        try {
+            favoritePriorityInserter.insert(userId, ...);   // REQUIRES_NEW
+            return;
+        } catch (DataIntegrityViolationException e) {
+            if (!isUniqueViolation(e) || attempt == 3) throw e;
+            sleepBackoff(attempt);
+        }
+    }
+}
+```
+
+핵심:
+1. **별도 빈으로 분리** — Spring AOP self-invocation 제약상 같은 클래스의 `@Transactional` 메서드 호출은 propagation이 무시된다. `FavoritePriorityInserter`처럼 별도 `@Service` 빈에 두면 프록시를 통해 호출되어 새 트랜잭션이 시작된다.
+2. **각 attempt가 독립 트랜잭션** — INSERT 실패 시 inner 트랜잭션만 rollback되며 commit 시 23505가 raise. 호출자는 그 시점에 catch 가능. 다음 attempt는 새 트랜잭션을 시작하므로 25P02 상태 영향 없음.
+3. **idempotent-ish operation에만 사용** — outer 트랜잭션과 분리해도 안전한 단일 statement(부수효과 없음, retry 시 의미상 같은 결과)에 한정.
+
+### SQLState 정확 매칭으로 retry 대상 한정
+
+```java
+private boolean isUniqueViolation(DataIntegrityViolationException e) {
+    Throwable cause = e.getCause();
+    while (cause != null) {
+        if (cause instanceof SQLException sqlEx && "23505".equals(sqlEx.getSQLState())) {
+            return true;
+        }
+        cause = cause.getCause();
+    }
+    return false;
+}
+```
+
+`DataIntegrityViolationException`은 23505 외에도 NOT NULL 위반, FK 위반 등 다른 무결성 위반을 포함한다. SQLState로 정확 매칭해 retry 대상을 transient race로 한정하지 않으면 영구 결함을 무한 retry로 가린다.
+
+### swap-update(reorder)에는 DEFERRED 그대로 + 메서드 내 catch 제거
+
+reorder처럼 mid-tx 중복 priority가 알고리즘 정합성에 필수인 경우 DEFERRED를 유지하고, 메서드 본문의 `DataIntegrityViolationException` catch는 제거한다(어차피 commit 시 raise되어 메서드 외부로 던져지므로 dead code). 글로벌 핸들러(`@RestControllerAdvice`)에서 23505를 409로 매핑해 클라이언트에 전달.
+
+```java
+@Transactional
+public void reorder(...) {
+    // ... computeNewOrder + bulkUpdatePriority + assertGroupInvariant
+    // DEFERRED UNIQUE 위반은 commit 시점에 raise되므로 본 메서드 내 catch 불가 —
+    // GlobalExceptionHandler.handleDataIntegrityViolation이 409 CONFLICT로 매핑.
+}
+```
+
+## Why This Matters
+
+- **Silent reliability degradation**: 잘못된 retry 패턴은 컴파일 통과 + 단위 테스트로 발견 어려움 + 동시성 race 상황에서만 노출. 사용자에게 "추가 실패" 5xx가 노출되어도 retry log가 정상으로 보여 원인 추적이 늦어진다.
+- **자주 반복되는 함정**: Postgres DEFERRED + Spring `@Transactional`은 본 repo 외에도 흔한 조합. 본 패턴 미숙지 시 다른 모듈에서도 같은 dead retry를 도입할 가능성.
+- **문서화 가치**: 본 repo의 `external-http-per-item-transaction-isolation-2026-04-26.md`가 self-invocation 제약을 다룬다 — 본 문서는 DEFERRED 제약 시점 차이를 다루는 동일한 family의 trap.
+
+## When to Apply
+
+- Postgres `DEFERRABLE INITIALLY DEFERRED` 제약을 가진 테이블에 INSERT race retry를 도입할 때
+- Spring `@Transactional` 안에서 같은 statement를 try-catch로 재실행하려 할 때 (PSQLException 발생 후 재실행)
+- Hibernate `ddl-auto=update` + 수동 SQL 마이그레이션 환경에서 DEFERRABLE 제약을 SQL로만 관리할 때 — Entity의 `@UniqueConstraint(columnNames=...)`를 사용하면 ddl-auto가 NOT DEFERRABLE 중복 제약을 silent하게 추가해 본 패턴 자체가 깨진다(Entity에 절대 두지 말 것)
+- swap-update(bulk reorder)와 single-row INSERT가 같은 제약을 공유하지만 mid-tx 중복 허용 요구가 다를 때
+
+## Examples
+
+### 함정 시나리오 — 같은 트랜잭션 내 retry는 죽어있다
+
+```text
+T1: BEGIN
+T1: INSERT ... priority = 5  -- 성공
+T2: BEGIN
+T2: INSERT ... priority = 5  -- 성공 (DEFERRED는 statement 시점에 검증 안 함)
+T1: COMMIT  -- 성공
+T2: COMMIT  -- 23505 raise (deferred check fires)
+
+# 코드 흐름:
+# 1. inner repo.insertWithNextPriority 정상 종료(예외 없음)
+# 2. outer toggle() 메서드 본문 정상 종료
+# 3. Spring TransactionInterceptor가 commit 시도
+# 4. 여기서 23505 발생 — toggle() 내부의 catch는 이미 호출 스택에서 빠져나간 상태
+# 5. catch 블록은 실행될 수 없음 — retry 루프는 dead code
+```
+
+### 올바른 패턴 — REQUIRES_NEW로 retry 격리
+
+```text
+T1: BEGIN [outer]
+T1: BEGIN [inner — REQUIRES_NEW]
+T1: INSERT ... priority = 5
+T2: BEGIN [outer]
+T2: BEGIN [inner — REQUIRES_NEW]
+T2: INSERT ... priority = 5
+T1: COMMIT [inner]  -- 성공
+T2: COMMIT [inner]  -- 23505 raise here, propagation REQUIRES_NEW 덕에 inner만 rollback
+
+# 코드 흐름:
+# 1. T2의 favoritePriorityInserter.insert(...)가 23505로 throw
+# 2. T2의 toggle() 내 try-catch가 catch — inner 트랜잭션은 이미 rollback됨, outer는 살아있음
+# 3. attempt = 2로 retry
+# 4. 새 inner 트랜잭션에서 INSERT ... SELECT MAX(priority)+1 = 6 → 성공
+```
+
+### 본 작업 적용 사례
+
+- 변경 파일: `src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoritePriorityInserter.java`(신규), `FavoriteIndicatorService.java`(insertWithRetry/reorder catch 정정)
+- 마이그레이션 SQL: `src/main/resources/db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql` — 단일 트랜잭션(`BEGIN; ... COMMIT;`)으로 적용, Entity에 `@UniqueConstraint` 두지 말 것 명시
+- 운영 모니터링: `FAVORITE_INSERT_UNIQUE_RETRY_EXHAUSTED` ERROR 로그 — 5분 내 3회 이상 발생 시 escalation
+
+## Related
+
+- `docs/solutions/architecture-patterns/external-http-per-item-transaction-isolation-2026-04-26.md` — Spring AOP self-invocation 제약과 per-item 격리 패턴 (본 패턴의 형제 trap)
+- `docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md` — `ddl-auto=update` + NOT NULL 컬럼 추가의 silent skip 함정 (본 마이그레이션의 phase 1에서 동일 위험 회피)
+- `docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md` — Issue #42 plan, Unit 1.5 + Unit 4 의 race 모델
+- 외부 참고: PostgreSQL `SET CONSTRAINTS` 문서, Christian Emmer "Deferrable Constraints in PostgreSQL"

--- a/docs/solutions/architecture-patterns/spring-data-jpa-custom-impl-fragment-dynamic-sql-2026-05-10.md
+++ b/docs/solutions/architecture-patterns/spring-data-jpa-custom-impl-fragment-dynamic-sql-2026-05-10.md
@@ -1,0 +1,196 @@
+---
+title: "Spring Data JPA — 가변 길이 dynamic SQL을 위한 custom-impl fragment 패턴"
+category: architecture-patterns
+date: 2026-05-10
+module: favorite, common-persistence
+problem_type: best_practice
+component: database
+severity: medium
+tags:
+  - spring-data-jpa
+  - custom-impl-fragment
+  - dynamic-sql
+  - case-when-bulk-update
+  - entity-manager
+  - chunked-update
+  - flush-clear
+applies_when:
+  - "JPA Repository에 가변 길이 입력(Map/List)에 의존하는 동적 SQL이 필요할 때"
+  - "@Modifying @Query 정적 JPQL로는 표현 불가능한 CASE WHEN 일괄 UPDATE를 발행해야 할 때"
+  - "Spring Data JPA가 자동 합쳐주는 fragment 패턴을 본 repo에 처음 도입할 때"
+---
+
+# Spring Data JPA — 가변 길이 dynamic SQL을 위한 custom-impl fragment 패턴
+
+## Context
+
+`@Modifying @Query`로 정의된 JPA Repository 메서드는 *static* JPQL/native SQL만 받는다. 다음 같은 가변 길이 입력에 의존하는 SQL은 표현 불가:
+
+```sql
+UPDATE user_favorite_indicator
+SET priority = CASE id
+    WHEN ?1 THEN ?2
+    WHEN ?3 THEN ?4
+    -- ... id가 N개면 N개의 WHEN
+END
+WHERE id IN (?N+1, ?N+2, ...);
+```
+
+본 PR의 reorder 알고리즘은 `Map<Long, Integer> idToPriority`를 받아 한 트랜잭션에서 일괄 priority 갱신해야 한다. 입력 크기가 가변이라 `@Query`로는 못 적는다 — Spring Data JPA의 **custom-impl fragment** 패턴을 본 repo에 처음 도입했다.
+
+## Guidance
+
+### 1. `*Custom` 인터페이스 + `*Impl` 클래스 + main repository 상속
+
+Spring Data JPA는 main Repository 인터페이스가 `*Custom` 인터페이스를 추가로 상속하면, **`<RepositoryName>Impl` 클래스명을 자동 인식**해 custom 메서드를 main repository에 합쳐준다. 별도 `@Bean` 등록 불필요.
+
+```java
+// 1) Custom fragment 인터페이스 (도메인 의도만 노출)
+public interface UserFavoriteIndicatorJpaRepositoryCustom {
+    int bulkUpdatePriority(Map<Long, Integer> idToPriority);
+}
+
+// 2) 동적 SQL 구현체 — 클래스명이 정확히 *Impl 이어야 자동 인식됨
+public class UserFavoriteIndicatorJpaRepositoryImpl
+        implements UserFavoriteIndicatorJpaRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public int bulkUpdatePriority(Map<Long, Integer> idToPriority) {
+        // ... 동적 SQL 빌드 + setParameter ...
+    }
+}
+
+// 3) main Repository — 일반 JpaRepository + custom fragment를 동시 상속
+public interface UserFavoriteIndicatorJpaRepository
+        extends JpaRepository<UserFavoriteIndicatorEntity, Long>,
+                UserFavoriteIndicatorJpaRepositoryCustom {
+
+    // 일반 derived query / @Query
+    List<UserFavoriteIndicatorEntity> findByUserId(Long userId);
+
+    // custom 메서드는 자동으로 추가됨 — 별도 선언 불필요
+}
+```
+
+호출 측은 `userFavoriteIndicatorJpaRepository.bulkUpdatePriority(map)` 형태로 일관되게 사용. main과 custom이 자연스럽게 합쳐진 단일 인터페이스로 보인다.
+
+### 2. EntityManager 직접 사용 — chunk 분할 + flush/clear 책임
+
+```java
+private static final int SMALL_BATCH_THRESHOLD = 5;
+private static final int CHUNK_SIZE = 50;
+
+@Override
+public int bulkUpdatePriority(Map<Long, Integer> idToPriority) {
+    if (idToPriority == null || idToPriority.isEmpty()) {
+        return 0;
+    }
+    int affected;
+    if (idToPriority.size() <= SMALL_BATCH_THRESHOLD) {
+        affected = updateOneByOne(idToPriority);
+    } else {
+        affected = updateInChunks(idToPriority);
+    }
+    // L1 cache가 stale entity를 반환하지 않도록 flush + clear.
+    // 후속 read(예: post-write invariant assertion)가 mutated state를 정확히 본다.
+    entityManager.flush();
+    entityManager.clear();
+    return affected;
+}
+```
+
+핵심 책임:
+- **chunk 분할**: CASE WHEN expression이 비대해지지 않도록 50개 단위로 분할. 작은 입력(≤5)은 개별 UPDATE로 단순화 — CASE WHEN 빌드 비용 회피.
+- **flush + clear**: L1 cache는 dirty 추적용 + lazy 로딩용. 본 메서드는 native SQL로 직접 UPDATE하므로 cache는 갱신을 모른다. flush로 보류 중인 다른 변경을 먼저 반영 + clear로 stale entity 캐시 폐기 → 후속 read가 정확.
+- **반환 row count**: chunk별 `executeUpdate()` 합산. 호출자가 변경 행 수로 no-op short-circuit 결정.
+
+### 3. CASE WHEN 동적 빌드 — 파라미터 인덱스 정확성
+
+```java
+private int executeChunk(List<Map.Entry<Long, Integer>> chunk) {
+    StringBuilder sql = new StringBuilder("UPDATE user_favorite_indicator SET priority = CASE id");
+    for (int i = 0; i < chunk.size(); i++) {
+        sql.append(" WHEN ?").append(i * 2 + 1).append(" THEN ?").append(i * 2 + 2);
+    }
+    sql.append(" END WHERE id IN (");
+    for (int i = 0; i < chunk.size(); i++) {
+        if (i > 0) sql.append(", ");
+        sql.append("?").append(chunk.size() * 2 + i + 1);
+    }
+    sql.append(")");
+
+    Query q = entityManager.createNativeQuery(sql.toString());
+    for (int i = 0; i < chunk.size(); i++) {
+        q.setParameter(i * 2 + 1, chunk.get(i).getKey());
+        q.setParameter(i * 2 + 2, chunk.get(i).getValue());
+    }
+    for (int i = 0; i < chunk.size(); i++) {
+        q.setParameter(chunk.size() * 2 + i + 1, chunk.get(i).getKey());
+    }
+    return q.executeUpdate();
+}
+```
+
+파라미터 인덱스 약속:
+- `1 .. 2N`: CASE WHEN의 (id, priority) 쌍. 1-기반 인덱스라 `i * 2 + 1`(WHEN id), `i * 2 + 2`(THEN priority).
+- `2N+1 .. 3N`: WHERE IN 절 id. `chunk.size() * 2 + i + 1`.
+- `setParameter(int, Object)`는 1-기반이며 모든 `?N` 자리에 값을 채워야 한다 — 누락 시 IllegalArgumentException.
+
+빌드와 바인딩 양쪽이 같은 산식을 쓰므로 향후 리팩터링 시 한 곳만 변경하면 다른 곳도 동기화 필요. helper로 더 분해하면 안전하지만(예: `buildCaseWhenSql(chunk)` / `bindCaseParameters(q, chunk)`) 단일 메서드에 묶으면 산식 일관성이 시각적으로 즉시 확인됨.
+
+### 4. native SQL 사용 — JPQL CASE WHEN의 한계
+
+JPA spec의 JPQL은 `CASE id WHEN ... THEN ... END`를 제한적으로 지원하지만, Hibernate에서 기준 entity 타입 외 가변 표현을 받기 어렵다. `nativeQuery=true` + `createNativeQuery`가 가장 견고. 본 repo의 `NewsJpaRepository.java`도 native `INSERT ... ON CONFLICT` 패턴을 사용해 동일 정책 — 가변/dialect-specific SQL은 native로.
+
+### 5. SQL injection 안전성
+
+본 패턴의 모든 값은 `setParameter`로 바인딩되며, 동적 부분은 `?N` placeholder 자리뿐 — 사용자 입력 문자열을 SQL에 concat하지 않는다. 따라서 SQL injection 표면 없음. 동적 placeholder 개수는 `chunk.size()`에만 의존(서버 측 결정).
+
+## Why This Matters
+
+- **JPA `@Query`의 표현력 한계**: 가변 길이 입력에 의존하는 bulk DML은 `@Query`로 못 적는다 — 모르고 시도하면 컴파일은 통과하지만 런타임에 `NamedParameterNotBoundException` 또는 SQL syntax error로 터진다.
+- **N+1 회피**: 행 단위 individual UPDATE를 루프하면 N번 round-trip + L1 cache 누적 → 대규모 입력에서 부팅/응답 시간 비대화. chunk CASE WHEN으로 N/50 round-trip으로 감축.
+- **stale L1 cache 회피**: native UPDATE는 L1 cache를 갱신하지 않으므로 후속 read가 stale을 본다. flush + clear는 fragment 책임으로 두는 게 호출자 쪽에서 잊지 않는다.
+
+## When to Apply
+
+- 가변 길이 Map/List를 받아 한 트랜잭션에서 일괄 UPDATE/DELETE해야 할 때
+- `@Modifying @Query` 정적 JPQL로 표현 불가능한 dynamic CASE WHEN, dynamic IN, dynamic ORDER BY가 필요할 때
+- bulk DML 후 같은 트랜잭션 내에서 mutated row를 다시 read해야 할 때 (post-write invariant 검증, 일관성 점검 등)
+- 본 repo에 동일 패턴(custom-impl fragment)이 다른 모듈에서도 필요해질 때 — 본 문서를 reference로 사용
+
+## Examples
+
+### 잘못된 시도 — `@Query`로 가변 CASE WHEN 표현 시도
+
+```java
+// 컴파일 통과 + 단위 테스트 인지 어려움 + 런타임에 실패
+@Modifying
+@Query("UPDATE UserFavoriteIndicatorEntity e SET e.priority = " +
+       "CASE e.id WHEN ... END WHERE e.id IN (:ids)")
+int bulkUpdatePriority(@Param("ids") List<Long> ids,
+                       @Param("priorities") List<Integer> priorities);
+```
+
+`CASE e.id WHEN ... END`의 `...` 부분이 가변이라 정적 JPQL로 못 적음. 호출 시 NamedParameter 바인딩 실패.
+
+### 본 작업 적용 사례
+
+- 변경 파일:
+  - `src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepositoryCustom.java`(신규 fragment 인터페이스)
+  - `UserFavoriteIndicatorJpaRepositoryImpl.java`(신규, EntityManager 직접 사용)
+  - `UserFavoriteIndicatorJpaRepository.java`(`extends ..., UserFavoriteIndicatorJpaRepositoryCustom` 추가)
+- 호출처:
+  - `FavoriteIndicatorRepositoryImpl.bulkUpdatePriority` → 도메인 port에서 fragment 호출
+  - `FavoritePriorityBackfillRunner.applyAssignments` → 동일 fragment 재사용으로 N+1 round-trip 회피
+- chunk 정책: `CHUNK_SIZE = 50`, `SMALL_BATCH_THRESHOLD = 5`. 본 repo의 사용자 단위 favorites 항목은 30개 이내가 주류라 chunk 1회로 처리되며 small-batch도 흔함
+
+## Related
+
+- `docs/solutions/architecture-patterns/deposit-history-n-plus-one-batch-pattern.md` — 본 repo의 다른 bulk 패턴(`WHERE IN (...) + groupingBy`)과 보완 관계
+- `docs/solutions/architecture-patterns/external-http-per-item-transaction-isolation-2026-04-26.md` — per-item 격리와 bulk 처리의 trade-off
+- `docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md` — 같은 PR의 DEFERRABLE UNIQUE 제약과 본 fragment의 swap-update 호환성
+- 외부 참고: Spring Data JPA Reference — Custom Implementations for Spring Data Repositories (`*Custom` + `*Impl` 자동 인식 규약)

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoriteIndicatorService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoriteIndicatorService.java
@@ -30,6 +30,9 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,6 +51,7 @@ public class FavoriteIndicatorService {
     private static final int HISTORY_LIMIT = 30;
 
     private final FavoriteIndicatorRepository favoriteIndicatorRepository;
+    private final FavoritePriorityInserter favoritePriorityInserter;
     private final EcosIndicatorService ecosIndicatorService;
     private final GlobalIndicatorQueryService globalIndicatorQueryService;
     private final GlobalIndicatorCacheService globalIndicatorCacheService;
@@ -57,6 +61,7 @@ public class FavoriteIndicatorService {
 
     public FavoriteIndicatorService(
             FavoriteIndicatorRepository favoriteIndicatorRepository,
+            FavoritePriorityInserter favoritePriorityInserter,
             EcosIndicatorService ecosIndicatorService,
             GlobalIndicatorQueryService globalIndicatorQueryService,
             GlobalIndicatorCacheService globalIndicatorCacheService,
@@ -64,6 +69,7 @@ public class FavoriteIndicatorService {
             SingleFlightCoordinator singleFlightCoordinator,
             @Qualifier(GlobalFavoriteExecutorConfig.BEAN_NAME) ExecutorService globalFavoriteFetchExecutor) {
         this.favoriteIndicatorRepository = favoriteIndicatorRepository;
+        this.favoritePriorityInserter = favoritePriorityInserter;
         this.ecosIndicatorService = ecosIndicatorService;
         this.globalIndicatorQueryService = globalIndicatorQueryService;
         this.globalIndicatorCacheService = globalIndicatorCacheService;
@@ -72,8 +78,14 @@ public class FavoriteIndicatorService {
         this.globalFavoriteFetchExecutor = globalFavoriteFetchExecutor;
     }
 
+    private static final int INSERT_MAX_RETRIES = 3;
+    private static final long INSERT_RETRY_BACKOFF_BASE_MS = 50L;
+
     /**
-     * 관심 지표 토글 (등록/해제)
+     * 관심 지표 토글 (등록/해제).
+     * INSERT 분기는 단일 SQL `INSERT ... SELECT MAX(priority)+1` + DEFERRABLE UNIQUE로 race를 처리한다.
+     * SQLState 23505(UNIQUE 위반)는 transient race로 간주해 최대 INSERT_MAX_RETRIES만큼 randomized backoff 후 재시도.
+     * 그 외 무결성 위반은 즉시 상위로 propagate.
      * @return true: 등록됨, false: 해제됨
      */
     @Transactional
@@ -83,11 +95,47 @@ public class FavoriteIndicatorService {
         if (deleted > 0) {
             return false;
         }
+        insertWithRetry(userId, sourceType, indicatorCode);
+        return true;
+    }
+
+    private void insertWithRetry(Long userId, FavoriteIndicatorSourceType sourceType, String indicatorCode) {
+        for (int attempt = 1; attempt <= INSERT_MAX_RETRIES; attempt++) {
+            try {
+                // REQUIRES_NEW로 격리된 트랜잭션을 호출 — 매 attempt가 독립 commit/rollback되어
+                // 23505 발생 시 후속 attempt가 'transaction aborted (25P02)' 상태에 빠지지 않는다.
+                favoritePriorityInserter.insert(userId, sourceType, indicatorCode);
+                return;
+            } catch (DataIntegrityViolationException e) {
+                if (!isUniqueViolation(e) || attempt == INSERT_MAX_RETRIES) {
+                    log.error("FAVORITE_INSERT_UNIQUE_RETRY_EXHAUSTED userId={} sourceType={} indicator={} attempts={}",
+                        userId, sourceType, indicatorCode, attempt, e);
+                    throw e;
+                }
+                sleepBackoff(attempt);
+            }
+        }
+    }
+
+    private boolean isUniqueViolation(DataIntegrityViolationException e) {
+        Throwable cause = e.getCause();
+        while (cause != null) {
+            if (cause instanceof java.sql.SQLException sqlEx
+                && "23505".equals(sqlEx.getSQLState())) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    private void sleepBackoff(int attempt) {
         try {
-            favoriteIndicatorRepository.save(FavoriteIndicator.create(userId, sourceType, indicatorCode));
-            return true;
-        } catch (DataIntegrityViolationException e) {
-            return true;
+            long base = INSERT_RETRY_BACKOFF_BASE_MS * attempt;
+            long jitter = (long) (Math.random() * base);
+            Thread.sleep(base + jitter);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -100,6 +148,219 @@ public class FavoriteIndicatorService {
                                   String indicatorCode,
                                   FavoriteDisplayMode displayMode) {
         favoriteIndicatorRepository.updateDisplayMode(userId, sourceType, indicatorCode, displayMode);
+    }
+
+    /**
+     * 컨테이너 (sourceType × displayMode) 내 항목들의 새 순서를 일괄 반영한다.
+     * 알고리즘 (Option B — group-wide dense reassignment):
+     *  1) (user_id, sourceType) 그룹을 PESSIMISTIC_WRITE로 잠그고 priority ASC NULLS LAST + id ASC로 조회
+     *  2) edited(현재 컨테이너 항목)와 others(다른 displayMode 항목)로 분리
+     *  3) 페이로드 indicatorCodes에서 dedup 후 매칭되는 edited 항목을 그 순서로, 매칭 안 된 edited 항목(다른 탭에서 추가됨)은 기존 priority 순으로 뒤에 append
+     *  4) others의 기존 *상대 순서*를 유지하면서 ordered_edited와 인터리브해 group dense 0..N-1 할당
+     *  5) 변경된 행만 bulk update (no-op 단축)
+     *  6) Post-write invariant assertion: 같은 그룹의 priority 목록이 0..N-1 contiguous인지 검증, 위반 시 IllegalStateException
+     *
+     * R7 정책:
+     *  (a) 페이로드의 cross-container 코드는 silent ignore
+     *  (b) 다른 displayMode 항목의 *상대 순서* 보존 (priority 정수 자체는 dense 재할당 — 코드 주석 참조)
+     *  (c) 다른 탭에서 추가된 항목은 컨테이너 맨 뒤로 부여
+     *  (d) 동시 저장 시 ordering intent는 last-writer-wins
+     */
+    @Transactional
+    public void reorder(Long userId,
+                        FavoriteIndicatorSourceType sourceType,
+                        FavoriteDisplayMode displayMode,
+                        List<String> indicatorCodes) {
+        try {
+            List<FavoriteIndicator> rows = favoriteIndicatorRepository.findForReorderUpdate(userId, sourceType);
+            List<FavoriteIndicator> combined = computeNewOrder(rows, displayMode, indicatorCodes);
+            Map<Long, Integer> assignments = denseAssign(combined);
+            Map<Long, Integer> diff = filterChanged(rows, assignments);
+            if (!diff.isEmpty()) {
+                favoriteIndicatorRepository.bulkUpdatePriority(diff);
+            }
+            assertGroupInvariant(userId, sourceType, combined.size());
+            log.info("FAVORITE_REORDER_OK userId={} sourceType={} displayMode={} payloadSize={} rowsUpdated={}",
+                userId, sourceType, displayMode, indicatorCodes.size(), diff.size());
+        } catch (IllegalStateException e) {
+            log.error("FAVORITE_REORDER_INVARIANT_VIOLATION userId={} sourceType={} displayMode={}",
+                userId, sourceType, displayMode, e);
+            throw e;
+        }
+        // DEFERRABLE INITIALLY DEFERRED UNIQUE 제약 위반은 commit 시점에만 검증되므로
+        // 본 메서드 내부에서 catch 불가능 — GlobalExceptionHandler.handleDataIntegrityViolation 이
+        // 409 CONFLICT 응답으로 매핑한다(공식 race 시그널). 운영 모니터링은 그 핸들러의
+        // publishError 이벤트로 잡힌다.
+    }
+
+    /**
+     * 페이로드 + 서버 상태에서 그룹 전체의 새 순서를 산출한다 (순수 함수).
+     */
+    private List<FavoriteIndicator> computeNewOrder(List<FavoriteIndicator> rows,
+                                                   FavoriteDisplayMode mode,
+                                                   List<String> codes) {
+        List<FavoriteIndicator> edited = filterByMode(rows, mode, true);
+        List<FavoriteIndicator> others = filterByMode(rows, mode, false);
+        Map<String, FavoriteIndicator> byCode = indexFirstOccurrenceByCode(edited);
+        List<FavoriteIndicator> fromPayload = pickByCodes(codes, byCode);
+        List<FavoriteIndicator> appended = appendMissing(edited, fromPayload);
+        List<FavoriteIndicator> orderedEdited = concat(fromPayload, appended);
+        return interleavePreservingOthersOrder(rows, others, orderedEdited);
+    }
+
+    private List<FavoriteIndicator> filterByMode(List<FavoriteIndicator> rows,
+                                                FavoriteDisplayMode mode,
+                                                boolean equals) {
+        return rows.stream()
+            .filter(r -> equals == (r.getDisplayMode() == mode))
+            .toList();
+    }
+
+    private Map<String, FavoriteIndicator> indexFirstOccurrenceByCode(List<FavoriteIndicator> edited) {
+        Map<String, FavoriteIndicator> byCode = new HashMap<>();
+        for (FavoriteIndicator e : edited) {
+            byCode.putIfAbsent(e.getIndicatorCode(), e);
+        }
+        return byCode;
+    }
+
+    private List<FavoriteIndicator> pickByCodes(List<String> codes, Map<String, FavoriteIndicator> byCode) {
+        java.util.LinkedHashSet<String> seen = new LinkedHashSet<>();
+        List<FavoriteIndicator> picked = new ArrayList<>();
+        for (String code : codes) {
+            if (!seen.add(code)) {
+                continue;
+            }
+            FavoriteIndicator match = byCode.get(code);
+            if (match != null) {
+                picked.add(match);
+            }
+        }
+        return picked;
+    }
+
+    private List<FavoriteIndicator> appendMissing(List<FavoriteIndicator> edited,
+                                                 List<FavoriteIndicator> fromPayload) {
+        Set<Long> picked = fromPayload.stream()
+            .map(FavoriteIndicator::getId)
+            .collect(Collectors.toSet());
+        return edited.stream()
+            .filter(e -> !picked.contains(e.getId()))
+            .toList();
+    }
+
+    private List<FavoriteIndicator> concat(List<FavoriteIndicator> a, List<FavoriteIndicator> b) {
+        List<FavoriteIndicator> out = new ArrayList<>(a.size() + b.size());
+        out.addAll(a);
+        out.addAll(b);
+        return out;
+    }
+
+    /**
+     * others(다른 displayMode 항목)는 기존 등장 순서 그대로, edited는 orderedEdited 순서로,
+     * 두 시퀀스가 원본 rows의 displayMode 패턴을 따라 인터리브된 새 List를 반환한다.
+     * 결과는 group dense 0..N-1로 할당될 수 있다.
+     */
+    private List<FavoriteIndicator> interleavePreservingOthersOrder(List<FavoriteIndicator> rows,
+                                                                    List<FavoriteIndicator> others,
+                                                                    List<FavoriteIndicator> orderedEdited) {
+        List<FavoriteIndicator> result = new ArrayList<>(others.size() + orderedEdited.size());
+        Iterator<FavoriteIndicator> othersIt = others.iterator();
+        Iterator<FavoriteIndicator> editedIt = orderedEdited.iterator();
+        FavoriteDisplayMode editedMode = resolveEditedMode(orderedEdited);
+        fillByPattern(rows, editedMode, othersIt, editedIt, result);
+        drain(editedIt, result);
+        drain(othersIt, result);
+        return result;
+    }
+
+    private FavoriteDisplayMode resolveEditedMode(List<FavoriteIndicator> orderedEdited) {
+        return orderedEdited.isEmpty() ? null : orderedEdited.get(0).getDisplayMode();
+    }
+
+    private void fillByPattern(List<FavoriteIndicator> rows,
+                              FavoriteDisplayMode editedMode,
+                              Iterator<FavoriteIndicator> othersIt,
+                              Iterator<FavoriteIndicator> editedIt,
+                              List<FavoriteIndicator> result) {
+        for (FavoriteIndicator r : rows) {
+            takeNextSlot(r, editedMode, othersIt, editedIt, result);
+        }
+    }
+
+    private void takeNextSlot(FavoriteIndicator r,
+                             FavoriteDisplayMode editedMode,
+                             Iterator<FavoriteIndicator> othersIt,
+                             Iterator<FavoriteIndicator> editedIt,
+                             List<FavoriteIndicator> result) {
+        boolean isEditedSlot = editedMode != null && r.getDisplayMode() == editedMode;
+        Iterator<FavoriteIndicator> source = isEditedSlot ? editedIt : othersIt;
+        if (source.hasNext()) {
+            result.add(source.next());
+        }
+    }
+
+    private void drain(Iterator<FavoriteIndicator> it, List<FavoriteIndicator> result) {
+        while (it.hasNext()) {
+            result.add(it.next());
+        }
+    }
+
+    private Map<Long, Integer> denseAssign(List<FavoriteIndicator> combined) {
+        Map<Long, Integer> assignments = new LinkedHashMap<>();
+        for (int i = 0; i < combined.size(); i++) {
+            assignments.put(combined.get(i).getId(), i);
+        }
+        return assignments;
+    }
+
+    private Map<Long, Integer> filterChanged(List<FavoriteIndicator> rows, Map<Long, Integer> assignments) {
+        Map<Long, Integer> diff = new LinkedHashMap<>();
+        Map<Long, Integer> currentById = rows.stream()
+            .collect(Collectors.toMap(FavoriteIndicator::getId, FavoriteIndicator::getPriority, (a, b) -> a));
+        for (Map.Entry<Long, Integer> e : assignments.entrySet()) {
+            Integer current = currentById.get(e.getKey());
+            if (current == null || !current.equals(e.getValue())) {
+                diff.put(e.getKey(), e.getValue());
+            }
+        }
+        return diff;
+    }
+
+    /**
+     * Post-write invariant: 같은 그룹의 priority가 dense 0..N-1 contiguous인지 검증.
+     *
+     * <p>Transition window 가드: 3-phase 마이그레이션 phase 1~2 사이(NOT NULL 격상 전)에
+     * backfill 실패/일부 진행으로 NULL priority 행이 잔존할 수 있다. 이때 dense 검증을 강행하면
+     * 정상 reorder가 false positive로 차단된다. NULL이 발견되면 invariant 검증을 skip하고
+     * WARN 로그만 남겨 운영자가 backfill 완료/재시도를 결정하도록 한다.
+     */
+    private void assertGroupInvariant(Long userId, FavoriteIndicatorSourceType sourceType, int expectedSize) {
+        List<Integer> ps = favoriteIndicatorRepository.findPriorities(userId, sourceType);
+        if (containsNull(ps)) {
+            log.warn("FAVORITE_REORDER_INVARIANT_SKIPPED reason=null-priority-in-transition userId={} sourceType={}",
+                userId, sourceType);
+            return;
+        }
+        if (ps.size() != expectedSize) {
+            throw new IllegalStateException(
+                "priority count mismatch: expected=" + expectedSize + " actual=" + ps.size());
+        }
+        for (int i = 0; i < ps.size(); i++) {
+            if (ps.get(i) != i) {
+                throw new IllegalStateException(
+                    "priority not dense 0..N-1: index=" + i + " value=" + ps.get(i));
+            }
+        }
+    }
+
+    private boolean containsNull(List<Integer> ps) {
+        for (Integer p : ps) {
+            if (p == null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoritePriorityInserter.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/application/FavoritePriorityInserter.java
@@ -1,0 +1,33 @@
+package com.thlee.stock.market.stockmarket.favorite.application;
+
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
+import com.thlee.stock.market.stockmarket.favorite.domain.repository.FavoriteIndicatorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관심지표 INSERT를 별도 트랜잭션 경계로 격리한다.
+ *
+ * <p>FavoriteIndicatorService.toggle 의 retry 루프는 SQLState 23505 발생 시 같은
+ * 트랜잭션을 재사용하면 PostgreSQL이 'transaction aborted (25P02)' 상태로 만들어
+ * 후속 statement가 모두 거부된다. 별도 빈으로 분리해 {@link Propagation#REQUIRES_NEW}
+ * 로 호출하면 매 attempt가 독립 트랜잭션으로 commit/rollback되어 retry 의도가 살아난다.
+ *
+ * <p>또한 INSERT는 단일 statement(`INSERT ... SELECT MAX(priority)+1`)이고 부수효과 없는
+ * idempotent-ish operation이므로 outer 트랜잭션과 분리해도 안전하다.
+ */
+@Service
+@RequiredArgsConstructor
+public class FavoritePriorityInserter {
+
+    private final FavoriteIndicatorRepository favoriteIndicatorRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void insert(Long userId,
+                       FavoriteIndicatorSourceType sourceType,
+                       String indicatorCode) {
+        favoriteIndicatorRepository.insertWithNextPriority(userId, sourceType, indicatorCode);
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/model/FavoriteIndicator.java
@@ -15,6 +15,7 @@ public class FavoriteIndicator {
     private final FavoriteIndicatorSourceType sourceType;
     private final String indicatorCode;
     private final FavoriteDisplayMode displayMode;
+    private final Integer priority;
     private final LocalDateTime createdAt;
 
     public FavoriteIndicator(Long id,
@@ -22,23 +23,32 @@ public class FavoriteIndicator {
                              FavoriteIndicatorSourceType sourceType,
                              String indicatorCode,
                              FavoriteDisplayMode displayMode,
+                             Integer priority,
                              LocalDateTime createdAt) {
         this.id = id;
         this.userId = userId;
         this.sourceType = sourceType;
         this.indicatorCode = indicatorCode;
         this.displayMode = displayMode != null ? displayMode : FavoriteDisplayMode.INDICATOR;
+        this.priority = priority;
         this.createdAt = createdAt;
     }
 
+    /**
+     * 신규 관심지표 생성. priority는 SQL이 산출하므로 도메인에서는 null로 둔다.
+     */
     public static FavoriteIndicator create(Long userId,
                                            FavoriteIndicatorSourceType sourceType,
                                            String indicatorCode) {
         return new FavoriteIndicator(null, userId, sourceType, indicatorCode,
-                FavoriteDisplayMode.INDICATOR, LocalDateTime.now());
+                FavoriteDisplayMode.INDICATOR, null, LocalDateTime.now());
     }
 
     public FavoriteIndicator changeDisplayMode(FavoriteDisplayMode newDisplayMode) {
-        return new FavoriteIndicator(id, userId, sourceType, indicatorCode, newDisplayMode, createdAt);
+        return new FavoriteIndicator(id, userId, sourceType, indicatorCode, newDisplayMode, priority, createdAt);
+    }
+
+    public FavoriteIndicator withPriority(Integer newPriority) {
+        return new FavoriteIndicator(id, userId, sourceType, indicatorCode, displayMode, newPriority, createdAt);
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/repository/FavoriteIndicatorRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/domain/repository/FavoriteIndicatorRepository.java
@@ -13,6 +13,14 @@ public interface FavoriteIndicatorRepository {
 
     void save(FavoriteIndicator favoriteIndicator);
 
+    /**
+     * 신규 관심지표를 단일 SQL로 INSERT — priority는 그룹의 MAX(priority)+1로 산출된다.
+     * 호출자는 SQLState 23505 (UNIQUE 위반) 발생 시 1회 retry해야 한다.
+     */
+    void insertWithNextPriority(Long userId,
+                                FavoriteIndicatorSourceType sourceType,
+                                String indicatorCode);
+
     int deleteByUserIdAndSourceTypeAndIndicatorCode(Long userId,
                                                      FavoriteIndicatorSourceType sourceType,
                                                      String indicatorCode);
@@ -25,4 +33,19 @@ public interface FavoriteIndicatorRepository {
                           FavoriteIndicatorSourceType sourceType,
                           String indicatorCode,
                           FavoriteDisplayMode displayMode);
+
+    /**
+     * 일괄 reorder를 위한 잠금 조회. 호출 트랜잭션 안에서 (user_id, sourceType) 그룹을 PESSIMISTIC_WRITE로 잠근다.
+     */
+    List<FavoriteIndicator> findForReorderUpdate(Long userId, FavoriteIndicatorSourceType sourceType);
+
+    /**
+     * (id → 새 priority) 맵을 일괄 적용. flush + clear까지 수행해 후속 read가 stale 결과를 반환하지 않는다.
+     */
+    int bulkUpdatePriority(java.util.Map<Long, Integer> idToPriority);
+
+    /**
+     * Post-write invariant 검증용 priority projection. lock 미사용.
+     */
+    List<Integer> findPriorities(Long userId, FavoriteIndicatorSourceType sourceType);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/config/FavoritePriorityBackfillRunner.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/config/FavoritePriorityBackfillRunner.java
@@ -1,0 +1,121 @@
+package com.thlee.stock.market.stockmarket.favorite.infrastructure.config;
+
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
+import com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence.UserFavoriteIndicatorEntity;
+import com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence.UserFavoriteIndicatorJpaRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 앱 시작 시 priority가 NULL인 user_favorite_indicator 행에 대해
+ * (user_id, source_type) 그룹별로 created_at ASC, id ASC 기준 dense 0..N-1을 부여.
+ * 모든 행이 NOT NULL이면 즉시 종료(idempotent).
+ *
+ * <p>Multi-replica 안전성: Postgres advisory lock(`pg_try_advisory_xact_lock`)으로 backfill을 단일
+ * replica에서만 수행하도록 직렬화한다. lock 획득 실패 시 다른 replica가 backfill 중이라 가정하고
+ * 즉시 skip — 부팅을 차단하지 않는다.
+ *
+ * <p>오류 격리: backfill 도중 예외가 발생해도 ApplicationRunner가 부팅을 차단하지 않도록
+ * try/catch로 격리하고 ERROR 로그만 남긴다. 다음 부팅에서 idempotent하게 재시도된다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FavoritePriorityBackfillRunner implements ApplicationRunner {
+
+    /** Postgres advisory lock key — 본 backfill 작업 전용 상수. 다른 advisory lock과 충돌 회피. */
+    private static final long ADVISORY_LOCK_KEY = 4242042001L;
+
+    private final UserFavoriteIndicatorJpaRepository repository;
+    private final EntityManager entityManager;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            backfillWithLock();
+        } catch (Exception e) {
+            log.error("FAVORITE_PRIORITY_BACKFILL_FAILED next-boot-will-retry", e);
+        }
+    }
+
+    @Transactional
+    protected void backfillWithLock() {
+        if (!tryAcquireAdvisoryLock()) {
+            log.info("FAVORITE_PRIORITY_BACKFILL_SKIPPED reason=advisory-lock-held-by-another-replica");
+            return;
+        }
+        List<UserFavoriteIndicatorEntity> nullRows = repository.findAllWithNullPriority();
+        if (nullRows.isEmpty()) {
+            return;
+        }
+        Map<GroupKey, Integer> nextSlot = collectNextSlotPerGroup(nullRows);
+        Map<Long, Integer> assignments = assignDenseSequence(nullRows, nextSlot);
+        applyAssignments(assignments);
+        log.info("FAVORITE_PRIORITY_BACKFILL_APPLIED rows={}", assignments.size());
+    }
+
+    /**
+     * Postgres `pg_try_advisory_xact_lock`으로 트랜잭션 단위 advisory lock 획득 시도.
+     * 트랜잭션 종료 시 자동 해제. 다른 replica가 같은 키로 잠그고 있으면 false 반환.
+     */
+    private boolean tryAcquireAdvisoryLock() {
+        Object result = entityManager
+            .createNativeQuery("SELECT pg_try_advisory_xact_lock(:key)")
+            .setParameter("key", ADVISORY_LOCK_KEY)
+            .getSingleResult();
+        return Boolean.TRUE.equals(result);
+    }
+
+    private Map<GroupKey, Integer> collectNextSlotPerGroup(List<UserFavoriteIndicatorEntity> nullRows) {
+        Map<GroupKey, Integer> nextSlot = new HashMap<>();
+        for (UserFavoriteIndicatorEntity row : nullRows) {
+            GroupKey key = new GroupKey(row.getUserId(), row.getSourceType());
+            nextSlot.computeIfAbsent(key, this::resolveStartingPriority);
+        }
+        return nextSlot;
+    }
+
+    private Integer resolveStartingPriority(GroupKey key) {
+        Query q = entityManager.createQuery(
+            "SELECT COALESCE(MAX(e.priority), -1) + 1 FROM UserFavoriteIndicatorEntity e " +
+            "WHERE e.userId = :userId AND e.sourceType = :sourceType");
+        q.setParameter("userId", key.userId());
+        q.setParameter("sourceType", key.sourceType());
+        Object result = q.getSingleResult();
+        return result == null ? 0 : ((Number) result).intValue();
+    }
+
+    private Map<Long, Integer> assignDenseSequence(List<UserFavoriteIndicatorEntity> nullRows,
+                                                   Map<GroupKey, Integer> nextSlot) {
+        Map<Long, Integer> assignments = new LinkedHashMap<>();
+        for (UserFavoriteIndicatorEntity row : nullRows) {
+            GroupKey key = new GroupKey(row.getUserId(), row.getSourceType());
+            int slot = nextSlot.get(key);
+            assignments.put(row.getId(), slot);
+            nextSlot.put(key, slot + 1);
+        }
+        return assignments;
+    }
+
+    /**
+     * Repository의 chunk CASE WHEN bulk update를 재사용해 N개 개별 UPDATE 라운드트립을
+     * chunk(50개) 단위로 묶어 부팅 지연을 줄인다.
+     */
+    private void applyAssignments(Map<Long, Integer> assignments) {
+        repository.bulkUpdatePriority(assignments);
+    }
+
+    private record GroupKey(Long userId, FavoriteIndicatorSourceType sourceType) {
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/FavoriteIndicatorRepositoryImpl.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,6 +21,13 @@ public class FavoriteIndicatorRepositoryImpl implements FavoriteIndicatorReposit
     @Override
     public void save(FavoriteIndicator favoriteIndicator) {
         jpaRepository.save(mapper.toEntity(favoriteIndicator));
+    }
+
+    @Override
+    public void insertWithNextPriority(Long userId,
+                                       FavoriteIndicatorSourceType sourceType,
+                                       String indicatorCode) {
+        jpaRepository.insertWithNextPriority(userId, sourceType.name(), indicatorCode);
     }
 
     @Override
@@ -49,5 +57,22 @@ public class FavoriteIndicatorRepositoryImpl implements FavoriteIndicatorReposit
                                  String indicatorCode,
                                  FavoriteDisplayMode displayMode) {
         return jpaRepository.updateDisplayMode(userId, sourceType, indicatorCode, displayMode);
+    }
+
+    @Override
+    public List<FavoriteIndicator> findForReorderUpdate(Long userId, FavoriteIndicatorSourceType sourceType) {
+        return jpaRepository.findForReorderUpdate(userId, sourceType).stream()
+            .map(mapper::toDomain)
+            .toList();
+    }
+
+    @Override
+    public int bulkUpdatePriority(Map<Long, Integer> idToPriority) {
+        return jpaRepository.bulkUpdatePriority(idToPriority);
+    }
+
+    @Override
+    public List<Integer> findPriorities(Long userId, FavoriteIndicatorSourceType sourceType) {
+        return jpaRepository.findPrioritiesByUserIdAndSourceType(userId, sourceType);
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorEntity.java
@@ -46,6 +46,15 @@ public class UserFavoriteIndicatorEntity {
     )
     private FavoriteDisplayMode displayMode;
 
+    /**
+     * 표시 우선순위. (user_id, source_type) 그룹 내 dense 0..N-1 시퀀스.
+     * 신규 추가 시 SQL이 MAX(priority)+1로 부여하므로 도메인/Entity 생성 시 null 허용.
+     * UNIQUE 제약은 Entity가 아닌 db/migration SQL이 DEFERRABLE INITIALLY DEFERRED로 관리한다
+     * (Hibernate @UniqueConstraint는 DEFERRABLE 미지원 → 절대 unique=true로 두지 말 것).
+     */
+    @Column(name = "priority")
+    private Integer priority;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -57,12 +66,14 @@ public class UserFavoriteIndicatorEntity {
                                        FavoriteIndicatorSourceType sourceType,
                                        String indicatorCode,
                                        FavoriteDisplayMode displayMode,
+                                       Integer priority,
                                        LocalDateTime createdAt) {
         this.id = id;
         this.userId = userId;
         this.sourceType = sourceType;
         this.indicatorCode = indicatorCode;
         this.displayMode = displayMode;
+        this.priority = priority;
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepository.java
@@ -2,18 +2,49 @@ package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence;
 
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
 import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface UserFavoriteIndicatorJpaRepository extends JpaRepository<UserFavoriteIndicatorEntity, Long> {
+public interface UserFavoriteIndicatorJpaRepository
+    extends JpaRepository<UserFavoriteIndicatorEntity, Long>, UserFavoriteIndicatorJpaRepositoryCustom {
 
-    List<UserFavoriteIndicatorEntity> findByUserId(Long userId);
+    @Query("SELECT e FROM UserFavoriteIndicatorEntity e " +
+           "WHERE e.userId = :userId " +
+           "ORDER BY e.priority ASC NULLS LAST, e.id ASC")
+    List<UserFavoriteIndicatorEntity> findByUserId(@Param("userId") Long userId);
 
-    List<UserFavoriteIndicatorEntity> findByUserIdAndSourceType(Long userId, FavoriteIndicatorSourceType sourceType);
+    @Query("SELECT e FROM UserFavoriteIndicatorEntity e " +
+           "WHERE e.userId = :userId AND e.sourceType = :sourceType " +
+           "ORDER BY e.priority ASC NULLS LAST, e.id ASC")
+    List<UserFavoriteIndicatorEntity> findByUserIdAndSourceType(@Param("userId") Long userId,
+                                                                @Param("sourceType") FavoriteIndicatorSourceType sourceType);
+
+    /**
+     * 일괄 reorder를 위한 잠금 조회. 트랜잭션 안에서 (user_id, source_type) 그룹을 PESSIMISTIC_WRITE로 잠근다.
+     * 후속 bulk update의 UNIQUE DEFERRABLE 충돌을 막고 동시 reorder를 직렬화한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM UserFavoriteIndicatorEntity e " +
+           "WHERE e.userId = :userId AND e.sourceType = :sourceType " +
+           "ORDER BY e.priority ASC NULLS LAST, e.id ASC")
+    List<UserFavoriteIndicatorEntity> findForReorderUpdate(@Param("userId") Long userId,
+                                                           @Param("sourceType") FavoriteIndicatorSourceType sourceType);
+
+    /**
+     * Post-write invariant 검증용 priority 목록 projection. lock 미사용.
+     * 정렬 일관성을 위해 NULLS LAST를 명시한다(H2 등 다른 RDBMS의 NULLS-FIRST 기본값과 차이 회피).
+     */
+    @Query("SELECT e.priority FROM UserFavoriteIndicatorEntity e " +
+           "WHERE e.userId = :userId AND e.sourceType = :sourceType " +
+           "ORDER BY e.priority ASC NULLS LAST, e.id ASC")
+    List<Integer> findPrioritiesByUserIdAndSourceType(@Param("userId") Long userId,
+                                                     @Param("sourceType") FavoriteIndicatorSourceType sourceType);
 
     @Modifying
     @Query("DELETE FROM UserFavoriteIndicatorEntity e " +
@@ -30,4 +61,30 @@ public interface UserFavoriteIndicatorJpaRepository extends JpaRepository<UserFa
                           @Param("sourceType") FavoriteIndicatorSourceType sourceType,
                           @Param("indicatorCode") String indicatorCode,
                           @Param("displayMode") FavoriteDisplayMode displayMode);
+
+    /**
+     * priority가 NULL인 행을 (user_id, source_type, created_at, id) 정렬로 조회.
+     * Bootstrap backfill 전용.
+     */
+    @Query("SELECT e FROM UserFavoriteIndicatorEntity e " +
+           "WHERE e.priority IS NULL " +
+           "ORDER BY e.userId ASC, e.sourceType ASC, e.createdAt ASC, e.id ASC")
+    List<UserFavoriteIndicatorEntity> findAllWithNullPriority();
+
+    /**
+     * 신규 관심지표를 단일 SQL로 INSERT — priority는 동일 (user_id, source_type) 그룹의 MAX(priority)+1로 산출.
+     * READ_COMMITTED isolation에서 SELECT MAX → 별도 INSERT는 race를 못 막으므로 단일 statement로 atomicity 확보.
+     * 동시 트랜잭션이 같은 priority를 도출하면 DEFERRABLE UNIQUE가 commit 시 SQLState 23505로 거부 → 호출자가 1회 retry.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "INSERT INTO user_favorite_indicator " +
+                   "(user_id, source_type, indicator_code, display_mode, priority, created_at) " +
+                   "SELECT :userId, :sourceType, :indicatorCode, 'INDICATOR', " +
+                   "       COALESCE(MAX(priority), -1) + 1, NOW() " +
+                   "FROM user_favorite_indicator " +
+                   "WHERE user_id = :userId AND source_type = :sourceType",
+           nativeQuery = true)
+    int insertWithNextPriority(@Param("userId") Long userId,
+                               @Param("sourceType") String sourceType,
+                               @Param("indicatorCode") String indicatorCode);
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepositoryCustom.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepositoryCustom.java
@@ -1,0 +1,21 @@
+package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence;
+
+import java.util.Map;
+
+/**
+ * 가변 길이 입력에 의존하는 동적 SQL이 필요한 메서드를 분리한 fragment.
+ * Spring Data JPA의 custom-impl 패턴(`*Custom` 인터페이스 + `*Impl` 클래스)으로 main 리포지토리에 자동 합쳐진다.
+ */
+public interface UserFavoriteIndicatorJpaRepositoryCustom {
+
+    /**
+     * 주어진 (id, priority) 쌍에 따라 priority를 일괄 갱신.
+     * Postgres `UNIQUE(user_id, source_type, priority) DEFERRABLE INITIALLY DEFERRED` 가정 하에 mid-tx 중복 priority 허용.
+     * 실제 SQL은 항목 수에 따라 단일 CASE WHEN UPDATE 또는 chunk 분할로 발행된다.
+     * 호출 후 EntityManager L1 cache는 flush + clear되어 후속 invariant 재조회가 stale 결과를 반환하지 않는다.
+     *
+     * @param idToPriority id별 새 priority. 비어있으면 즉시 0 반환.
+     * @return 영향받은 row 수.
+     */
+    int bulkUpdatePriority(Map<Long, Integer> idToPriority);
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/UserFavoriteIndicatorJpaRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.thlee.stock.market.stockmarket.favorite.infrastructure.persistence;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spring Data JPA가 *Impl 접미사로 자동 인식해 main repository에 합치는 custom fragment.
+ * 가변 길이의 (id → priority) 매핑을 동적 native SQL로 발행해 일괄 갱신한다.
+ *
+ * 50개 이상이면 chunk로 분할 — 단일 statement의 파라미터/식 길이 비대화를 피한다.
+ * 5개 이하는 개별 update로 단순화.
+ */
+public class UserFavoriteIndicatorJpaRepositoryImpl implements UserFavoriteIndicatorJpaRepositoryCustom {
+
+    private static final int SMALL_BATCH_THRESHOLD = 5;
+    private static final int CHUNK_SIZE = 50;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public int bulkUpdatePriority(Map<Long, Integer> idToPriority) {
+        if (idToPriority == null || idToPriority.isEmpty()) {
+            return 0;
+        }
+        int affected;
+        if (idToPriority.size() <= SMALL_BATCH_THRESHOLD) {
+            affected = updateOneByOne(idToPriority);
+        } else {
+            affected = updateInChunks(idToPriority);
+        }
+        entityManager.flush();
+        entityManager.clear();
+        return affected;
+    }
+
+    private int updateOneByOne(Map<Long, Integer> idToPriority) {
+        int total = 0;
+        for (Map.Entry<Long, Integer> entry : idToPriority.entrySet()) {
+            Query q = entityManager.createNativeQuery(
+                "UPDATE user_favorite_indicator SET priority = ? WHERE id = ?");
+            q.setParameter(1, entry.getValue());
+            q.setParameter(2, entry.getKey());
+            total += q.executeUpdate();
+        }
+        return total;
+    }
+
+    private int updateInChunks(Map<Long, Integer> idToPriority) {
+        List<Map.Entry<Long, Integer>> entries = new ArrayList<>(idToPriority.entrySet());
+        int total = 0;
+        for (int from = 0; from < entries.size(); from += CHUNK_SIZE) {
+            int to = Math.min(from + CHUNK_SIZE, entries.size());
+            total += executeChunk(entries.subList(from, to));
+        }
+        return total;
+    }
+
+    private int executeChunk(List<Map.Entry<Long, Integer>> chunk) {
+        StringBuilder sql = new StringBuilder("UPDATE user_favorite_indicator SET priority = CASE id");
+        for (int i = 0; i < chunk.size(); i++) {
+            sql.append(" WHEN ?").append(i * 2 + 1).append(" THEN ?").append(i * 2 + 2);
+        }
+        sql.append(" END WHERE id IN (");
+        for (int i = 0; i < chunk.size(); i++) {
+            if (i > 0) {
+                sql.append(", ");
+            }
+            sql.append("?").append(chunk.size() * 2 + i + 1);
+        }
+        sql.append(")");
+
+        Query q = entityManager.createNativeQuery(sql.toString());
+        for (int i = 0; i < chunk.size(); i++) {
+            q.setParameter(i * 2 + 1, chunk.get(i).getKey());
+            q.setParameter(i * 2 + 2, chunk.get(i).getValue());
+        }
+        for (int i = 0; i < chunk.size(); i++) {
+            q.setParameter(chunk.size() * 2 + i + 1, chunk.get(i).getKey());
+        }
+        return q.executeUpdate();
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/infrastructure/persistence/mapper/FavoriteIndicatorMapper.java
@@ -15,6 +15,7 @@ public class FavoriteIndicatorMapper {
             domain.getSourceType(),
             domain.getIndicatorCode(),
             domain.getDisplayMode() != null ? domain.getDisplayMode() : FavoriteDisplayMode.INDICATOR,
+            domain.getPriority(),
             domain.getCreatedAt()
         );
     }
@@ -26,6 +27,7 @@ public class FavoriteIndicatorMapper {
             entity.getSourceType(),
             entity.getIndicatorCode(),
             entity.getDisplayMode() != null ? entity.getDisplayMode() : FavoriteDisplayMode.INDICATOR,
+            entity.getPriority(),
             entity.getCreatedAt()
         );
     }

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/FavoriteIndicatorController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/FavoriteIndicatorController.java
@@ -9,6 +9,7 @@ import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicato
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.EnrichedFavoriteResponse;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteDisplayModeRequest;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteIndicatorResponse;
+import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteOrderRequest;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.FavoriteToggleRequest;
 import com.thlee.stock.market.stockmarket.favorite.presentation.dto.GlobalRefreshResponse;
 import jakarta.validation.Valid;
@@ -95,6 +96,17 @@ public class FavoriteIndicatorController {
         Long userId = getCurrentUserId();
         favoriteIndicatorService.changeDisplayMode(
             userId, request.sourceType(), request.indicatorCode(), request.displayMode());
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 컨테이너 (sourceType × displayMode) 단위 일괄 순서 갱신.
+     */
+    @PutMapping("/order")
+    public ResponseEntity<Void> reorder(@Valid @RequestBody FavoriteOrderRequest request) {
+        Long userId = getCurrentUserId();
+        favoriteIndicatorService.reorder(
+            userId, request.sourceType(), request.displayMode(), request.indicatorCodes());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/FavoriteOrderRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/favorite/presentation/dto/FavoriteOrderRequest.java
@@ -1,0 +1,33 @@
+package com.thlee.stock.market.stockmarket.favorite.presentation.dto;
+
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteDisplayMode;
+import com.thlee.stock.market.stockmarket.favorite.domain.model.FavoriteIndicatorSourceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * 관심지표 일괄 순서 갱신 요청.
+ *
+ * <p>컨테이너 스코프 (sourceType × displayMode) 내 보이는 항목들의 새 순서를 원하는 순으로 담는다.
+ * 서버는 R7 슬롯 보존 알고리즘에 따라 (user_id, sourceType) 그룹 전체를 dense 0..N-1로 재할당한다.
+ *
+ * <p><b>중복 코드 dedup 정책:</b> 같은 코드가 두 번 이상 들어오면 첫 occurrence만 채택, 이후는 silent skip.
+ * 400 거부 대신 last-writer-wins 정책과 일관된 방어적 수용을 한다.
+ *
+ * <p><b>cross-container 코드:</b> 페이로드 안에 다른 sourceType이나 다른 displayMode 항목 코드가 섞이면
+ * R7(a)에 따라 서버가 silent ignore한다(서버 컨테이너에 없는 코드로 취급).
+ */
+public record FavoriteOrderRequest(
+    @NotNull FavoriteIndicatorSourceType sourceType,
+    @NotNull FavoriteDisplayMode displayMode,
+    // MAX_CODES=200: 사용자 단위 컨테이너 카드 상한 추정치(DoS 방지용 페이로드 캡)
+    // 각 String 최대 310자: Entity indicator_code 컬럼 length와 일치
+    @NotEmpty
+    @Size(max = 200, message = "indicatorCodes는 최대 200개까지 허용합니다")
+    List<@NotBlank @Size(max = 310, message = "각 indicatorCode는 310자 이하여야 합니다") String> indicatorCodes
+) {
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/infrastructure/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/infrastructure/web/GlobalExceptionHandler.java
@@ -27,6 +27,8 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -51,6 +53,25 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException e) {
         publishError(e);
         return buildResponse(HttpStatus.BAD_REQUEST, "BAD_REQUEST", e.getMessage());
+    }
+
+    /**
+     * @Valid 위반 (Bean Validation) — 신규/기존 컨트롤러에서 일관된 400 응답 보장.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException e) {
+        publishError(e);
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(fieldError.getField(),
+                fieldError.getDefaultMessage() != null ? fieldError.getDefaultMessage() : "invalid");
+        }
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", "VALIDATION_FAILED");
+        body.put("message", "요청 본문 검증에 실패했습니다.");
+        body.put("fieldErrors", fieldErrors);
+        body.put("timestamp", LocalDateTime.now().toString());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 
     /**

--- a/src/main/resources/db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql
+++ b/src/main/resources/db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql
@@ -1,0 +1,34 @@
+-- user_favorite_indicator.priority 운영 강화: NOT NULL + UNIQUE DEFERRABLE INITIALLY DEFERRED
+--
+-- 적용 순서:
+--   1) issue #42 Phase 자바 배포 (Entity priority 컬럼 nullable 추가 + FavoritePriorityBackfillRunner 실행)
+--   2) Bootstrap이 모든 NULL 행을 (user_id, source_type) 그룹별 dense 0..N-1로 채웠는지 확인
+--      예) SELECT COUNT(*) FROM user_favorite_indicator WHERE priority IS NULL;  -- expect 0
+--   3) 본 SQL 적용 (운영자 수동 psql 실행)
+--   4) (선택) 다음 자바 배포에서 UserFavoriteIndicatorEntity.priority 컬럼을 nullable=false로 격상
+--
+-- 주의:
+-- - DEFERRABLE INITIALLY DEFERRED는 Hibernate @UniqueConstraint로 표현 불가 → SQL로만 관리한다.
+-- - Entity에 unique=true / @UniqueConstraint(columnNames={"user_id","source_type","priority"}) 절대 두지 말 것.
+--   (ddl-auto=update가 NOT DEFERRABLE 중복 constraint를 silent하게 추가해 본 swap-update가 깨진다.)
+-- - Postgres 기본 distinct 동작 가정 — 다중 NULL 허용은 backfill 미완 단계에서만 의미.
+--   Postgres 15+ 환경 업그레이드 시 NULLS NOT DISTINCT 키워드를 도입하지 말 것.
+-- - 본 plan: docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md
+-- - 본 SQL은 단일 트랜잭션으로 적용한다 — 어느 ALTER 하나라도 실패하면 전체 롤백되어
+--   'NOT NULL은 적용되었지만 UNIQUE는 빠진' 어색한 중간 상태를 회피한다.
+--   psql에서 `psql -v ON_ERROR_STOP=1 -f ...`와 함께 적용 권장.
+
+BEGIN;
+
+ALTER TABLE user_favorite_indicator
+    ALTER COLUMN priority SET NOT NULL;
+
+ALTER TABLE user_favorite_indicator
+    DROP CONSTRAINT IF EXISTS user_favorite_indicator_priority_unique;
+
+ALTER TABLE user_favorite_indicator
+    ADD CONSTRAINT user_favorite_indicator_priority_unique
+        UNIQUE (user_id, source_type, priority)
+        DEFERRABLE INITIALLY DEFERRED;
+
+COMMIT;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,6 +6,7 @@
     <title>Stock Market Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
     <link rel="stylesheet" href="/css/custom.css">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" rel="stylesheet">

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -173,6 +173,13 @@ const API = {
         return this.request('PUT', '/api/favorites/display-mode', { sourceType, indicatorCode, displayMode });
     },
 
+    /**
+     * 컨테이너 (sourceType × displayMode) 단위 일괄 순서 갱신.
+     */
+    reorderFavorites(sourceType, displayMode, indicatorCodes) {
+        return this.request('PUT', '/api/favorites/order', { sourceType, displayMode, indicatorCodes });
+    },
+
     getRecentUpdates() {
         return this.request('GET', '/api/economics/indicators/recent-updates');
     },

--- a/src/main/resources/static/js/components/favorite.js
+++ b/src/main/resources/static/js/components/favorite.js
@@ -8,6 +8,19 @@ const FavoriteComponent = {
         loading: false,
     },
 
+    /**
+     * 우선순위 편집 모드 상태.
+     * 한 번에 한 컨테이너만 편집 가능. dirty가 true이면 표시 모드 전환·새로고침 시 confirm 다이얼로그.
+     */
+    favoriteEdit: {
+        active: null,      // null | { sourceType, displayMode, containerId }
+        dirty: false,      // 드래그로 변경된 미저장 순서 존재 여부
+        snapshotIds: [],   // 편집 진입 시점 카드 indicatorCode 순서 (취소용)
+        snapshotKey: null, // snapshot이 어느 컨테이너용인지 검증
+        sortable: null,    // SortableJS 인스턴스
+        saving: false,
+    },
+
     initFavorites() {
         Object.defineProperty(this.favorites, '_set', {
             value: new Set(), writable: true, enumerable: false
@@ -15,6 +28,18 @@ const FavoriteComponent = {
         Object.defineProperty(this.favorites, '_togglePending', {
             value: false, writable: true, enumerable: false
         });
+        // beforeunload 한 번만 등록.
+        if (!this.favorites._beforeunloadAttached) {
+            window.addEventListener('beforeunload', (e) => {
+                if (this.favoriteEdit.dirty) {
+                    e.preventDefault();
+                    e.returnValue = '';
+                }
+            });
+            Object.defineProperty(this.favorites, '_beforeunloadAttached', {
+                value: true, writable: false, enumerable: false
+            });
+        }
     },
 
     async loadFavorites() {
@@ -98,6 +123,174 @@ const FavoriteComponent = {
         const container = document.getElementById(containerId);
         if (!container) return;
         container.scrollBy({ left: direction * 320, behavior: 'smooth' });
+    },
+
+    // ==================== 우선순위 편집 모드 ====================
+    isEditing(sourceType, displayMode) {
+        const a = this.favoriteEdit.active;
+        return a !== null && a.sourceType === sourceType && a.displayMode === displayMode;
+    },
+
+    canEnterEditMode(sourceType, displayMode) {
+        if (this.favoriteEdit.active !== null) return false;
+        const items = this.containerCards(sourceType, displayMode);
+        return items.length >= 2;
+    },
+
+    containerCards(sourceType, displayMode) {
+        const enriched = this.homeSummary?.enrichedFavorites;
+        if (!enriched) return [];
+        const bucket = sourceType === 'ECOS' ? enriched.ecos : enriched.global;
+        if (!Array.isArray(bucket)) return [];
+        if (sourceType === 'GLOBAL' && displayMode === 'GRAPH') {
+            return bucket.filter(c => c.displayMode === 'GRAPH' && !c.failed);
+        }
+        if (displayMode === 'GRAPH') {
+            return bucket.filter(c => c.displayMode === 'GRAPH');
+        }
+        // GLOBAL+INDICATOR: home.html에서 `c.displayMode !== 'GRAPH' || c.failed`(failed GRAPH 카드 fallback 렌더링)
+        // 패턴을 사용하므로 동일 필터를 적용해 향후 INDICATOR 편집 모드 도입 시 snapshotIds 정합성 유지.
+        if (sourceType === 'GLOBAL') {
+            return bucket.filter(c => c.displayMode !== 'GRAPH' || c.failed);
+        }
+        return bucket.filter(c => c.displayMode !== 'GRAPH');
+    },
+
+    enterEditMode(sourceType, displayMode, containerId) {
+        if (!this.canEnterEditMode(sourceType, displayMode)) return;
+        this.favoriteEdit.active = { sourceType, displayMode, containerId };
+        this.favoriteEdit.dirty = false;
+        this.favoriteEdit.snapshotIds = this.containerCards(sourceType, displayMode)
+            .map(c => c.indicatorCode);
+        this.favoriteEdit.snapshotKey = sourceType + '::' + displayMode;
+        this.$nextTick(() => this.attachSortable(containerId));
+    },
+
+    attachSortable(containerId) {
+        const container = document.getElementById(containerId);
+        if (!container || typeof Sortable === 'undefined') return;
+        if (this.favoriteEdit.sortable) {
+            try { this.favoriteEdit.sortable.destroy(); } catch (_) { /* noop */ }
+        }
+        this.favoriteEdit.sortable = Sortable.create(container, {
+            animation: 150,
+            delay: 200,
+            delayOnTouchOnly: true,
+            touchStartThreshold: 5,
+            ghostClass: 'opacity-40',
+            onEnd: (evt) => this.handleSortEnd(evt),
+        });
+    },
+
+    /**
+     * SortableJS onEnd 콜백.
+     *
+     * Alpine x-for + reactive splice 충돌 회피를 위해 revert-then-splice 패턴 사용.
+     * 알고리즘:
+     *  (1) SortableJS가 옮긴 DOM을 즉시 되돌려 Alpine이 reactive array를 source-of-truth로 다시 그리게 한다.
+     *  (2) `containerCards` 결과(현재 컨테이너 카드들의 *pre-revert* 순서)에서 oldIndex → newIndex 로 항목을 재배치한 새 컨테이너 순서를 만든다.
+     *  (3) bucket 내 컨테이너 카드 위치(절대 인덱스)는 그대로 두고, 그 슬롯들에 새 컨테이너 순서를 차례로 다시 채워 넣는다.
+     *      → 다른 displayMode 항목의 절대 위치는 보존되며, 인덱스 보정이 필요 없는 안전한 슬롯-기반 갱신.
+     */
+    handleSortEnd(evt) {
+        if (evt.oldIndex === evt.newIndex) return;
+        const a = this.favoriteEdit.active;
+        if (!a) return;
+        const parent = evt.from;
+        const children = Array.from(parent.children);
+        if (evt.oldIndex < children.length) {
+            parent.insertBefore(evt.item, children[evt.oldIndex] === evt.item ? children[evt.oldIndex + 1] : children[evt.oldIndex]);
+        }
+        const enriched = this.homeSummary?.enrichedFavorites;
+        if (!enriched) return;
+        const bucket = a.sourceType === 'ECOS' ? enriched.ecos : enriched.global;
+        const items = this.containerCards(a.sourceType, a.displayMode);
+        if (evt.oldIndex >= items.length || evt.newIndex >= items.length) return;
+        // (2) 컨테이너 카드들의 새 순서 계산 — splice on copy.
+        const reordered = items.slice();
+        const [moving] = reordered.splice(evt.oldIndex, 1);
+        reordered.splice(evt.newIndex, 0, moving);
+        // (3) bucket 내 컨테이너 슬롯 절대 인덱스 수집 후 새 순서로 채워 넣기.
+        const slots = items.map(card => bucket.indexOf(card)).filter(idx => idx >= 0);
+        if (slots.length !== items.length) return;
+        slots.forEach((slot, i) => { bucket[slot] = reordered[i]; });
+        this.favoriteEdit.dirty = true;
+    },
+
+    async saveOrder() {
+        const a = this.favoriteEdit.active;
+        if (!a || this.favoriteEdit.saving) return;
+        this.favoriteEdit.saving = true;
+        const codes = this.containerCards(a.sourceType, a.displayMode).map(c => c.indicatorCode);
+        try {
+            await API.reorderFavorites(a.sourceType, a.displayMode, codes);
+            this.exitEditMode(true);
+        } catch (e) {
+            console.error('관심지표 순서 저장 실패:', e);
+            alert('순서 저장에 실패했어요. 잠시 후 다시 시도해주세요');
+        } finally {
+            this.favoriteEdit.saving = false;
+        }
+    },
+
+    cancelOrder() {
+        const a = this.favoriteEdit.active;
+        if (!a) return;
+        this.restoreSnapshot();
+        this.exitEditMode(false);
+    },
+
+    /**
+     * 편집 진입 시점의 컨테이너 카드 순서로 되돌린다.
+     *
+     * Slot-based 갱신: 컨테이너 카드들이 점유한 bucket 절대 인덱스 슬롯들에 snapshot 순서로 다시 채워 넣는다.
+     * 다른 컨테이너 항목의 절대 위치는 변경하지 않는다 — handleSortEnd와 동일 패턴이라 cancel/save 동작 일관성 확보.
+     * snapshot에 있던 카드가 그 사이 다른 탭/액션으로 사라졌으면 silent skip(R8 즉시 반영 정책과 정합).
+     */
+    restoreSnapshot() {
+        const a = this.favoriteEdit.active;
+        if (!a) return;
+        if (this.favoriteEdit.snapshotKey !== a.sourceType + '::' + a.displayMode) return;
+        const enriched = this.homeSummary?.enrichedFavorites;
+        if (!enriched) return;
+        const bucket = a.sourceType === 'ECOS' ? enriched.ecos : enriched.global;
+        const items = this.containerCards(a.sourceType, a.displayMode);
+        const slots = items.map(card => bucket.indexOf(card)).filter(idx => idx >= 0);
+        if (slots.length !== items.length) return;
+        const restored = this.favoriteEdit.snapshotIds
+            .map(code => bucket.find(c => c.indicatorCode === code))
+            .filter(c => c !== undefined);
+        // snapshot보다 현재 컨테이너에 항목이 더 적거나 많으면(추가/해제 발생) 가능한 만큼만 복원.
+        const fillCount = Math.min(slots.length, restored.length);
+        for (let i = 0; i < fillCount; i++) {
+            bucket[slots[i]] = restored[i];
+        }
+    },
+
+    exitEditMode(saved) {
+        if (this.favoriteEdit.sortable) {
+            try { this.favoriteEdit.sortable.destroy(); } catch (_) { /* noop */ }
+            this.favoriteEdit.sortable = null;
+        }
+        this.favoriteEdit.active = null;
+        this.favoriteEdit.dirty = false;
+        this.favoriteEdit.snapshotIds = [];
+        this.favoriteEdit.snapshotKey = null;
+    },
+
+    /**
+     * R8: 표시 모드 전환은 편집 종료를 트리거한다. dirty이면 confirm.
+     */
+    attemptToggleDisplayMode(card, sourceType) {
+        const a = this.favoriteEdit.active;
+        if (a && this.favoriteEdit.dirty) {
+            const ok = confirm('저장하지 않은 순서 변경이 있어요. 폐기하고 표시 모드를 전환할까요?');
+            if (!ok) return;
+            this.cancelOrder();
+        } else if (a) {
+            this.exitEditMode(false);
+        }
+        return this.toggleDisplayMode(card, sourceType);
     },
 
     /**

--- a/src/main/resources/static/partials/home.html
+++ b/src/main/resources/static/partials/home.html
@@ -224,21 +224,33 @@
                                         <span class="text-yellow-400">&#9733;</span> 관심 지표 — 그래프
                                     </p>
                                     <div class="flex gap-1">
-                                        <button @click="scrollFavorites(-1, 'ecos-fav-graph-scroll')"
-                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9664;</button>
-                                        <button @click="scrollFavorites(1, 'ecos-fav-graph-scroll')"
-                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9654;</button>
+                                        <template x-if="!isEditing('ECOS', 'GRAPH')">
+                                            <button @click="enterEditMode('ECOS', 'GRAPH', 'ecos-fav-graph-scroll')"
+                                                    :disabled="!canEnterEditMode('ECOS', 'GRAPH')"
+                                                    title="순서 편집"
+                                                    class="px-2 py-0.5 text-[11px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">순서 편집</button>
+                                        </template>
+                                        <template x-if="isEditing('ECOS', 'GRAPH')">
+                                            <div class="flex gap-1">
+                                                <button @click="saveOrder()"
+                                                        :disabled="favoriteEdit.saving"
+                                                        class="px-2 py-0.5 text-[11px] rounded bg-blue-500 hover:bg-blue-600 disabled:opacity-50 text-white cursor-pointer">저장</button>
+                                                <button @click="cancelOrder()"
+                                                        :disabled="favoriteEdit.saving"
+                                                        class="px-2 py-0.5 text-[11px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">취소</button>
+                                            </div>
+                                        </template>
                                     </div>
                                 </div>
-                                <div id="ecos-fav-graph-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
+                                <div id="ecos-fav-graph-scroll" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                                     <template x-for="card in homeSummary.enrichedFavorites.ecos.filter(c => c.displayMode === 'GRAPH')" :key="card.indicatorCode">
-                                        <div class="snap-start flex-shrink-0 w-[400px] sm:w-[440px]">
+                                        <div>
                                             <div class="bg-white border border-gray-200 rounded-xl p-4 shadow-sm relative">
                                                 <!-- 해제 버튼 -->
                                                 <button @click="removeDashboardFavorite('ECOS', card.indicatorCode)"
                                                         class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
                                                 <!-- 표시 모드 토글 버튼 -->
-                                                <button @click="toggleDisplayMode(card, 'ECOS')"
+                                                <button @click="attemptToggleDisplayMode(card, 'ECOS')"
                                                         :disabled="!!card._displayModePending"
                                                         title="지표로 보기"
                                                         class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">지표</button>
@@ -286,7 +298,7 @@
                                                 <button @click="removeDashboardFavorite('ECOS', card.indicatorCode)"
                                                         class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
                                                 <!-- 표시 모드 토글 버튼 -->
-                                                <button @click="toggleDisplayMode(card, 'ECOS')"
+                                                <button @click="attemptToggleDisplayMode(card, 'ECOS')"
                                                         :disabled="!!card._displayModePending"
                                                         title="그래프로 보기"
                                                         class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">그래프</button>
@@ -355,21 +367,33 @@
                                         <span class="text-yellow-400">&#9733;</span> 관심 지표 — 그래프
                                     </p>
                                     <div class="flex gap-1">
-                                        <button @click="scrollFavorites(-1, 'global-fav-graph-scroll')"
-                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9664;</button>
-                                        <button @click="scrollFavorites(1, 'global-fav-graph-scroll')"
-                                                class="w-7 h-7 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 text-sm cursor-pointer">&#9654;</button>
+                                        <template x-if="!isEditing('GLOBAL', 'GRAPH')">
+                                            <button @click="enterEditMode('GLOBAL', 'GRAPH', 'global-fav-graph-scroll')"
+                                                    :disabled="!canEnterEditMode('GLOBAL', 'GRAPH')"
+                                                    title="순서 편집"
+                                                    class="px-2 py-0.5 text-[11px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">순서 편집</button>
+                                        </template>
+                                        <template x-if="isEditing('GLOBAL', 'GRAPH')">
+                                            <div class="flex gap-1">
+                                                <button @click="saveOrder()"
+                                                        :disabled="favoriteEdit.saving"
+                                                        class="px-2 py-0.5 text-[11px] rounded bg-blue-500 hover:bg-blue-600 disabled:opacity-50 text-white cursor-pointer">저장</button>
+                                                <button @click="cancelOrder()"
+                                                        :disabled="favoriteEdit.saving"
+                                                        class="px-2 py-0.5 text-[11px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">취소</button>
+                                            </div>
+                                        </template>
                                     </div>
                                 </div>
-                                <div id="global-fav-graph-scroll" class="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory" style="scrollbar-width: thin;">
+                                <div id="global-fav-graph-scroll" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                                     <template x-for="card in homeSummary.enrichedFavorites.global.filter(c => c.displayMode === 'GRAPH' && !c.failed)" :key="card.indicatorCode">
-                                        <div class="snap-start flex-shrink-0 w-[400px] sm:w-[440px]">
+                                        <div>
                                             <div class="bg-white border border-gray-200 rounded-xl p-4 shadow-sm relative">
                                                 <!-- 해제 버튼 -->
                                                 <button @click="removeDashboardFavorite('GLOBAL', card.indicatorCode)"
                                                         class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
                                                 <!-- 표시 모드 토글 버튼 -->
-                                                <button @click="toggleDisplayMode(card, 'GLOBAL')"
+                                                <button @click="attemptToggleDisplayMode(card, 'GLOBAL')"
                                                         :disabled="!!card._displayModePending"
                                                         title="지표로 보기"
                                                         class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">지표</button>
@@ -422,7 +446,7 @@
                                                 <button @click="removeDashboardFavorite('GLOBAL', card.indicatorCode)"
                                                         class="absolute top-2 right-2 text-yellow-400 hover:text-yellow-500 cursor-pointer text-lg">&#9733;</button>
                                                 <!-- 표시 모드 토글 버튼 -->
-                                                <button @click="toggleDisplayMode(card, 'GLOBAL')"
+                                                <button @click="attemptToggleDisplayMode(card, 'GLOBAL')"
                                                         :disabled="!!card._displayModePending"
                                                         title="그래프로 보기"
                                                         class="absolute top-2 right-9 px-1.5 py-0.5 text-[10px] rounded bg-gray-100 hover:bg-gray-200 disabled:opacity-50 text-gray-600 cursor-pointer">그래프</button>


### PR DESCRIPTION
## Summary

이슈 #42 대응. 관심지표에 사용자 지정 우선순위 컬럼(`priority` INT)을 도입해 드래그 앤 드롭 reorder UI를 제공하고, GRAPH 표시 모드 컨테이너를 가로 스크롤에서 **1~4열 반응형 그리드**로 전환해 5개 이상 항목을 한 화면에서 비교할 수 있도록 함.

- 백엔드: priority 컬럼 + R7 슬롯 보존 알고리즘(Option B — group-wide dense 재할당) + post-write invariant assertion + DEFERRABLE INITIALLY DEFERRED UNIQUE 제약
- 프론트엔드: SortableJS 1.15.x UMD 도입(본 repo 첫 DnD) + Alpine.js x-for slot-based reorder 패턴
- 운영: 3-phase 마이그레이션 (Entity nullable 추가 → backfill runner → 운영자 수동 SQL)

상세 설계: [`docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md`](docs/plans/2026-05-07-001-feat-watchlist-priority-and-graph-layout-plan.md)
요구사항: [`docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md`](docs/brainstorms/2026-05-06-watchlist-priority-and-graph-layout-requirements.md)

## Approval Gate

본 PR은 CLAUDE.md Approval Gate 3건을 동시에 트리거함. plan Unit 0에서 사용자 승인 받은 뒤 진행:
- Entity 수정 — \`UserFavoriteIndicatorEntity.priority\` 컬럼 추가
- 신규 public API — \`PUT /api/favorites/order\`
- 비즈니스 로직 동작 변경 — \`GET /api/favorites\`(+\`/enriched\`) 응답 정렬 \`priority ASC NULLS LAST, id ASC\`

## Implementation Units

| Unit | 변경 |
|------|------|
| Unit 1 | Entity \`priority\` 컬럼 + \`FavoritePriorityBackfillRunner\` (advisory lock + 부팅 차단 회피) |
| Unit 1.5 | 신규 추가 시 priority 부여 — native INSERT + REQUIRES_NEW 격리 + SQLState 23505 retry |
| Unit 2 | Repository 정렬(\`priority ASC NULLS LAST, id ASC\`) + \`UserFavoriteIndicatorJpaRepositoryImpl\` custom-impl fragment (chunk CASE WHEN bulk update) |
| Unit 3 | 도메인/Mapper priority 전파 (응답 DTO 비노출) |
| Unit 4 | \`FavoriteIndicatorService.reorder\` Option B 알고리즘 + Controller \`PUT /api/favorites/order\` + \`FavoriteOrderRequest\` 검증 |
| Unit 5 | SortableJS UMD + Alpine 편집 모드 상태기계 + slot-based reorder + dirty confirm |
| Unit 6 | GRAPH 컨테이너 1~4열 반응형 그리드 (Tailwind \`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4\`) |

추가 보강: \`MethodArgumentNotValidException\` 글로벌 핸들러 추가 (@Valid 위반 → 400).

## Deployment Sequence (운영자 수동 단계 포함)

3-phase 마이그레이션. 자세한 절차/롤백/검증 SQL은 plan의 **Documentation / Operational Notes** 섹션 참조.

1. PR 머지 후 자바 배포 → \`FavoritePriorityBackfillRunner\`가 NULL 행을 dense 0..N-1로 채움 (idempotent, advisory lock으로 multi-replica race 방지)
2. 운영자가 backfill 완료를 SQL로 검증
   \`\`\`sql
   SELECT COUNT(*) FROM user_favorite_indicator WHERE priority IS NULL;  -- expect 0
   \`\`\`
3. 운영자가 \`psql\`로 마이그레이션 SQL 적용
   \`\`\`bash
   psql -v ON_ERROR_STOP=1 -f db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql
   \`\`\`
4. (선택) 다음 자바 배포에서 \`UserFavoriteIndicatorEntity.priority\` 컬럼을 nullable=false로 격상

## Test Plan

본 repo 정책상 자동 테스트 없음. 다음 dev 환경 수동 시나리오로 검증:

- [ ] **백엔드 unit-level**
  - [ ] 빈 favorite 사용자가 첫 항목 추가 → priority=0 부여 확인
  - [ ] 같은 source_type에 항목 추가 시 priority가 MAX+1로 부여되는지 확인
  - [ ] \`PUT /api/favorites/order\`에 \`indicatorCodes=[]\` 전송 → 400 (Bean Validation)
  - [ ] \`PUT /api/favorites/order\`에 다른 사용자 코드 혼입 → 204 + 본인 행만 reorder
  - [ ] \`PUT /api/favorites/order\`에 다른 source_type 코드 혼입 → 204 + 무시
- [ ] **프론트엔드**
  - [ ] ECOS GRAPH 컨테이너에서 편집 모드 진입 → 카드 드래그 → 저장 → 새로고침 시 순서 유지
  - [ ] 편집 모드에서 드래그 → 취소 → 원래 순서로 복원
  - [ ] 편집 모드 활성 중 표시 모드 토글 시 dirty confirm 다이얼로그
  - [ ] GLOBAL GRAPH 컨테이너 동일 동작 확인
  - [ ] 항목 0~1개 컨테이너에서 편집 버튼 disabled
  - [ ] iOS Safari에서 long-press(200ms) 후 드래그 정상 동작, 일반 페이지 스크롤 유지
- [ ] **반응형 그리드**
  - [ ] Chrome DevTools 너비 1280px 이상 → 4열, 1024px대 → 3열, 640px대 → 2열, 모바일 → 1열
  - [ ] 5개 이상 항목 시 자동 줄바꿈

## Known Limitations (후속 이슈로 분리)

- **키보드 접근성**: SortableJS는 keyboard-driven reorder를 first-class 지원하지 않음. ↑/↓ + Space, aria-live announce는 별도 이슈로 분리
- **Agent-native 챗봇 도메인 인지**: 현재 챗봇이 favorites 컨텍스트를 모름 (\`ChatMode.FAVORITE\` 부재 + tool layer 미존재). 별도 이슈
- **PESSIMISTIC_WRITE의 INSERT race**: \`SELECT FOR UPDATE\`는 기존 행만 잠그고 INSERT를 막지 못함. \`assertGroupInvariant\`은 transition window NULL priority 행에 대해 WARN+skip으로 가드되어 false positive는 회피하나, 동시 INSERT가 reorder와 겹치면 invariant size mismatch 가능 — race 빈도 낮아 본 PR 범위 외
- **외부 HTTP timeout 의존성**: \`enrichGlobalFavorites\`의 카테고리 fetch가 하위 HTTP 클라이언트 timeout에 의존 (본 PR 범위 외)
- **테스트 0건**: CLAUDE.md 정책상 의도적. helper들이 \`private static\` 순수 함수로 분해되어 향후 테스트 도입 시 패키지-private 가시성 조정만 필요

## Post-Deploy Monitoring & Validation

운영 모니터링 키워드 (ELK alert 룰 등록 권장):

| Keyword | Severity | Threshold |
|---|---|---|
| \`FAVORITE_PRIORITY_BACKFILL_APPLIED\` | INFO | 부팅마다 0 또는 1회 (rows>0이면 점검) |
| \`FAVORITE_PRIORITY_BACKFILL_SKIPPED\` | INFO | 다른 replica가 lock 보유 — 정상 |
| \`FAVORITE_PRIORITY_BACKFILL_FAILED\` | ERROR | 1회라도 발생 시 backfill 미완료 점검 |
| \`FAVORITE_INSERT_UNIQUE_RETRY_EXHAUSTED\` | ERROR | 5분 내 3회 이상 — race 폭주 신호 |
| \`FAVORITE_REORDER_INVARIANT_VIOLATION\` | ERROR | 1회라도 발생 시 데이터 무결성 사고 |
| \`FAVORITE_REORDER_INVARIANT_SKIPPED\` | WARN | transition window 한정. backfill 완료 후 발생하면 점검 |
| \`FAVORITE_REORDER_OK\` | INFO | trend 모니터 (rowsUpdated=0 비율) |

운영 SQL invariant runbook 쿼리 (주기 점검 권장):

\`\`\`sql
SELECT user_id, source_type, COUNT(*) AS n, MAX(priority) AS m
FROM user_favorite_indicator
GROUP BY 1, 2
HAVING MAX(priority) <> COUNT(*) - 1 OR MIN(priority) <> 0;
-- expected: 0 rows. 결과 행이 있으면 dense 0..N-1 invariant 위반
\`\`\`

## Documented Learnings (docs/solutions/)

본 PR로 도입한 신규 패턴 4건을 \`docs/solutions/architecture-patterns/\`에 등재:

- \`deferred-unique-constraint-retry-requires-new-2026-05-10.md\` — DEFERRED UNIQUE + REQUIRES_NEW retry 격리
- \`alpine-sortablejs-umd-slot-based-reorder-2026-05-10.md\` — Alpine x-for + SortableJS slot-based reorder
- \`spring-data-jpa-custom-impl-fragment-dynamic-sql-2026-05-10.md\` — \`*Custom\` fragment + chunked CASE WHEN
- \`application-runner-backfill-multi-replica-safety-2026-05-10.md\` — \`pg_try_advisory_xact_lock\` + 부팅 차단 회피