### PR TITLE
fix: 운영자 로그 중복 렌더링 + 포트폴리오 종목분석 컨텍스트/접근제어

### DIFF
--- a/docs/brainstorms/2026-05-24-portfolio-stock-analysis-fix.md
+++ b/docs/brainstorms/2026-05-24-portfolio-stock-analysis-fix.md
@@ -1,0 +1,99 @@
+---
+title: "fix: portfolio stock analysis context and access control"
+date: 2026-05-24
+status: brainstorm
+scope: portfolio, chatbot, stock financial frontend/backend
+---
+
+# fix: portfolio stock analysis context and access control
+
+## Problem
+
+Portfolio 화면의 주식 분석 기능은 두 갈래로 나뉘어 있다.
+
+- 보유 자산 카드의 `재무상세` 슬라이드 패널
+- floating chat의 `종목 분석` 모드
+
+현재 두 기능이 같은 사용자/보유 주식 맥락을 공유하지 않고, 일부 백엔드 호출은 `userId` query parameter를 그대로 신뢰한다. 그 결과 아래 문제가 발생할 수 있다.
+
+1. 인증된 사용자와 요청 `userId`가 다른 경우에도 포트폴리오/챗봇 컨텍스트 조회가 가능할 수 있다.
+2. 챗봇 `종목 분석`은 미국 주식을 프론트에서 선택할 수 있지만 백엔드는 국내 DART 기반 분석만 수행한다.
+3. 챗봇 분석은 포트폴리오 보유 수량, 평단, 투자금, 비중, 손익을 사용하지 않아 "내 보유 주식 분석"으로 보기 어렵다.
+4. 국내 재무상세 패널은 현재 연도를 기본값으로 사용해, 아직 공시 데이터가 없는 연도에서 빈 결과가 기본 노출될 가능성이 높다.
+
+## Current Behavior
+
+### Portfolio API access control
+
+- `PortfolioController.assertUserMatches`는 존재하지만 매도 API 일부에만 적용되어 있다.
+- 포트폴리오 항목 목록, 등록, 수정, 삭제, 매수/납입/뉴스 토글 등의 엔드포인트는 `userId` query parameter를 그대로 서비스에 전달한다.
+- `ChatController`도 `userId` query parameter를 그대로 `ChatRequest`에 담는다.
+
+### Financial detail panel
+
+- 포트폴리오 카드의 `재무상세` 버튼은 `country === 'KR' || country === 'US'`이고 ETF가 아닌 주식에 노출된다.
+- KR은 DART API 메뉴를 사용한다.
+- US는 SEC API 메뉴를 사용한다.
+- 국내 기본 연도는 `new Date().getFullYear()`이다.
+
+### Chat financial analysis
+
+- 프론트는 검색 결과의 국가/거래소 제한 없이 종목을 선택할 수 있다.
+- 백엔드 `ChatContextBuilder`는 `StockFinancialService`와 `ValuationMetricService`를 통해 DART 기반 재무계정/지표/가치평가만 조립한다.
+- 분석 요청에는 `portfolioItemId`가 없고, 보유 자산 정보는 사용하지 않는다.
+
+## Goals
+
+- 인증된 사용자와 요청 `userId` 불일치 시 포트폴리오/챗봇 컨텍스트 접근을 차단한다.
+- 포트폴리오 보유 주식에서 바로 분석을 요청할 수 있도록 보유 종목 컨텍스트를 분석 입력에 포함한다.
+- 국내 주식은 기존 DART 분석을 유지하고, 미국 주식은 SEC 기반 분석 또는 명시적인 미지원 안내 중 하나로 일관되게 처리한다.
+- 국내 재무상세 기본 조회가 공시 데이터가 없는 현재 연도에서 빈 결과로 시작하지 않도록 fallback을 둔다.
+- 기존 정적 프론트 구조(Alpine.js + Tailwind)와 레이어 규칙을 유지한다.
+
+## Non-goals
+
+- 투자 추천 알고리즘을 새로 만든다.
+- 신규 JS 라이브러리를 도입한다.
+- 포트폴리오 Entity 구조를 변경한다.
+- 외부 API 저장소나 캐시 구조를 전면 재설계한다.
+
+## Candidate Approach
+
+### Access control
+
+- `PortfolioController`의 `userId` 기반 엔드포인트에 `@AuthenticationPrincipal Long jwtUserId`를 추가하고 `assertUserMatches(jwtUserId, userId)`를 호출한다.
+- `ChatController`에도 동일한 검증을 추가한다.
+- dev 환경의 anonymous/null principal은 기존 주석 계약대로 건너뛴다.
+
+### Portfolio-aware analysis
+
+- 프론트에서 포트폴리오 보유 주식의 `재무상세` 패널 또는 카드 액션에서 챗봇 FINANCIAL 모드를 열 수 있게 한다.
+- 분석 요청 DTO에는 `portfolioItemId`를 선택적으로 추가한다.
+- 백엔드 FINANCIAL 분석은 `portfolioItemId`가 있으면 `PortfolioService.getItems(userId)` 또는 dedicated 조회를 통해 해당 사용자의 보유 항목인지 검증하고, 보유 컨텍스트를 facts에 추가한다.
+- public API 요청 필드 추가가 필요하므로 approval gate 대상이다.
+
+### Country-specific financial facts
+
+- KR: 기존 DART 기반 facts 유지.
+- US: 이미 존재하는 `SecFinancialService`를 사용해 SEC 재무제표/투자지표 facts를 구성한다.
+- 기타 국가/ETF: 프론트에서 분석 버튼을 숨기거나 백엔드에서 명확한 미지원 안내를 반환한다.
+
+### Financial detail fallback
+
+- 국내 상세 패널 기본 연도를 current year 대신 백엔드가 실제 데이터 있는 연도를 찾는 방식과 맞춘다.
+- 최소 변경으로는 프론트 `getDefaultYear()`를 `currentYear - 1`로 변경하고, 데이터 없음 시 이전 연도 재조회 fallback을 적용한다.
+
+## Risks
+
+- `ChatRequest` 필드 추가는 프론트/백엔드 API 계약 변경이다.
+- SEC facts를 챗봇에 넣으면 prompt 크기가 커질 수 있다.
+- 포트폴리오 API 전체에 인증 검증을 추가하면 dev/prod principal 주입 방식 차이를 반드시 확인해야 한다.
+- DART/SEC 외부 API 실패 시 분석 응답이 지나치게 빈 컨텍스트로 생성될 수 있다.
+
+## Approval Gates
+
+- `ChatRequest`/프론트 `streamChat` 요청 필드 변경은 public API 시그니처 변경에 해당한다.
+- 포트폴리오/챗봇 userId 검증 강화는 비즈니스 동작 변경에 해당한다.
+- US 종목 분석을 SEC로 확장하는 것은 기능 동작 변경에 해당한다.
+
+구현 전 plan 승인 후 진행한다.

