### PR TITLE
fix(realestate): 관리자 수동 배치 트리거 프론트 UI 추가 (#41)

### DIFF
--- a/docs/brainstorms/2026-05-24-realestate-admin-batch-trigger-ui-fix.md
+++ b/docs/brainstorms/2026-05-24-realestate-admin-batch-trigger-ui-fix.md
@@ -1,0 +1,33 @@
+---
+date: 2026-05-24
+topic: realestate-admin-batch-trigger-ui-fix
+issue: 41
+status: fix
+---
+
+# fix: realestate 관리자 수동 배치 트리거 프론트 UI 누락
+
+## 문제
+
+PR #57 (`feat(realestate)`)에 **백엔드 + admin guard path** 는 머지됐으나,
+**프론트 UI(api 헬퍼 + 버튼 + 호출 액션)** 가 누락되어 관리자가 화면에서 일배치를
+즉시 실행할 방법이 없음.
+
+확인:
+- 백엔드: `POST /api/admin/realestate/batch/run` (`RealEstateAdminController` +
+  `RealEstateBatchTriggerService` in-flight guard) ✅ main 존재
+- AdminGuardInterceptor path: `/api/admin/realestate/**` ✅ 등록됨
+- 프론트 `api.js` / `realestate.js` / `realestate.html` 어디에도 호출 코드 없음 ❌
+
+## 결정
+
+realestate 페이지 헤더에 **관리자 전용 "지금 동기화" 버튼** 추가:
+- `auth.isAdmin` 으로 노출 가드 (사이드바 admin-logs 메뉴와 동일 패턴)
+- 응답 분기: 202 triggered (성공 메시지) / 409 rejected (경고) / 401·403 (에러)
+- 동시 클릭 방지: `realestate.adminBatch.triggering` flag 로 disabled
+
+## 검증
+
+- 비관리자 계정 로그인 시 버튼 미노출
+- 관리자 클릭 시 202 → "동기화가 시작되었습니다…" 메시지
+- 연속 클릭 / 다른 트리거 중 클릭 → 409 → "다른 배치가 이미 실행 중입니다…"

--- a/docs/plans/2026-05-24-002-fix-realestate-admin-batch-trigger-ui-plan.md
+++ b/docs/plans/2026-05-24-002-fix-realestate-admin-batch-trigger-ui-plan.md
@@ -1,0 +1,49 @@
+---
+title: "fix: realestate 관리자 수동 배치 트리거 프론트 UI 추가"
+type: fix
+status: completed
+date: 2026-05-24
+origin: docs/brainstorms/2026-05-24-realestate-admin-batch-trigger-ui-fix.md
+issue: 41
+---
+
+# fix: realestate 관리자 수동 배치 트리거 프론트 UI 추가
+
+## Overview
+
+PR #57 머지 후 누락된 관리자 수동 배치 트리거 프론트 UI 를 추가. 백엔드/admin guard
+는 변경 없이 frontend 만 수정 (api 헬퍼 + 컴포넌트 액션 + 헤더 버튼/메시지).
+
+## Scope Boundaries
+
+- 백엔드/Controller/Service 변경 없음 (이미 main 에 존재)
+- 다른 도메인 영향 없음
+
+## Implementation Units
+
+- [x] **Unit 1: api.js 에 `triggerRealEstateBatch()` 헬퍼 추가**
+
+`POST /api/admin/realestate/batch/run` 호출. realestate 섹션 끝에 한 줄 추가.
+
+- [x] **Unit 2: realestate.js 에 `triggerRealEstateAdminBatch()` 액션 + 상태 추가**
+
+`realestate.adminBatch = { triggering, message, messageType }` 상태와 토글/응답
+분기(202 triggered / 409 rejected / 401·403 / 기타) 처리.
+
+- [x] **Unit 3: realestate.html 헤더에 관리자 버튼 + 결과 메시지 박스 추가**
+
+`x-show="auth.isAdmin"` 가드, disabled while triggering, success/warning/error
+색상별 메시지 박스(emerald/amber/rose).
+
+## Verification
+
+- 헤더 우측에 "지금 동기화" 버튼이 관리자에게만 표시
+- 클릭 시 disabled 상태로 전환, 응답 후 메시지 박스에 결과 표시
+- 동시/연속 클릭 차단 (frontend triggering flag + backend in-flight guard 양면 가드)
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| 관리자 권한 미부여 사용자가 버튼 노출 회피 후 직접 호출 | 백엔드 `AdminGuardInterceptor` 가 userId 화이트리스트로 가드 (이미 PR #57에서 적용) |
+| 트리거 후 진행 상황 polling 부재 | MVP 한정. 추후 진행 상태/완료 알림은 별도 이터레이션 |

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -658,6 +658,10 @@ const API = {
         if (emdCode) params.set('emdCode', emdCode);
         return this.request('DELETE', `/api/realestate/favorites/regions?${params.toString()}`);
     },
+    // 관리자 전용: 부동산 일배치 수동 트리거 (202 triggered / 409 rejected)
+    triggerRealEstateBatch() {
+        return this.request('POST', '/api/admin/realestate/batch/run');
+    },
 
     // Glossary (개인 용어 사전)
     getGlossaryCategories() {

--- a/src/main/resources/static/js/components/realestate.js
+++ b/src/main/resources/static/js/components/realestate.js
@@ -39,7 +39,43 @@ const RealEstateComponent = {
         // 관심지역
         favorites: [],
         // 비교 지역
-        compareTargets: []
+        compareTargets: [],
+        // 관리자 수동 배치 트리거 상태
+        adminBatch: {
+            triggering: false,
+            message: null,
+            messageType: null  // 'success' | 'warning' | 'error'
+        }
+    },
+
+    /**
+     * 관리자 전용 — 부동산 일배치 수동 트리거.
+     * 응답: 202 triggered (성공) / 409 rejected (다른 배치 in-flight) / 401·403 (권한 없음).
+     */
+    async triggerRealEstateAdminBatch() {
+        if (this.realestate.adminBatch.triggering) return;
+        this.realestate.adminBatch.triggering = true;
+        this.realestate.adminBatch.message = null;
+        try {
+            const res = await API.triggerRealEstateBatch();
+            const at = (res && res.triggeredAt) ? ` (${res.triggeredAt})` : '';
+            this.realestate.adminBatch.message = `동기화가 시작되었습니다${at}. 완료까지 잠시 걸릴 수 있어요.`;
+            this.realestate.adminBatch.messageType = 'success';
+        } catch (e) {
+            const status = e && e.status;
+            if (status === 409) {
+                this.realestate.adminBatch.message = '다른 배치가 이미 실행 중입니다. 잠시 후 다시 시도해 주세요.';
+                this.realestate.adminBatch.messageType = 'warning';
+            } else if (status === 401 || status === 403) {
+                this.realestate.adminBatch.message = '관리자 권한이 필요합니다.';
+                this.realestate.adminBatch.messageType = 'error';
+            } else {
+                this.realestate.adminBatch.message = (e && e.message) || '동기화 요청에 실패했습니다.';
+                this.realestate.adminBatch.messageType = 'error';
+            }
+        } finally {
+            this.realestate.adminBatch.triggering = false;
+        }
     },
 
     initRealEstateCharts() {

--- a/src/main/resources/static/partials/realestate.html
+++ b/src/main/resources/static/partials/realestate.html
@@ -5,10 +5,39 @@
 
     <!-- 헤더 + 관심지역 칩 -->
     <div class="bg-white border border-gray-200 rounded-lg p-4">
-        <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center justify-between mb-3 gap-3 flex-wrap">
             <h2 class="text-lg font-semibold text-gray-800">부동산 시장 데이터</h2>
-            <p class="text-xs text-gray-500">데이터 출처/기준일은 각 카드에 표시됩니다. 판단/추천 정보는 제공하지 않습니다.</p>
+            <div class="flex items-center gap-3 ml-auto">
+                <!-- 관리자 전용: 수동 배치 동기화 -->
+                <button x-show="auth.isAdmin"
+                        @click="triggerRealEstateAdminBatch()"
+                        :disabled="realestate.adminBatch.triggering"
+                        class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded transition disabled:opacity-50 disabled:cursor-not-allowed"
+                        :class="realestate.adminBatch.triggering
+                                ? 'border-gray-300 text-gray-400 bg-gray-50'
+                                : 'border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100'"
+                        title="관리자 전용: 일배치를 즉시 실행합니다.">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5"
+                         :class="realestate.adminBatch.triggering ? 'animate-spin' : ''"
+                         fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    <span x-text="realestate.adminBatch.triggering ? '동기화 중…' : '지금 동기화'"></span>
+                </button>
+                <p class="text-xs text-gray-500">데이터 출처/기준일은 각 카드에 표시됩니다. 판단/추천 정보는 제공하지 않습니다.</p>
+            </div>
         </div>
+
+        <!-- 관리자 트리거 결과 메시지 -->
+        <div x-show="auth.isAdmin && realestate.adminBatch.message"
+             x-cloak
+             class="mb-3 px-3 py-2 text-xs rounded border"
+             :class="{
+                 'bg-emerald-50 border-emerald-200 text-emerald-700': realestate.adminBatch.messageType === 'success',
+                 'bg-amber-50 border-amber-200 text-amber-700': realestate.adminBatch.messageType === 'warning',
+                 'bg-rose-50 border-rose-200 text-rose-700': realestate.adminBatch.messageType === 'error'
+             }"
+             x-text="realestate.adminBatch.message"></div>
 
         <!-- 관심지역 칩 -->
         <div class="flex flex-wrap gap-2 mb-3" x-show="realestate.favorites.length > 0">


### PR DESCRIPTION
## Summary

PR #57 머지 후 누락된 **관리자 수동 동기화 UI**를 보강합니다. 백엔드 (`POST /api/admin/realestate/batch/run`)와 `AdminGuardInterceptor` path는 이미 main에 존재하나, 프론트에서 호출할 경로가 없어 운영자가 일배치를 즉시 실행할 수 없었습니다.

- brainstorm: [`docs/brainstorms/2026-05-24-realestate-admin-batch-trigger-ui-fix.md`](docs/brainstorms/2026-05-24-realestate-admin-batch-trigger-ui-fix.md)
- plan: [`docs/plans/2026-05-24-002-fix-realestate-admin-batch-trigger-ui-plan.md`](docs/plans/2026-05-24-002-fix-realestate-admin-batch-trigger-ui-plan.md)

## 변경

- `api.js`: `triggerRealEstateBatch()` 헬퍼 1개 추가
- `realestate.js`: `triggerRealEstateAdminBatch()` 액션 + `realestate.adminBatch` 상태(triggering/message/messageType)
  - 응답 분기: 202 triggered / 409 rejected / 401·403 / 기타
  - frontend `triggering` flag로 동시 클릭 차단 (backend in-flight guard와 이중 가드)
- `realestate.html` 헤더: `x-show=\"auth.isAdmin\"` "지금 동기화" 버튼 + 결과 메시지 박스 (emerald/amber/rose)

**백엔드 변경 없음.**

## Test plan

- [x] 컴파일 영향 없음 (frontend only)
- [ ] 비관리자 계정: 버튼 미노출 확인
- [ ] 관리자 클릭: 202 → "동기화가 시작되었습니다…" 성공 메시지
- [ ] 연속 클릭 / 다른 트리거 진행 중 클릭: 409 → "다른 배치가 이미 실행 중입니다…" 경고 메시지
- [ ] 권한 없는 사용자가 직접 API 호출 시도: AdminGuardInterceptor가 차단 (이미 PR #57에서 검증)

## Post-Deploy Monitoring & Validation

- 로그 쿼리: `[realestate.admin] manual batch trigger request received`
- 헬스 신호: `/api/admin/realestate/batch/run` 202/409 비율 정상
- 실패 신호: 5xx 발생 또는 비관리자에게 버튼 노출 보고 시 즉시 revert