### PR TITLE
fix(frontend): ensureMounted 미정의 및 realestate.tab null 참조 런타임 에러 수정

### DIFF
--- a/src/main/resources/static/js/utils/partial-loader.js
+++ b/src/main/resources/static/js/utils/partial-loader.js
@@ -75,9 +75,11 @@ const PartialLoader = {
             host.setAttribute('aria-busy', 'false');
             this._retryCount.delete(name);
 
+            // skipDispatch: ensureMounted 경로처럼 호출자가 직접 후속 로직을 이어가는 경우 navigateTo 재dispatch 를 막아 중복 진입 방지.
             const isActive = this._dashboard
                 && this._dashboard.currentPage === name
-                && this._dashboard.bootReady === true;
+                && this._dashboard.bootReady === true
+                && !opts.skipDispatch;
             if (isActive && typeof this._dashboard.navigateTo === 'function') {
                 try { await this._dashboard.navigateTo(name); } catch (e) {
                     console.warn('[partial-loader] navigateTo dispatch after remount failed for ' + name, e);
@@ -119,6 +121,22 @@ const PartialLoader = {
         host.setAttribute('aria-busy', 'true');
         const secured = host.getAttribute('data-secured') === 'true';
         await this.mountPartial(name, host, { secured });
+    },
+
+    /**
+     * navigateTo 진입 시점에 secured partial 이 부트 시 401/403 으로 비어 있을 경우 lazy mount.
+     * - host 가 비어 있으면(data-secured 여부 무관) mountPartial 재호출
+     * - 이미 마운트되어 있으면 no-op
+     * - skipDispatch: true 로 호출해 mountPartial 내부의 navigateTo 재dispatch 를 막음
+     *   (호출자가 후속 데이터 로드를 직접 이어서 실행하므로 중복 진입 방지)
+     */
+    async ensureMounted(name) {
+        const host = document.querySelector('[data-partial="' + name + '"]');
+        if (!host) return;
+        if (host.children.length > 0) return;
+        const secured = host.getAttribute('data-secured') === 'true';
+        host.setAttribute('aria-busy', 'true');
+        await this.mountPartial(name, host, { secured, skipDispatch: true });
     },
 
     _renderErrorCard(host, name, attempt) {

--- a/src/main/resources/static/partials/realestate.html
+++ b/src/main/resources/static/partials/realestate.html
@@ -175,7 +175,7 @@
                  class="text-center text-sm text-gray-500 py-8">
                 <p>데이터가 없습니다.</p>
                 <p class="text-xs text-gray-400 mt-2" x-show="realestate.tab && realestate.tab.nextScheduledAt">
-                    다음 갱신 예정: <span x-text="realestate.tab.nextScheduledAt"></span>
+                    다음 갱신 예정: <span x-text="realestate.tab?.nextScheduledAt"></span>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## 배경
PR #63 머지 후 두 가지 런타임 에러 발생. #63이 `app.js`의 `ensureMounted('admin-logs')` 호출만 포함하고 `partial-loader.js`의 정의를 누락한 것이 원인.

## 에러 1: `PartialLoader.ensureMounted is not a function` (app.js:259)
- `app.js`는 `ensureMounted`를 호출하지만 `partial-loader.js`에 정의가 없었음
- **수정**: working tree에 있던 `ensureMounted` 정의 + 짝이 되는 `mountPartial` `skipDispatch` 처리 커밋

## 에러 2: `Cannot read properties of null (reading 'nextScheduledAt')`
- `realestate.html`의 `x-text="realestate.tab.nextScheduledAt"`가 `realestate.tab` null일 때 throw
- 부모 `x-show` 가드와 무관하게 Alpine이 자식 표현식을 평가하면서 발생
- **수정**: 옵셔널 체이닝 `realestate.tab?.nextScheduledAt`

## 검증
- 런타임 검증 미실시 (앱 재로드 후 콘솔 에러 소멸 확인 권장)