### PR TITLE
fix(security): /secured-partials/** 인가를 AdminGuardInterceptor 화이트리스트로 일원화

### DIFF
--- a/src/main/java/com/thlee/stock/market/stockmarket/infrastructure/security/config/ProdSecurityConfig.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/infrastructure/security/config/ProdSecurityConfig.java
@@ -66,7 +66,9 @@ public class ProdSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/partials/**").permitAll()
 
                 // 보호 partial: admin 전용 마크업 (50GB 임계값·도메인 enum 등 운영 정보 포함)
-                .requestMatchers("/secured-partials/**").hasRole("ADMIN")
+                // 인가는 AdminGuardInterceptor 가 화이트리스트({@code app.logging.admin.user-ids}) 로 처리 —
+                // JWT 의 UserRole enum 에는 ADMIN 이 없으므로 hasRole 사용 불가.
+                .requestMatchers("/secured-partials/**").authenticated()
 
                 // 인증 엔드포인트는 permitAll
                 .requestMatchers("/api/auth/**").permitAll()

--- a/src/main/java/com/thlee/stock/market/stockmarket/logging/infrastructure/config/AdminWebMvcConfig.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/logging/infrastructure/config/AdminWebMvcConfig.java
@@ -11,8 +11,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * 운영자 전용 인터셉터 등록 + {@link AdminProperties} 활성화.
  *
  * <p>{@code /api/admin/logs/**} (운영자 로그 페이지) 와 {@code /api/admin/dashboard/**}
- * (메인 대시보드 운영자 카드) 두 경로에 {@link AdminGuardInterceptor} 를 연결해 Spring Security
- * 체인 이후의 HandlerInterceptor 단계에서 인가를 수행한다.
+ * (메인 대시보드 운영자 카드), {@code /secured-partials/**} (운영 정보 포함 정적 마크업) 세 경로에
+ * {@link AdminGuardInterceptor} 를 연결해 Spring Security 체인 이후의 HandlerInterceptor
+ * 단계에서 인가를 수행한다.
  */
 @Configuration
 @RequiredArgsConstructor
@@ -24,6 +25,6 @@ public class AdminWebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(adminGuardInterceptor)
-                .addPathPatterns("/api/admin/logs/**", "/api/admin/dashboard/**");
+                .addPathPatterns("/api/admin/logs/**", "/api/admin/dashboard/**", "/secured-partials/**");
     }
 }


### PR DESCRIPTION
## Summary

이전 PR #52 의 후속 — 운영자 로그가 여전히 빈 화면이던 원인의 진짜 root cause 수정.

### 진단

| 항목 | 내용 |
|---|---|
| JWT 권한 | `JwtAuthenticationFilter:46` — `ROLE_<UserRole>`. `UserRole` enum 은 `USER`, `SIGNING_USER` 두 개뿐 → JWT 에 절대 `ROLE_ADMIN` 이 들어가지 않음 |
| Admin 식별 | `AdminProperties.userIds` 화이트리스트 (`ADMIN_USER_IDS=...`) |
| API 보호 | `AdminGuardInterceptor` 가 화이트리스트로 체크 — `/api/admin/logs/**`, `/api/admin/dashboard/**` 에만 적용 |
| 회귀 지점 | `ProdSecurityConfig:69` — `/secured-partials/**` 를 `hasRole("ADMIN")` 으로 보호 → **누구도 통과 못 함, 항상 403** → `PartialLoader` 가 silent UNAUTHORIZED 처리해 placeholder 비움 → 빈 화면 |

PR #52 의 `PartialLoader` JWT 헤더 동봉은 필요한 변경이었으나, JWT 안에 `ROLE_ADMIN` 이 없는 한 `hasRole` 은 여전히 false. 즉 PR #52 만으로는 빈 화면 회귀가 풀리지 않음.

### 수정

- `ProdSecurityConfig`: `/secured-partials/**` → `hasRole("ADMIN")` → `authenticated()`
- `AdminWebMvcConfig`: `AdminGuardInterceptor` 적용 경로에 `/secured-partials/**` 추가

API 와 동일한 단일 메커니즘(`AdminProperties.userIds` 화이트리스트)으로 일원화. `AdminGuardInterceptor.afterCompletion` 의 `ADMIN_LOG_ACCESS` audit 도 partial fetch 1건당 1건 발행되어 SOC2 CC6.1 / ISO 27001 A.12.4.3 시그널 보존.

## Test plan

- [ ] 운영자 화이트리스트(`ADMIN_USER_IDS`)에 포함된 계정으로 로그인 → 운영자 로그 메뉴 진입 → 로그 목록 + 필터 + 차트 정상 표시
- [ ] 화이트리스트 미포함 일반 사용자: 사이드바에 운영자 로그 메뉴 노출 안 됨, `/secured-partials/admin-logs.html` 직접 호출 시 403
- [ ] 비로그인 사용자: `/secured-partials/admin-logs.html` 직접 호출 시 401
- [ ] admin 페이지 진입 시 `ADMIN_LOG_ACCESS` business audit 1건 발행 확인 (partial fetch + API 호출 각 1건)
- [ ] 일반 페이지(/portfolio 등) 정상 동작 회귀 없음

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpwyGz8LsyLA56Yc8J1C9m)_