--- a/docs/plans/2026-05-24-004-fix-portfolio-stock-analysis-plan.md
+++ b/docs/plans/2026-05-24-004-fix-portfolio-stock-analysis-plan.md
@@ -1,0 +1,123 @@
+---
+title: "fix: portfolio stock analysis context and access control"
+date: 2026-05-24
+status: planned
+origin: docs/brainstorms/2026-05-24-portfolio-stock-analysis-fix.md
+scope: portfolio, chatbot, stock financial frontend/backend
+---
+
+# fix: portfolio stock analysis context and access control
+
+## Summary
+
+Portfolio의 주식 분석 기능을 보유 종목 기준으로 일관되게 동작하도록 수정한다. 우선 `userId` query parameter 신뢰 문제를 막고, 챗봇 `종목 분석`에 보유 주식 컨텍스트를 전달하며, 국내/미국 재무 데이터 경로의 불일치를 정리한다.
+
+## Scope
+
+- `PortfolioController` userId access control 적용 범위 확대
+- `ChatController` userId access control 추가
+- `ChatRequest`에 선택적 `portfolioItemId` 추가
+- 프론트 `streamChat` 요청에 선택적 `portfolioItemId` 전달
+- 포트폴리오 보유 주식에서 챗봇 종목 분석을 바로 시작하는 UI 메서드 추가
+- `ChatContextBuilder`에 보유 주식 컨텍스트 추가
+- FINANCIAL 분석의 KR/US 분기 처리
+- 국내 재무상세 기본 연도/fallback 개선
+
+## Out of Scope
+
+- Entity 생성/수정
+- 신규 JS 라이브러리 도입
+- 투자 판단 모델 신규 설계
+- DART/SEC 외부 API 어댑터 전면 재작성
+
+## Design
+
+### 1. Access Control
+
+- `PortfolioController`의 `@RequestParam Long userId` 엔드포인트에 `@AuthenticationPrincipal Long jwtUserId`를 추가한다.
+- 각 핸들러 시작 지점에서 `assertUserMatches(jwtUserId, userId)`를 호출한다.
+- `ChatController.chat`도 동일하게 `@AuthenticationPrincipal Long jwtUserId`를 받고 요청 `userId`와 비교한다.
+- dev 환경에서 principal이 null이면 기존 방식대로 통과한다.
+
+### 2. Portfolio-aware Chat Analysis
+
+- `ChatRequest`와 `ChatMessageRequest`에 `Long portfolioItemId`를 선택 필드로 추가한다.
+- `API.streamChat` 인자와 request body에 `portfolioItemId`를 추가한다.
+- `ChatComponent` 상태에 `portfolioItemId`를 추가한다.
+- 포트폴리오 주식 카드 또는 재무상세 패널에서 `openChatForPortfolioStockAnalysis(item)` 같은 메서드로 다음 상태를 설정한다.
+  - `chat.isOpen = true`
+  - `chat.chatMode = 'FINANCIAL'`
+  - `chat.stockCode = item.stockDetail.stockCode`
+  - `chat.stockName = item.itemName`
+  - `chat.portfolioItemId = item.id`
+
+### 3. Backend Facts
+
+- `ChatContextBuilder.buildFinancialAnalysis`에서 `portfolioItemId`가 있으면 해당 user의 보유 항목인지 확인한다.
+- 보유 컨텍스트에는 최소 아래 값을 포함한다.
+  - 종목명, 종목코드, 국가, 거래소
+  - 보유 수량
+  - 평균 매수가
+  - 투자 원금 원화 기준
+  - 현재 평가금/손익은 기존 가격 조회가 안정적인 경우에만 포함
+- `stockDetail.country`가 `KR`이면 기존 DART facts를 사용한다.
+- `stockDetail.country`가 `US`이면 `SecFinancialService` facts를 사용한다.
+- `portfolioItemId` 없이 `stockCode`만 들어온 경우는 기존 검색 기반 분석을 유지하되, KR 이외는 미지원 또는 SEC 가능 여부를 명확히 처리한다.
+
+### 4. Frontend Financial Detail Fallback
+
+- 국내 `openStockDetail` 기본 연도는 current year보다 current year - 1을 우선한다.
+- `loadSelectedFinancial`에서 accounts 조회 결과가 비어 있고 기본 연도인 경우, 이전 연도로 1회 fallback한다.
+- fallback 여부를 사용자에게 과도하게 노출하지 않고 결과 기준 연도를 select 값에 반영한다.
+
+### 5. Error and Unsupported Cases
+
+- ETF는 기존처럼 재무상세/분석 대상에서 제외한다.
+- KR/US 외 국가는 분석 버튼을 숨기거나 미지원 안내를 표시한다.
+- 외부 API 실패 시 빈 facts로 투자 의견을 생성하지 않고, 조회 실패 항목을 facts에 명시한다.
+
+## Checklist
+
+- [x] `PortfolioController` access control 적용 범위 확대
+- [x] `ChatController` access control 추가
+- [x] `ChatRequest`/`ChatMessageRequest`에 `portfolioItemId` 추가
+- [x] `API.streamChat` 및 `ChatComponent`에 `portfolioItemId` 전달 추가
+- [x] 포트폴리오 보유 주식에서 FINANCIAL 챗 분석을 시작하는 프론트 액션 추가
+- [x] `ChatContextBuilder`에 보유 주식 facts 추가
+- [x] `ChatContextBuilder`에 KR/US facts 분기 추가
+- [x] 국내 재무상세 기본 연도/fallback 개선
+- [x] code convention 관점에서 긴 메서드 분리 검토
+- [x] 하네스 실행: `scripts/run-harness-checks.sh local-documented`
+- [x] 필요 시 Gradle 테스트 또는 컴파일 검증 실행
+
+## Verification
+
+- 정적 하네스:
+  - `scripts/run-harness-checks.sh local-documented`
+- 백엔드:
+  - `./gradlew test` 또는 최소 `./gradlew compileJava`
+- 프론트:
+  - 포트폴리오 페이지에서 보유 KR 주식 `재무상세` 조회
+  - 보유 KR 주식에서 챗봇 `종목 분석` 요청
+  - 보유 US 주식에서 SEC 상세 조회 및 챗봇 분석 동작 확인
+  - 다른 `userId` query parameter 요청이 운영 인증 환경에서 차단되는지 확인
+
+## Verification Results
+
+- `git diff --check`: pass
+- `./gradlew compileJava`: pass
+- `scripts/run-harness-checks.sh local-documented`: fail
+  - reason: 현재 작업공간이 primary worktree이며, documented workflow 하네스가 linked worktree 실행을 요구한다.
+- `ALLOW_PRIMARY_DOCUMENTED=1 scripts/run-harness-checks.sh local-documented`: pass
+  - reason: 샌드박스의 Git ref lock 생성 제한 때문에 primary documented escape hatch를 명시적으로 사용했다.
+
+## Approval Required Before Work
+
+이 plan은 아래 approval gate를 포함한다.
+
+- public API 요청 필드 추가: `portfolioItemId`
+- `userId` 검증 강화로 인한 동작 변경
+- 미국 주식 챗봇 분석의 SEC facts 추가
+- 포트폴리오 보유 주식 컨텍스트를 LLM 분석 facts에 포함
+
+사용자 승인 후 구현을 시작한다.

