### PR TITLE
fix(frontend): 운영자 로그 빈화면 + 모바일 챗봇 풀스크린 플래시 수정

### DIFF
--- a/src/main/resources/static/js/utils/partial-loader.js
+++ b/src/main/resources/static/js/utils/partial-loader.js
@@ -34,8 +34,12 @@ const PartialLoader = {
 
     async fetchPartial(name, opts = {}) {
         const url = this._buildUrl(name, opts.secured);
+        // /secured-partials/** 는 hasRole(ADMIN) 필요 — STATELESS JWT 인증이라 Authorization 헤더 누락 시 403.
+        const headers = { 'Accept': 'text/html' };
+        const token = typeof localStorage !== 'undefined' ? localStorage.getItem('accessToken') : null;
+        if (token) headers['Authorization'] = 'Bearer ' + token;
         const response = await fetch(url, {
-            headers: { 'Accept': 'text/html' },
+            headers,
             credentials: 'same-origin'
         });
         if (response.status === 401 || response.status === 403) {

--- a/src/main/resources/static/partials/_chat.html
+++ b/src/main/resources/static/partials/_chat.html
@@ -18,7 +18,11 @@
     </button>
 
     <!-- 챗 패널 -->
+    <!-- style="display:none" 초기 인라인 가드: template x-if 로 모바일 진입 시 패널 DOM 이 새로 -->
+    <!-- 마운트되면서 Mobile Safari 에서 x-show+x-cloak 처리 전 fixed inset-0 패널이 한 프레임 -->
+    <!-- 풀스크린 노출되던 회귀 차단. Alpine 의 x-show 가 toggleChat 시 정상 토글. -->
     <div x-show="chat.isOpen"
+         style="display: none;"
          x-transition:enter="transition ease-out duration-200"
          x-transition:enter-start="opacity-0 translate-y-4"
          x-transition:enter-end="opacity-100 translate-y-0"


### PR DESCRIPTION
## Summary

- **운영자 로그 빈화면**: `PartialLoader.fetchPartial`이 `/secured-partials/**` 호출 시 Authorization Bearer 헤더를 누락. STATELESS JWT 환경에서 익명 요청으로 분류되어 403 → 로더가 silent UNAUTHORIZED 처리해 placeholder 를 비워 빈 화면이 나오던 회귀를 수정. `localStorage.accessToken` 이 있으면 항상 헤더 동봉.
- **모바일 챗봇 패널 플래시**: `_chat.html` 이 `currentPage` 기반 `<template x-if>` 로 감싸져 portfolio 진입/새로고침마다 패널 DOM 이 재마운트되는데, 모바일 패널은 `fixed inset-0` 풀스크린이라 Mobile Safari 에서 `x-show + x-cloak` 처리 전 한 프레임 노출됨. 패널 div 에 inline `style="display:none"` 가드를 추가해 Alpine 평가 전에도 항상 hidden 보장.

## Test plan

- [ ] 관리자 계정으로 로그인 → 운영자 로그 메뉴 진입 → 로그 목록 + 필터 + 차트 정상 표시
- [ ] 일반 사용자 계정으로 로그인 → 운영자 로그 메뉴는 사이드바에 노출되지 않음 확인
- [ ] 모바일(또는 DevTools 모바일 뷰)로 포트폴리오 진입 → 챗봇 패널이 자동으로 뜨지 않는지 확인
- [ ] 모바일에서 포트폴리오 새로고침 시 챗 패널 한 프레임 노출 없는지 확인
- [ ] 모바일 챗 버블 탭 → 패널 정상 표시 → 헤더 X 버튼 1회 탭으로 정상 종료 확인
- [ ] 데스크탑 챗봇 드래그/확대 등 기존 동작 회귀 없는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpwyGz8LsyLA56Yc8J1C9m)_