### PR TITLE
fix(glossary): lower(null) bytea 추론으로 발생하던 용어 조회 실패 (#43)

### DIFF
--- a/docs/brainstorms/2026-05-24-glossary-lower-null-bytea-fix.md
+++ b/docs/brainstorms/2026-05-24-glossary-lower-null-bytea-fix.md
@@ -1,0 +1,50 @@
+---
+date: 2026-05-24
+topic: glossary-lower-null-bytea-fix
+issue: 43
+status: fix
+---
+
+# fix: glossary 용어 조회 `lower(bytea)` 실패
+
+## 문제
+
+용어 사전 조회 시 다음 에러로 500 발생:
+
+```
+ERROR: function lower(bytea) does not exist
+Hint: No function matches the given name and argument types. You might need to add explicit type casts.
+```
+
+발생 SQL:
+```sql
+where ... and (? is null or lower(t.name) like lower(?) escape '\')
+```
+
+## 원인
+
+PostgreSQL prepared statement 가 `?` 파라미터의 타입을 결정해야 하는데,
+`(:q IS NULL OR ... LOWER(:q) ...)` 분기에서 `:q` 가 null 인 경우에도 PG 가
+`lower(?)` 호출 식의 인수 타입을 미리 결정. 타입 힌트가 없어 `bytea` 로 추론
+→ `lower(bytea)` 함수를 못 찾아 실패.
+
+## 결정
+
+**Java 측에서 미리 소문자 정규화 + SQL 측은 컬럼만 LOWER**.
+
+1. `LikeEscaper.toContainsPattern()` 가 반환 직전 `.toLowerCase()` 적용 — 패턴 측 정규화
+2. JPQL 에서 `LOWER(:q)` / `LOWER(:definitionQ)` 제거 — 컬럼만 LOWER 유지
+
+검색 의미(R7 대소문자 무시)는 동일하게 보장. 응답 shape / 권한 검증 / 페이지네이션
+모두 변경 없음. 영향 범위는 `GlossaryTermService.list` 경로 한정.
+
+## 검증
+
+- `./gradlew compileJava` BUILD SUCCESSFUL
+- `./gradlew bootRun` 정상 부팅
+- 브라우저 수동 검증: 용어 사전 페이지 조회 정상 동작 확인
+
+## 후속
+
+운영 후속 작업으로 `docs/solutions/` 에 "PG prepared statement + LOWER(:param) null
+타입 추론" 회피 패턴을 정리해 두면 다른 도메인에서 동일 함정 회피 가능.

--- a/docs/plans/2026-05-24-001-fix-glossary-lower-null-bytea-plan.md
+++ b/docs/plans/2026-05-24-001-fix-glossary-lower-null-bytea-plan.md
@@ -1,0 +1,58 @@
+---
+title: "fix: glossary 용어 조회 lower(null) bytea 회피"
+type: fix
+status: completed
+date: 2026-05-24
+origin: docs/brainstorms/2026-05-24-glossary-lower-null-bytea-fix.md
+issue: 43
+---
+
+# fix: glossary 용어 조회 `lower(null)` bytea 회피
+
+## Overview
+
+용어 사전 조회 시 PostgreSQL 이 prepared statement 의 null 파라미터를 `bytea` 로
+추론해 `lower(?)` 호출이 실패하던 문제를 수정. JPQL 패턴 측 `LOWER(:q)` 호출을
+제거하고 application 계층에서 미리 소문자 정규화된 패턴을 넘기는 방식으로 전환.
+
+## Requirements Trace
+
+- R7. 용어명 부분 일치 검색 (대소문자 무시) — 의미 보존, SQL 실행 정상화
+
+## Scope Boundaries
+
+- 검색 결과 의미 변경 없음 (Java `toLowerCase` ↔ PG `LOWER` 결과는 ASCII/한글 입력에서 동일)
+- 응답 shape, 권한 검증, 페이지네이션, 정렬 변경 없음
+- 다른 도메인 영향 없음 (`glossary/` 한정)
+
+## Implementation Units
+
+- [x] **Unit 1: LikeEscaper 가 lowercase 패턴을 반환하도록 수정**
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/glossary/application/support/LikeEscaper.java`
+
+**Approach:**
+- `toContainsPattern()` 반환 직전 `.toLowerCase()` 적용. JavaDoc 에 PG 회피 사유 명시.
+
+- [x] **Unit 2: JPQL 에서 `LOWER(:q)` / `LOWER(:definitionQ)` 제거**
+
+**Files:**
+- Modify: `src/main/java/com/thlee/stock/market/stockmarket/glossary/infrastructure/persistence/GlossaryTermJpaRepository.java`
+
+**Approach:**
+- `findList`/`countList` 두 쿼리에서 `LOWER(:q)` → `:q`, `LOWER(:definitionQ)` → `:definitionQ`
+- 컬럼 측 `LOWER(t.name)` / `LOWER(t.definition)` 는 유지 (PG 함수형 인덱스 도입 시 호환)
+
+## Verification
+
+- `./gradlew compileJava` BUILD SUCCESSFUL
+- `./gradlew bootRun` 정상 부팅 (PID 90368)
+- 브라우저 수동 검증: 용어 사전 조회/검색 정상 동작
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Java `toLowerCase` 와 PG `LOWER` 의 locale 차이 | ASCII/한글 입력에서 동일. Turkish locale 등 코너 케이스는 사용자 입력 범위 밖 |
+| 향후 함수형 인덱스 도입 시 호환성 | 컬럼 측 `LOWER` 유지로 `CREATE INDEX ... ON glossary_term (LOWER(name))` 패턴 그대로 호환 |

--- a/src/main/java/com/thlee/stock/market/stockmarket/glossary/application/support/LikeEscaper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/glossary/application/support/LikeEscaper.java
@@ -21,6 +21,10 @@ public final class LikeEscaper {
      *   <li>null / blank → null 반환 (필터 비활성)</li>
      *   <li>입력 길이 상한 초과 → 앞에서부터 {@link #MAX_QUERY_LENGTH} 자까지만 사용</li>
      *   <li>와일드카드(`\`, `%`, `_`) 이스케이프 후 양쪽에 `%` 둘러쌈 (contains 검색)</li>
+     *   <li>소문자로 정규화 → 대소문자 무시 매칭을 패턴 측에서 보장 (R7).
+     *       JPQL/SQL 측은 {@code LOWER(col) LIKE :pattern ESCAPE '\\'} 형태로 받아야 한다.
+     *       (PostgreSQL prepared statement 가 null 파라미터를 {@code bytea} 로 추론해
+     *       {@code lower(?)} 호출이 실패하는 문제 회피)</li>
      * </ul>
      *
      * @return contains 검색 패턴 또는 {@code null}
@@ -36,7 +40,7 @@ public final class LikeEscaper {
         if (trimmed.length() > MAX_QUERY_LENGTH) {
             trimmed = trimmed.substring(0, MAX_QUERY_LENGTH);
         }
-        return "%" + escapeWildcards(trimmed) + "%";
+        return "%" + escapeWildcards(trimmed).toLowerCase() + "%";
     }
 
     private static String escapeWildcards(String s) {

--- a/src/main/java/com/thlee/stock/market/stockmarket/glossary/infrastructure/persistence/GlossaryTermJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/glossary/infrastructure/persistence/GlossaryTermJpaRepository.java
@@ -43,19 +43,24 @@ public interface GlossaryTermJpaRepository extends JpaRepository<GlossaryTermEnt
     /**
      * 용어 목록 조회. 옵셔널 필터:
      * <ul>
-     *   <li>{@code q} (용어명) — null/blank 면 비활성, 아니면 {@code LOWER(name) LIKE LOWER(:q) ESCAPE '\\'}</li>
+     *   <li>{@code q} (용어명) — null/blank 면 비활성, 아니면 {@code LOWER(name) LIKE :q ESCAPE '\\'}
+     *       ({@code :q} 는 application 계층에서 이미 소문자/와일드카드 escape된 패턴)</li>
      *   <li>{@code definitionQ} — 동일 패턴</li>
      *   <li>{@code categoryId} — null = 비활성, 값 = 일치</li>
      *   <li>{@code uncategorizedOnly} — true 면 categoryId IS NULL</li>
      * </ul>
+     *
+     * <p>주의: 패턴 측에 {@code LOWER(:q)} 를 호출하지 않는다. PostgreSQL prepared statement 가
+     * null 파라미터를 {@code bytea} 로 추론해 {@code lower(?)} 가 실패하기 때문.
+     * 대소문자 무시는 application 계층 {@code LikeEscaper.toContainsPattern()} 에서 이미 보장.
      *
      * <p>정렬은 호출자가 Pageable.Sort 로 주입 (REGISTERED_DESC/REGISTERED_ASC/ALPHA_ASC).
      */
     @Query("""
             SELECT t FROM GlossaryTermEntity t
              WHERE t.userId = :userId
-               AND (:q IS NULL OR LOWER(t.name) LIKE LOWER(:q) ESCAPE '\\')
-               AND (:definitionQ IS NULL OR LOWER(t.definition) LIKE LOWER(:definitionQ) ESCAPE '\\')
+               AND (:q IS NULL OR LOWER(t.name) LIKE :q ESCAPE '\\')
+               AND (:definitionQ IS NULL OR LOWER(t.definition) LIKE :definitionQ ESCAPE '\\')
                AND (
                     (:uncategorizedOnly = TRUE AND t.categoryId IS NULL)
                  OR (:uncategorizedOnly = FALSE AND (:categoryId IS NULL OR t.categoryId = :categoryId))
@@ -73,8 +78,8 @@ public interface GlossaryTermJpaRepository extends JpaRepository<GlossaryTermEnt
     @Query("""
             SELECT COUNT(t) FROM GlossaryTermEntity t
              WHERE t.userId = :userId
-               AND (:q IS NULL OR LOWER(t.name) LIKE LOWER(:q) ESCAPE '\\')
-               AND (:definitionQ IS NULL OR LOWER(t.definition) LIKE LOWER(:definitionQ) ESCAPE '\\')
+               AND (:q IS NULL OR LOWER(t.name) LIKE :q ESCAPE '\\')
+               AND (:definitionQ IS NULL OR LOWER(t.definition) LIKE :definitionQ ESCAPE '\\')
                AND (
                     (:uncategorizedOnly = TRUE AND t.categoryId IS NULL)
                  OR (:uncategorizedOnly = FALSE AND (:categoryId IS NULL OR t.categoryId = :categoryId))


### PR DESCRIPTION
## Summary

용어 사전 조회 시 PostgreSQL 이 prepared statement 의 null 파라미터를 `bytea` 로 추론해 `lower(?)` 호출이 실패하던 문제를 수정합니다.

- 문서:
  - brainstorm: [`docs/brainstorms/2026-05-24-glossary-lower-null-bytea-fix.md`](docs/brainstorms/2026-05-24-glossary-lower-null-bytea-fix.md)
  - plan: [`docs/plans/2026-05-24-001-fix-glossary-lower-null-bytea-plan.md`](docs/plans/2026-05-24-001-fix-glossary-lower-null-bytea-plan.md)

## 에러

```
org.springframework.dao.InvalidDataAccessResourceUsageException:
  JDBC exception executing SQL [ERROR: function lower(bytea) does not exist
  Hint: No function matches the given name and argument types.]
```

발생 SQL (요약):
```sql
where ... and (? is null or lower(t.name) like lower(?) escape '\')
```

## 원인

`(:q IS NULL OR ... LOWER(:q) ...)` 분기에서 `:q` 가 null 이어도 PG 가
`lower(?)` 호출 식의 인수 타입을 미리 결정. 타입 힌트가 없어 `bytea` 로 추론
→ `lower(bytea)` 함수를 못 찾아 실패.

## 수정

**Java 측에서 미리 소문자 정규화 + SQL 측은 컬럼만 LOWER**:

1. `LikeEscaper.toContainsPattern()` 반환 직전 `.toLowerCase()` 적용
2. JPQL `LOWER(:q)` / `LOWER(:definitionQ)` 제거 — 컬럼 측 `LOWER(t.name)` 유지

검색 의미(R7 대소문자 무시)는 동일하게 보장. 응답 shape / 권한 검증 / 페이지네이션
모두 변경 없음. 영향 범위는 `GlossaryTermService.list` 경로 한정.

## Test plan

- [x] `./gradlew compileJava` BUILD SUCCESSFUL
- [x] `./gradlew bootRun` 정상 부팅 (PID 90368)
- [x] 브라우저 수동 검증: 용어 사전 조회/검색 정상 동작 (사용자 확인 완료)

## Post-Deploy Monitoring & Validation

- **로그 쿼리**: `lower(bytea)` 또는 `InvalidDataAccessResourceUsageException` 가 0건임을 24시간 모니터링
- **헬스 신호**: `/api/glossary/terms` 5xx 비율 < 0.1%
- **실패 신호 + 롤백 트리거**: 동일 에러 또는 검색 결과 누락 보고 시 즉시 revert
- **검증 윈도우**: 배포 후 24시간

## Scope Boundaries

- 검색 결과 의미 변경 없음 (Java `toLowerCase` ↔ PG `LOWER` 결과는 ASCII/한글에서 동일)
- 다른 도메인 영향 없음 (`glossary/` 한정)
- 향후 함수형 인덱스(`CREATE INDEX ... (LOWER(name))`) 도입 호환성 유지