--- a/src/main/java/com/thlee/stock/market/stockmarket/chatbot/application/ChatContextBuilder.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/chatbot/application/ChatContextBuilder.java
@@ -13,11 +13,19 @@ import com.thlee.stock.market.stockmarket.portfolio.application.PortfolioAllocat
 import com.thlee.stock.market.stockmarket.portfolio.application.PortfolioService;
 import com.thlee.stock.market.stockmarket.portfolio.application.dto.AllocationResponse;
 import com.thlee.stock.market.stockmarket.portfolio.application.dto.PortfolioItemResponse;
+import com.thlee.stock.market.stockmarket.portfolio.application.dto.StockDetailResponse;
+import com.thlee.stock.market.stockmarket.stock.application.SecFinancialService;
 import com.thlee.stock.market.stockmarket.stock.application.StockFinancialService;
 import com.thlee.stock.market.stockmarket.stock.application.ValuationMetricService;
 import com.thlee.stock.market.stockmarket.stock.application.dto.FinancialAccountResponse;
 import com.thlee.stock.market.stockmarket.stock.application.dto.FinancialIndexResponse;
+import com.thlee.stock.market.stockmarket.stock.application.dto.SecFinancialItemResponse;
+import com.thlee.stock.market.stockmarket.stock.application.dto.SecFinancialStatementResponse;
+import com.thlee.stock.market.stockmarket.stock.application.dto.SecInvestmentMetricResponse;
 import com.thlee.stock.market.stockmarket.stock.application.dto.ValuationMetricResponse;
+import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
+import com.thlee.stock.market.stockmarket.stock.domain.model.Stock;
+import com.thlee.stock.market.stockmarket.stock.domain.service.StockPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -28,6 +36,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -36,9 +45,10 @@ import java.util.concurrent.CompletableFuture;
 public class ChatContextBuilder {
 
     private static final String REPORT_CODE_ANNUAL = "11011";
-    private static final int HISTORY_YEARS = 3;
+    private static final String COUNTRY_KR = "KR";
+    private static final String COUNTRY_US = "US";
     private static final String DEFENSIVE_PROMPT = """
-            당신은 한국 주식 종목 분석 전문가입니다.
+            당신은 주식 종목 분석 전문가입니다.
             분석에 필요한 정보(종목 또는 분석 작업)가 누락되었습니다.
             사용자에게 종목을 선택하고 분석 버튼을 눌러달라고 정중히 안내하세요.
             """;
@@ -46,7 +56,9 @@ public class ChatContextBuilder {
     private final PortfolioService portfolioService;
     private final PortfolioAllocationService portfolioAllocationService;
     private final StockFinancialService stockFinancialService;
+    private final SecFinancialService secFinancialService;
     private final ValuationMetricService valuationMetricService;
+    private final StockPort stockPort;
     private final FinancialAnalysisPromptTemplate promptTemplate;
     private final EcosIndicatorService ecosIndicatorService;
     private final EcosDerivedIndicatorService ecosDerivedIndicatorService;
@@ -91,11 +103,78 @@ public class ChatContextBuilder {
         if (request.analysisTask() == null || request.stockCode() == null || request.stockCode().isBlank()) {
             return DEFENSIVE_PROMPT;
         }
-        String facts = assembleFacts(request.stockCode(), request.analysisTask());
+        FinancialTarget target = resolveFinancialTarget(request);
+        String facts = buildHoldingFacts(target.item()) +
+                assembleFacts(target.stockCode(), request.analysisTask(), target.country());
         return promptTemplate.render(request.analysisTask(), facts);
     }
 
-    private String assembleFacts(String stockCode, AnalysisTask task) {
+    private FinancialTarget resolveFinancialTarget(ChatRequest request) {
+        if (request.portfolioItemId() == null) {
+            return new FinancialTarget(request.stockCode(), inferCountry(request.stockCode()), null);
+        }
+        PortfolioItemResponse item = findPortfolioStock(request.userId(), request.portfolioItemId());
+        return new FinancialTarget(item.getStockDetail().getStockCode(), item.getStockDetail().getCountry(), item);
+    }
+
+    private PortfolioItemResponse findPortfolioStock(Long userId, Long portfolioItemId) {
+        return portfolioService.getItems(userId).stream()
+                .filter(item -> portfolioItemId.equals(item.getId()))
+                .filter(item -> "STOCK".equals(item.getAssetType()))
+                .filter(item -> item.getStockDetail() != null)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("보유 주식 항목을 찾을 수 없습니다."));
+    }
+
+    private String inferCountry(String stockCode) {
+        Optional<Stock> stock = stockPort.findByCode(stockCode);
+        return stock.map(Stock::exchangeCode)
+                .map(this::countryFromExchange)
+                .orElse(null);
+    }
+
+    private String countryFromExchange(ExchangeCode exchangeCode) {
+        return switch (exchangeCode) {
+            case KRX -> COUNTRY_KR;
+            case NAS, NYS, AMS -> COUNTRY_US;
+            default -> null;
+        };
+    }
+
+    private String buildHoldingFacts(PortfolioItemResponse item) {
+        if (item == null || item.getStockDetail() == null) {
+            return "";
+        }
+        StockDetailResponse stock = item.getStockDetail();
+        return """
+                ## 포트폴리오 보유 정보
+                - 보유 항목명: %s
+                - 종목코드: %s
+                - 국가/거래소: %s / %s
+                - 보유 수량: %s
+                - 평균 매수가: %s %s
+                - 투자 원금: %s원
+
+                """.formatted(
+                item.getItemName(),
+                stock.getStockCode(),
+                stock.getCountry(),
+                stock.getExchangeCode(),
+                stock.getQuantity(),
+                stock.getAvgBuyPrice(),
+                stock.getPriceCurrency(),
+                item.getInvestedAmount()
+        );
+    }
+
+    private String assembleFacts(String stockCode, AnalysisTask task, String country) {
+        if (COUNTRY_US.equals(country)) {
+            return assembleSecFacts(stockCode, task);
+        }
+        if (country != null && !COUNTRY_KR.equals(country)) {
+            return "## 지원 범위\n- 현재 챗봇 종목 분석은 국내(KR)와 미국(US) 주식만 지원합니다.\n\n";
+        }
+
         StringBuilder sb = new StringBuilder();
         int effectiveYear = resolveEffectiveYear(stockCode);
 
@@ -110,6 +189,70 @@ public class ChatContextBuilder {
             }
         }
         return sb.toString();
+    }
+
+    private String assembleSecFacts(String ticker, AnalysisTask task) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("## 데이터 출처\n- SEC company facts 기반 미국 주식 재무 데이터\n\n");
+        appendSecStatements(sb, ticker);
+        if (task.categories().contains(FinancialCategory.VALUATION)) {
+            appendSecMetrics(sb, ticker);
+        }
+        return sb.toString();
+    }
+
+    private void appendSecStatements(StringBuilder sb, String ticker) {
+        List<SecFinancialStatementResponse> statements;
+        try {
+            statements = secFinancialService.getFinancialStatements(ticker);
+        } catch (Exception e) {
+            log.warn("SEC 재무제표 조회 실패: ticker={}", ticker, e);
+            sb.append("## SEC 재무제표\n- 조회 실패: ").append(e.getMessage()).append("\n\n");
+            return;
+        }
+        if (statements.isEmpty()) {
+            sb.append("## SEC 재무제표\n- 데이터 없음\n\n");
+            return;
+        }
+        statements.forEach(statement -> appendSecStatement(sb, statement));
+    }
+
+    private void appendSecStatement(StringBuilder sb, SecFinancialStatementResponse statement) {
+        sb.append("## SEC ").append(statement.getStatementType()).append("\n");
+        statement.getItems().forEach(item -> appendSecItem(sb, item));
+        sb.append("\n");
+    }
+
+    private void appendSecItem(StringBuilder sb, SecFinancialItemResponse item) {
+        sb.append("- ").append(item.getLabel()).append(": ");
+        if (item.getValues() == null || item.getValues().isEmpty()) {
+            sb.append("데이터 없음\n");
+            return;
+        }
+        boolean first = true;
+        for (Map.Entry<String, Long> entry : item.getValues().entrySet()) {
+            if (!first) {
+                sb.append(", ");
+            }
+            sb.append(entry.getKey()).append("=").append(entry.getValue());
+            first = false;
+        }
+        sb.append("\n");
+    }
+
+    private void appendSecMetrics(StringBuilder sb, String ticker) {
+        try {
+            List<SecInvestmentMetricResponse> metrics = secFinancialService.getInvestmentMetrics(ticker);
+            sb.append("## SEC 투자지표\n");
+            metrics.forEach(metric -> sb.append("- ").append(metric.getName())
+                    .append(": ").append(metric.getValue() != null ? metric.getValue() : "N/A")
+                    .append(metric.getUnit() != null ? metric.getUnit() : "")
+                    .append(" (").append(metric.getDescription()).append(")\n"));
+            sb.append("\n");
+        } catch (Exception e) {
+            log.warn("SEC 투자지표 조회 실패: ticker={}", ticker, e);
+            sb.append("## SEC 투자지표\n- 조회 실패: ").append(e.getMessage()).append("\n\n");
+        }
     }
 
     private int resolveEffectiveYear(String stockCode) {
@@ -339,6 +482,8 @@ public class ChatContextBuilder {
 
         return sb.toString();
     }
+
+    private record FinancialTarget(String stockCode, String country, PortfolioItemResponse item) {}
 
     private record YearIndices(int year, List<FinancialIndexResponse> indices) {}
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/chatbot/application/dto/ChatRequest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/chatbot/application/dto/ChatRequest.java
@@ -7,6 +7,7 @@ public record ChatRequest(
         String message,
         ChatMode chatMode,
         String stockCode,
+        Long portfolioItemId,
         String indicatorCategory,
         AnalysisTask analysisTask,
         List<ChatMessage> messages

--- a/src/main/java/com/thlee/stock/market/stockmarket/chatbot/application/prompt/FinancialAnalysisPromptTemplate.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/chatbot/application/prompt/FinancialAnalysisPromptTemplate.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 public class FinancialAnalysisPromptTemplate {
 
     private static final String COMMON_HEADER = """
-            당신은 한국 주식 종목 분석 전문가입니다.
+            당신은 주식 종목 분석 전문가입니다.
             아래 '제공된 팩트' 만을 1순위 근거로 사용하세요.
             업종 평균이 필요하면 일반지식으로 추정하되, 추정치임을 반드시 명시하세요.
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/chatbot/presentation/ChatController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/chatbot/presentation/ChatController.java
@@ -7,6 +7,8 @@ import com.thlee.stock.market.stockmarket.chatbot.application.dto.ChatMode;
 import com.thlee.stock.market.stockmarket.chatbot.application.dto.ChatRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,24 +27,34 @@ public class ChatController {
 
     @PostMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> chat(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody ChatMessageRequest request
     ) {
+        assertUserMatches(jwtUserId, userId);
         return chatService.chat(new ChatRequest(
                 userId,
                 request.message(),
                 request.chatMode(),
                 request.stockCode(),
+                request.portfolioItemId(),
                 request.indicatorCategory(),
                 request.analysisTask(),
                 request.messages()
         ));
     }
 
+    private void assertUserMatches(Long jwtUserId, Long requestedUserId) {
+        if (jwtUserId != null && !jwtUserId.equals(requestedUserId)) {
+            throw new AccessDeniedException("요청한 사용자 정보가 인증된 사용자와 일치하지 않습니다.");
+        }
+    }
+
     public record ChatMessageRequest(
             String message,
             ChatMode chatMode,
             String stockCode,
+            Long portfolioItemId,
             String indicatorCategory,
             AnalysisTask analysisTask,
             List<ChatMessage> messages

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/presentation/PortfolioController.java
@@ -49,8 +49,10 @@ public class PortfolioController {
      */
     @PostMapping("/items/stock")
     public ResponseEntity<PortfolioItemResponse> addStockItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody StockItemAddRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addStockItem(
                 userId, request.getItemName(),
                 request.getRegion(), request.getMemo(),
@@ -67,8 +69,10 @@ public class PortfolioController {
      */
     @PostMapping("/items/bond")
     public ResponseEntity<PortfolioItemResponse> addBondItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody BondItemAddRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addBondItem(
                 userId, request.getItemName(), request.getInvestedAmount(),
                 request.getRegion(), request.getMemo(),
@@ -82,8 +86,10 @@ public class PortfolioController {
      */
     @PostMapping("/items/real-estate")
     public ResponseEntity<PortfolioItemResponse> addRealEstateItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody RealEstateItemAddRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addRealEstateItem(
                 userId, request.getItemName(), request.getInvestedAmount(),
                 request.getRegion(), request.getMemo(),
@@ -96,8 +102,10 @@ public class PortfolioController {
      */
     @PostMapping("/items/fund")
     public ResponseEntity<PortfolioItemResponse> addFundItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody FundItemAddRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addFundItem(
                 userId, request.getItemName(), request.getInvestedAmount(),
                 request.getRegion(), request.getMemo(),
@@ -111,8 +119,10 @@ public class PortfolioController {
      */
     @PostMapping("/items/cash")
     public ResponseEntity<PortfolioItemResponse> addCashItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody CashItemAddRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addCashItem(
                 userId, request.getItemName(), request.getInvestedAmount(),
                 request.getRegion(), request.getMemo(),
@@ -128,8 +138,10 @@ public class PortfolioController {
      */
     @PostMapping("/items/general")
     public ResponseEntity<PortfolioItemResponse> addGeneralItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @RequestBody GeneralItemAddRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addGeneralItem(
                 userId, request.getAssetType(), request.getItemName(),
                 request.getInvestedAmount(), request.getRegion(), request.getMemo());
@@ -140,7 +152,10 @@ public class PortfolioController {
      * 포트폴리오 항목 목록 조회
      */
     @GetMapping("/items")
-    public ResponseEntity<List<PortfolioItemResponse>> getItems(@RequestParam Long userId) {
+    public ResponseEntity<List<PortfolioItemResponse>> getItems(
+            @AuthenticationPrincipal Long jwtUserId,
+            @RequestParam Long userId) {
+        assertUserMatches(jwtUserId, userId);
         List<PortfolioItemResponse> responses = portfolioService.getItems(userId);
         return ResponseEntity.ok(responses);
     }
@@ -150,9 +165,11 @@ public class PortfolioController {
      */
     @PutMapping("/items/stock/{itemId}")
     public ResponseEntity<PortfolioItemResponse> updateStockItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody StockItemUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updateStockItem(
                 userId, itemId,
                 request.getItemName(), request.getMemo(),
@@ -169,9 +186,11 @@ public class PortfolioController {
      */
     @PutMapping("/items/bond/{itemId}")
     public ResponseEntity<PortfolioItemResponse> updateBondItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody BondItemUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updateBondItem(
                 userId, itemId,
                 request.getItemName(), request.getInvestedAmount(), request.getMemo(),
@@ -185,9 +204,11 @@ public class PortfolioController {
      */
     @PutMapping("/items/real-estate/{itemId}")
     public ResponseEntity<PortfolioItemResponse> updateRealEstateItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody RealEstateItemUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updateRealEstateItem(
                 userId, itemId,
                 request.getItemName(), request.getInvestedAmount(), request.getMemo(),
@@ -200,9 +221,11 @@ public class PortfolioController {
      */
     @PutMapping("/items/fund/{itemId}")
     public ResponseEntity<PortfolioItemResponse> updateFundItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody FundItemUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updateFundItem(
                 userId, itemId,
                 request.getItemName(), request.getInvestedAmount(), request.getMemo(),
@@ -216,9 +239,11 @@ public class PortfolioController {
      */
     @PutMapping("/items/cash/{itemId}")
     public ResponseEntity<PortfolioItemResponse> updateCashItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody CashItemUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updateCashItem(
                 userId, itemId,
                 request.getItemName(), request.getInvestedAmount(), request.getMemo(),
@@ -233,9 +258,11 @@ public class PortfolioController {
      */
     @PutMapping("/items/general/{itemId}")
     public ResponseEntity<PortfolioItemResponse> updateGeneralItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody GeneralItemUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updateGeneralItem(
                 userId, itemId,
                 request.getItemName(), request.getInvestedAmount(), request.getMemo());
@@ -247,9 +274,11 @@ public class PortfolioController {
      */
     @PostMapping("/items/stock/{itemId}/purchase")
     public ResponseEntity<PortfolioItemResponse> addStockPurchase(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody StockPurchaseRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.addStockPurchase(
                 userId, itemId, request.getQuantity(), request.getPurchasePrice(),
                 request.getInvestedAmountKrw());
@@ -261,8 +290,10 @@ public class PortfolioController {
      */
     @GetMapping("/items/stock/{itemId}/purchases")
     public ResponseEntity<List<StockPurchaseHistoryResponse>> getPurchaseHistories(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId) {
+        assertUserMatches(jwtUserId, userId);
         List<StockPurchaseHistoryResponse> responses = portfolioService.getPurchaseHistories(userId, itemId);
         return ResponseEntity.ok(responses);
     }
@@ -272,10 +303,12 @@ public class PortfolioController {
      */
     @PutMapping("/items/stock/{itemId}/purchases/{historyId}")
     public ResponseEntity<PortfolioItemResponse> updatePurchaseHistory(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @PathVariable Long historyId,
             @RequestBody StockPurchaseHistoryUpdateRequest request) {
+        assertUserMatches(jwtUserId, userId);
         PortfolioItemResponse response = portfolioService.updatePurchaseHistory(
                 userId, itemId, historyId,
                 request.getQuantity(), request.getPurchasePrice(),
@@ -288,9 +321,11 @@ public class PortfolioController {
      */
     @DeleteMapping("/items/stock/{itemId}/purchases/{historyId}")
     public ResponseEntity<Void> deletePurchaseHistory(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @PathVariable Long historyId) {
+        assertUserMatches(jwtUserId, userId);
         portfolioService.deletePurchaseHistory(userId, itemId, historyId);
         return ResponseEntity.noContent().build();
     }
@@ -410,9 +445,11 @@ public class PortfolioController {
      */
     @PostMapping("/items/{itemId}/deposits")
     public ResponseEntity<DepositHistoryResponse> addDeposit(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @Valid @RequestBody DepositRequest request) {
+        assertUserMatches(jwtUserId, userId);
         DepositHistoryResponse response = portfolioService.addDeposit(
                 userId, itemId, request.getDepositDate(), request.getAmount(),
                 request.getUnits(), request.getMemo());
@@ -424,8 +461,10 @@ public class PortfolioController {
      */
     @GetMapping("/items/{itemId}/deposits")
     public ResponseEntity<List<DepositHistoryResponse>> getDepositHistories(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId) {
+        assertUserMatches(jwtUserId, userId);
         List<DepositHistoryResponse> responses = portfolioService.getDepositHistories(userId, itemId);
         return ResponseEntity.ok(responses);
     }
@@ -435,10 +474,12 @@ public class PortfolioController {
      */
     @PutMapping("/items/{itemId}/deposits/{historyId}")
     public ResponseEntity<DepositHistoryResponse> updateDeposit(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @PathVariable Long historyId,
             @Valid @RequestBody DepositRequest request) {
+        assertUserMatches(jwtUserId, userId);
         DepositHistoryResponse response = portfolioService.updateDeposit(
                 userId, itemId, historyId,
                 request.getDepositDate(), request.getAmount(),
@@ -451,9 +492,11 @@ public class PortfolioController {
      */
     @DeleteMapping("/items/{itemId}/deposits/{historyId}")
     public ResponseEntity<Void> deleteDeposit(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @PathVariable Long historyId) {
+        assertUserMatches(jwtUserId, userId);
         portfolioService.deleteDeposit(userId, itemId, historyId);
         return ResponseEntity.noContent().build();
     }
@@ -463,8 +506,10 @@ public class PortfolioController {
      */
     @GetMapping("/items/{itemId}/expected-maturity")
     public ResponseEntity<BigDecimal> getExpectedMaturityAmount(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId) {
+        assertUserMatches(jwtUserId, userId);
         BigDecimal amount = portfolioService.calculateExpectedMaturityAmount(userId, itemId);
         return ResponseEntity.ok(amount);
     }
@@ -474,9 +519,11 @@ public class PortfolioController {
      */
     @PatchMapping("/items/{itemId}/news")
     public ResponseEntity<Void> toggleNews(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestBody PortfolioNewsToggleRequest request) {
+        assertUserMatches(jwtUserId, userId);
         portfolioService.toggleNews(userId, itemId, request.isEnabled());
         return ResponseEntity.noContent().build();
     }
@@ -486,10 +533,12 @@ public class PortfolioController {
      */
     @DeleteMapping("/items/{itemId}")
     public ResponseEntity<Void> deleteItem(
+            @AuthenticationPrincipal Long jwtUserId,
             @RequestParam Long userId,
             @PathVariable Long itemId,
             @RequestParam(required = false, defaultValue = "false") boolean restoreCash,
             @RequestParam(required = false) BigDecimal restoreAmount) {
+        assertUserMatches(jwtUserId, userId);
         portfolioService.deleteItem(userId, itemId, restoreCash, restoreAmount);
         return ResponseEntity.noContent().build();
     }
@@ -498,7 +547,10 @@ public class PortfolioController {
      * 자산 비중 조회
      */
     @GetMapping("/allocation")
-    public ResponseEntity<List<AllocationResponse>> getAllocation(@RequestParam Long userId) {
+    public ResponseEntity<List<AllocationResponse>> getAllocation(
+            @AuthenticationPrincipal Long jwtUserId,
+            @RequestParam Long userId) {
+        assertUserMatches(jwtUserId, userId);
         List<AllocationResponse> responses = portfolioAllocationService.getAllocation(userId);
         return ResponseEntity.ok(responses);
     }

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -411,12 +411,12 @@ const API = {
     },
 
     // ==================== Chat ====================
-    async streamChat(userId, message, chatMode, stockCode, indicatorCategory, analysisTask, messages, onChunk, onDone, onError, signal) {
+    async streamChat(userId, message, chatMode, stockCode, portfolioItemId, indicatorCategory, analysisTask, messages, onChunk, onDone, onError, signal) {
         try {
             const response = await fetch(`${this.baseUrl}/api/chat?userId=${userId}`, {
                 method: 'POST',
                 headers: this.getHeaders(),
-                body: JSON.stringify({ message, chatMode, stockCode, indicatorCategory, analysisTask, messages }),
+                body: JSON.stringify({ message, chatMode, stockCode, portfolioItemId, indicatorCategory, analysisTask, messages }),
                 signal: signal
             });
 

--- a/src/main/resources/static/js/components/chat.js
+++ b/src/main/resources/static/js/components/chat.js
@@ -8,6 +8,7 @@ const ChatComponent = {
         expanded: false,
         chatMode: 'PORTFOLIO',
         stockCode: null,
+        portfolioItemId: null,
         stockName: null,
         stockSearchQuery: '',
         stockSearchResults: [],
@@ -42,6 +43,7 @@ const ChatComponent = {
             this.chat.inputText = '';
             this.chat.isLoading = false;
             this.chat.stockCode = null;
+            this.chat.portfolioItemId = null;
             this.chat.stockName = null;
             this.chat.stockSearchQuery = '';
             this.chat.stockSearchResults = [];
@@ -65,6 +67,7 @@ const ChatComponent = {
     setChatMode(mode) {
         this.chat.chatMode = mode;
         this.chat.stockCode = null;
+        this.chat.portfolioItemId = null;
         this.chat.stockName = null;
         this.chat.stockSearchQuery = '';
         this.chat.stockSearchResults = [];
@@ -86,6 +89,7 @@ const ChatComponent = {
 
     selectChatStock(stock) {
         this.chat.stockCode = stock.stockCode;
+        this.chat.portfolioItemId = null;
         this.chat.stockName = stock.stockName;
         this.chat.stockSearchQuery = '';
         this.chat.stockSearchResults = [];
@@ -93,7 +97,29 @@ const ChatComponent = {
 
     clearChatStock() {
         this.chat.stockCode = null;
+        this.chat.portfolioItemId = null;
         this.chat.stockName = null;
+    },
+
+    openChatForPortfolioStockAnalysis(item) {
+        if (!item || !item.stockDetail || item.stockDetail.subType === 'ETF') return;
+        if (item.stockDetail.country !== 'KR' && item.stockDetail.country !== 'US') return;
+
+        if (this.chat._abortController) {
+            this.chat._abortController.abort();
+        }
+        this.chat.isOpen = true;
+        this.chat.chatMode = 'FINANCIAL';
+        this.chat.stockCode = item.stockDetail.stockCode;
+        this.chat.portfolioItemId = item.id;
+        this.chat.stockName = item.itemName;
+        this.chat.stockSearchQuery = '';
+        this.chat.stockSearchResults = [];
+        this.chat.indicatorCategory = null;
+        this.chat.inputText = '';
+        this.chat.messages = [];
+        this.chat.isLoading = false;
+        this.chat.dragPos = { x: null, y: null };
     },
 
     canRequestAnalysis() {
@@ -162,6 +188,7 @@ const ChatComponent = {
             rawText,
             this.chat.chatMode,
             this.chat.stockCode,
+            this.chat.portfolioItemId,
             this.chat.indicatorCategory,
             analysisTask,
             history,

--- a/src/main/resources/static/js/components/financial.js
+++ b/src/main/resources/static/js/components/financial.js
@@ -286,7 +286,7 @@ const FinancialComponent = {
     },
 
     getDefaultYear() {
-        return String(new Date().getFullYear());
+        return String(new Date().getFullYear() - 1);
     },
 
     async loadFinancialOptions() {
@@ -485,32 +485,11 @@ const FinancialComponent = {
         const thisGeneration = ++this.portfolio._financialRequestGeneration;
         this.portfolio.financialLoading = true;
         try {
-            let result;
-            switch (menu) {
-                case 'accounts':
-                    result = await API.getFinancialAccounts(stockCode, year, reportCode);
-                    break;
-                case 'indices':
-                    result = await API.getFinancialIndices(stockCode, year, reportCode, this.portfolio.financialIndexClass);
-                    break;
-                case 'full-statements':
-                    result = await API.getFullFinancialStatements(stockCode, year, reportCode, this.portfolio.financialFsDiv);
-                    break;
-                case 'stock-quantities':
-                    result = await API.getFinancialStockQuantities(stockCode, year, reportCode);
-                    break;
-                case 'dividends':
-                    result = await API.getFinancialDividends(stockCode, year, reportCode);
-                    break;
-                case 'lawsuits':
-                    result = await API.getLawsuits(stockCode, year + '0101', year + '1231');
-                    break;
-                case 'private-fund':
-                    result = await API.getPrivateFundUsages(stockCode, year, reportCode);
-                    break;
-                case 'public-fund':
-                    result = await API.getPublicFundUsages(stockCode, year, reportCode);
-                    break;
+            let result = await this.fetchSelectedFinancial(menu, stockCode, year, reportCode);
+            if (this.shouldFallbackFinancialYear(result, year)) {
+                const fallbackYear = String(Number(year) - 1);
+                result = await this.fetchSelectedFinancial(menu, stockCode, fallbackYear, reportCode);
+                this.portfolio.financialYear = fallbackYear;
             }
             if (thisGeneration !== this.portfolio._financialRequestGeneration) return;
             this.portfolio.financialResult = result || [];
@@ -528,6 +507,34 @@ const FinancialComponent = {
                 }
             }
         }
+    },
+
+    async fetchSelectedFinancial(menu, stockCode, year, reportCode) {
+        switch (menu) {
+            case 'accounts':
+                return API.getFinancialAccounts(stockCode, year, reportCode);
+            case 'indices':
+                return API.getFinancialIndices(stockCode, year, reportCode, this.portfolio.financialIndexClass);
+            case 'full-statements':
+                return API.getFullFinancialStatements(stockCode, year, reportCode, this.portfolio.financialFsDiv);
+            case 'stock-quantities':
+                return API.getFinancialStockQuantities(stockCode, year, reportCode);
+            case 'dividends':
+                return API.getFinancialDividends(stockCode, year, reportCode);
+            case 'lawsuits':
+                return API.getLawsuits(stockCode, year + '0101', year + '1231');
+            case 'private-fund':
+                return API.getPrivateFundUsages(stockCode, year, reportCode);
+            case 'public-fund':
+                return API.getPublicFundUsages(stockCode, year, reportCode);
+            default:
+                return [];
+        }
+    },
+
+    shouldFallbackFinancialYear(result, year) {
+        const defaultYear = this.getDefaultYear();
+        return year === defaultYear && Array.isArray(result) && result.length === 0;
     },
 
     // === SEC (해외주식) 재무제표 ===

--- a/src/main/resources/static/partials/portfolio-deposit-financial.html
+++ b/src/main/resources/static/partials/portfolio-deposit-financial.html
@@ -139,17 +139,6 @@
                 </div>
             </div>
 
-            <!-- ========== SALARY USAGE RATIO (partial) ========== -->
-            <div data-partial="salary" aria-busy="true" aria-live="polite"></div>
-
-            <!-- ========== NEWS JOURNAL (partial) ========== -->
-            <div data-partial="news-journal" aria-busy="true" aria-live="polite"></div>
-
-
-            <!-- ========== ADMIN LOGS (partial, secured) ========== -->
-            <div data-partial="admin-logs" data-secured="true" aria-busy="true" aria-live="polite"></div>
-
-
             <!-- Payload 모달 -->
             <div x-show="adminLogs.modal.open" x-cloak
                  class="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center p-4"

--- a/src/main/resources/static/partials/portfolio.html
+++ b/src/main/resources/static/partials/portfolio.html
@@ -166,6 +166,9 @@
                                                                 <button x-show="item.assetType === 'STOCK' && (item.stockDetail?.country === 'KR' || item.stockDetail?.country === 'US') && item.stockDetail?.subType !== 'ETF'"
                                                                     @click.stop="openStockDetail(item)"
                                                                     class="text-xs text-indigo-600 hover:text-indigo-800 font-medium transition">재무상세 ▸</button>
+                                                                <button x-show="item.assetType === 'STOCK' && (item.stockDetail?.country === 'KR' || item.stockDetail?.country === 'US') && item.stockDetail?.subType !== 'ETF'"
+                                                                    @click.stop="openChatForPortfolioStockAnalysis(item)"
+                                                                    class="text-xs text-violet-600 hover:text-violet-800 font-medium transition">AI분석</button>
                                                                 <!-- 추가 매수 (주식만) -->
                                                                 <button x-show="item.assetType === 'STOCK' && item.stockDetail"
                                                                     @click.stop="openPurchaseModal(item)"
@@ -273,6 +276,9 @@
                                                                 <button x-show="item.assetType === 'STOCK' && item.stockDetail?.country === 'US' && item.stockDetail?.subType !== 'ETF'"
                                                                     @click.stop="openStockDetail(item)"
                                                                     class="text-xs text-indigo-600 hover:text-indigo-800 font-medium transition">재무상세 ▸</button>
+                                                                <button x-show="item.assetType === 'STOCK' && item.stockDetail?.country === 'US' && item.stockDetail?.subType !== 'ETF'"
+                                                                    @click.stop="openChatForPortfolioStockAnalysis(item)"
+                                                                    class="text-xs text-violet-600 hover:text-violet-800 font-medium transition">AI분석</button>
                                                                 <button x-show="item.assetType === 'STOCK' && item.stockDetail"
                                                                     @click.stop="openPurchaseModal(item)"
                                                                     class="text-xs text-emerald-600 hover:text-emerald-800 font-medium transition">추가 매수</button>
@@ -478,4 +484,3 @@
                     </div>
                 </template>
             </div>
-


### PR DESCRIPTION
두 가지 수정을 함께 병합합니다.

## 1. 운영자 로그 탭 중복 렌더링 수정 (4f4abbd)
- `portfolio-deposit-financial.html`에 복붙 오배치된 partial host 3개(`salary`·`news-journal`·`admin-logs`) 제거
- `admin-logs` host가 두 곳에 존재해 `ensureMounted`가 빈 host까지 mount → 화면에 2벌 렌더되던 문제 해결
- 각 host는 `index.html`에 하나씩만 존재하도록 정리

## 2. 포트폴리오 종목분석 컨텍스트 및 접근 제어 (edef2fa)
- `ChatContextBuilder`: 종목분석 컨텍스트 구성 보강
- `ChatController`/`ChatRequest`: 종목분석 요청 연동
- `PortfolioController`: 종목 접근 제어 추가
- `financial.js`/`chat.js`/`portfolio.html`/`api.js`: 프론트 종목분석 연동
- Plan: `docs/plans/2026-05-24-004-fix-portfolio-stock-analysis-plan.md`

## 검증
- admin-logs: 오배치 host 제거 후 각 host 1곳 확인
- 포트폴리오 종목분석: 런타임 검증 미실시 (다른 세션 작성 변경 병합)