### PR TITLE
fix(portfolio): CLOSED 자산 재등록 409 해소 (issue #66)

### DIFF
--- a/docs/brainstorms/2026-05-30-issue-66-portfolio-asset-reregister.md
+++ b/docs/brainstorms/2026-05-30-issue-66-portfolio-asset-reregister.md
@@ -1,0 +1,103 @@
+---
+date: 2026-05-30
+topic: issue-66-portfolio-asset-reregister-409
+origin:
+  - github issue #66
+related_solutions:
+  - docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md
+  - docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md
+---
+
+# CLOSED 자산이 동일 자산 재등록을 409로 막는 문제 (issue #66)
+
+## Problem Frame
+
+전량 매도로 `CLOSED` 상태가 된 포트폴리오 자산이 DB에 남아 있으면,
+동일한 `(user_id, item_name, asset_type)` 조합의 자산을 다시 등록할 때 `409 CONFLICT`가 발생한다.
+
+핵심 불일치:
+
+- **애플리케이션 중복 검사**: `ACTIVE` 항목만 대상 → CLOSED는 통과시킴 (재매수를 새 항목으로 허용하려는 의도)
+- **DB unique 제약**: 상태를 보지 않음 → CLOSED row까지 중복으로 판단
+
+사용자는 화면에서 ACTIVE만 보므로 "등록된 자산 없음" 상태인데도 등록이 실패한다.
+
+## 재현 흐름
+
+1. 자산 등록 → `ACTIVE` row 생성
+2. 전량 매도 → 같은 row가 `CLOSED`로 상태 변경 (row 유지, 매도 이력 보존)
+3. 동일 자산 재등록 시도
+   - 앱 검사 `existsBy...AndStatus(ACTIVE)` → `false` (CLOSED만 존재) → 통과
+   - 새 `ACTIVE` row INSERT 시도
+   - DB `UNIQUE (user_id, item_name, asset_type)` → 기존 CLOSED row와 충돌 → `23505`
+   - `DataIntegrityViolationException` → `GlobalExceptionHandler` → `409 CONFLICT`
+
+## Key Context (코드 근거)
+
+- 엔티티/제약: [PortfolioItemEntity.java:11-18](src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemEntity.java) — `@UniqueConstraint(name="uk_portfolio_item", columnNames={"user_id","item_name","asset_type"})`
+- 상태 enum: [PortfolioItemStatus.java:3-5](src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/model/enums/PortfolioItemStatus.java) — `ACTIVE`, `CLOSED`
+- 앱 중복 검사: [PortfolioService.java:1399-1404](src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java) `validateDuplicate` (호출부: 106, 152, 174, 199, 229, 282)
+- 리포지토리 어댑터: [PortfolioItemRepositoryImpl.java:63-66](src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemRepositoryImpl.java) — `...AndStatus(..., ACTIVE)`
+- 도메인 의도: [PortfolioItemRepository.java:43-46](src/main/java/com/thlee/stock/market/stockmarket/portfolio/domain/repository/PortfolioItemRepository.java) — "재매수는 새 항목으로 등록 가능하도록 CLOSED는 제외"
+- 409 매핑: [GlobalExceptionHandler.java:80-85](src/main/java/com/thlee/stock/market/stockmarket/infrastructure/web/GlobalExceptionHandler.java)
+- DDL 전략: `ddl-auto: update` (dev/prod), PostgreSQL. Flyway 자동 실행 없음 — `db/migration/*.sql`은 운영 수동 적용/백업용. 엔티티 어노테이션이 권위.
+
+## 설계 의도 확정
+
+도메인 주석이 명시한다: **재매수는 기존 CLOSED row를 되살리는 게 아니라 새 ACTIVE row로 등록**한다.
+즉 (user, item, asset_type)별로 **CLOSED는 여러 개 누적 가능, ACTIVE는 최대 1개**가 올바른 불변식이다.
+현재 full unique 제약은 이 불변식보다 과하게 넓다.
+
+## Solution Options
+
+### Option A — Partial unique index `WHERE status = 'ACTIVE'` (추천)
+
+```sql
+CREATE UNIQUE INDEX uk_portfolio_item_active
+    ON portfolio_item (user_id, item_name, asset_type)
+    WHERE status = 'ACTIVE';
+```
+
+- DB 제약을 앱 검사 의도와 정확히 일치시킨다: ACTIVE 최대 1개만 강제, CLOSED는 자유롭게 누적.
+- 재등록 시 CLOSED row가 충돌을 일으키지 않는다.
+- 앱 검사(`existsBy...AndStatus(ACTIVE)`)와 INSERT 사이의 TOCTOU race도 DB가 막아준다 (true 동시 등록은 409가 정답).
+- 본 repo 확립 패턴과 정합: Hibernate `@UniqueConstraint`는 partial(WHERE) 표현 불가 → **엔티티에서 `@UniqueConstraint` 제거** + 수동 SQL 마이그레이션. (제거 안 하면 ddl-auto가 full 제약을 silent 재생성해 swap이 깨짐 — `deferred-unique-constraint` 학습과 동일 함정)
+- 기존 데이터 안전: 현재 full 제약상 조합별 row는 최대 1개 → partial index 생성 시 ACTIVE 중복 충돌 없음 (backfill 불필요).
+- 비용: dev/prod 모두 수동 SQL 적용 필요(ddl-auto는 제약 DROP/partial 생성 불가). 엔티티 어노테이션 제거를 잊으면 안 됨.
+
+### Option B — DB unique 제약 완전 제거, 앱 검사에만 의존
+
+- 가장 단순하나 DB 레벨 무결성 가드 상실. `existsBy` 검사와 INSERT 사이 동시 등록 race에서 ACTIVE 중복 2건 INSERT 가능.
+- 데이터 정합성 후퇴. **기각.**
+
+### Option C — 재등록 시 기존 CLOSED row를 ACTIVE로 되살림(reactivate)
+
+- 제약 자체를 우회(새 row 없음).
+- 그러나 도메인 의도("새 항목으로 등록")와 충돌, 이전 매도 이력 의미가 꼬임. **기각** (단, 제품이 머지 의미를 원하면 Open Question으로).
+
+### Option D — 전량 매도 시 hard-delete (CLOSED 상태 폐기)
+
+- CLOSED는 매도 이력 보존을 위해 의도적으로 도입(issue #32). **기각** — 이력 보존 요구 위반.
+
+## 추천
+
+**Option A**. 앱 의도와 DB 제약을 일치시키는 최소·정공법이며 repo 패턴과 정합한다.
+
+예상 변경 범위:
+
+1. `PortfolioItemEntity.java` — `@Table`의 `@UniqueConstraint(uk_portfolio_item)` 제거 (uniqueConstraints 비움 또는 partial 의도 주석)
+2. `src/main/resources/db/migration/portfolio_item_active_partial_unique.sql` (신규) — 기존 `uk_portfolio_item` DROP + partial unique index 생성, 단일 트랜잭션, 적용 순서/주의 헤더 (favorite SQL 헤더 컨벤션 준수)
+3. 앱 코드 변경 불필요 (`validateDuplicate`는 이미 ACTIVE 한정 — 정상)
+
+## Open Questions / Assumptions
+
+- (확인) `(user, item, asset_type)`당 CLOSED 다수 누적 + ACTIVE 1개가 의도된 불변식인가? — 도메인 주석상 yes로 가정.
+- (확인) 재매수를 기존 CLOSED 되살림이 아니라 새 row로 등록하는 게 맞는가? — 도메인 주석상 yes로 가정 (Option C 기각 근거).
+- partial index 이름 `uk_portfolio_item_active` 컨벤션 OK?
+- prod 적용 시점/절차 — 자바 배포(어노테이션 제거)와 SQL 적용 순서. ddl-auto는 기존 `uk_portfolio_item`을 자동 DROP하지 않으므로 SQL 적용 전까지는 dev/prod 모두 기존 제약이 살아있다(재현 지속). 순서 명시 필요.
+
+## Scope
+
+- 변경: 엔티티 어노테이션 1곳 + 마이그레이션 SQL 1개.
+- 테스트: 명시 요청 시에만 (재등록 happy path + CLOSED 누적 시나리오).
+- plan 단계에서 적용 순서/롤백 SQL 확정.

--- a/docs/plans/2026-05-30-001-fix-portfolio-asset-reregister-409-plan.md
+++ b/docs/plans/2026-05-30-001-fix-portfolio-asset-reregister-409-plan.md
@@ -1,0 +1,156 @@
+---
+title: "fix: CLOSED 자산이 동일 자산 재등록을 409로 막는 문제"
+type: fix
+status: active
+date: 2026-05-30
+issue: 66
+branch: fix/issue-66-portfolio-asset-reregister-409
+origin: docs/brainstorms/2026-05-30-issue-66-portfolio-asset-reregister.md
+---
+
+# fix: CLOSED 자산이 동일 자산 재등록을 409로 막는 문제 (issue #66)
+
+## Overview
+
+`portfolio_item`의 full unique 제약 `UNIQUE(user_id, item_name, asset_type)`을
+**partial unique index `WHERE status = 'ACTIVE'`**로 전환해, 애플리케이션 중복 검사 의도
+(ACTIVE 최대 1개, CLOSED 다수 누적 허용)와 DB 제약을 일치시킨다. (brainstorm Option A)
+
+앱 로직(`validateDuplicate`)은 이미 ACTIVE 한정이므로 **변경하지 않는다**.
+변경은 엔티티 어노테이션 1곳 + 수동 마이그레이션 SQL 1개뿐이다.
+
+## Problem Frame
+
+origin brainstorm의 Problem Frame을 그대로 수용한다.
+재현/원인/설계 의도는 origin 참조. 핵심 불변식: `(user_id, item_name, asset_type)`별 **ACTIVE 최대 1개, CLOSED 무제한**.
+
+## Scope Boundaries
+
+- 비목표: `validateDuplicate` 등 앱 중복검사 로직 변경 (이미 ACTIVE 한정 — 정상).
+- 비목표: CLOSED row 되살림(reactivate) 또는 hard-delete 정책 (brainstorm Option C/D 기각).
+- 비목표: 테스트 신규 작성 — 명시 요청 시에만 (Verification 절의 수동 검증으로 대체).
+- 비목표: 다른 엔티티/제약 변경.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- 엔티티/제약: [PortfolioItemEntity.java:11-22](src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemEntity.java) — `@Table(uniqueConstraints={@UniqueConstraint(name="uk_portfolio_item", ...)})`. JOINED 상속의 부모 테이블 `portfolio_item`에 제약 존재.
+- 앱 중복검사: [PortfolioService.java:1399-1404](src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java) `validateDuplicate` → [PortfolioItemRepositoryImpl.java:63-66](src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemRepositoryImpl.java) `...AndStatus(..., ACTIVE)`. 변경 불필요.
+- 409 매핑: [GlobalExceptionHandler.java:80-85](src/main/java/com/thlee/stock/market/stockmarket/infrastructure/web/GlobalExceptionHandler.java) `DataIntegrityViolationException → 409`.
+- DDL 전략: `ddl-auto: update`(dev/prod), PostgreSQL. Flyway 자동 실행 없음 — `db/migration/*.sql`은 운영자 수동 `psql` 적용/롤백 백업용. 엔티티 어노테이션이 권위.
+- 마이그레이션 SQL 헤더 컨벤션: [user_favorite_indicator_priority_not_null_unique_deferrable.sql](src/main/resources/db/migration/user_favorite_indicator_priority_not_null_unique_deferrable.sql) — 적용 순서/주의/plan 참조 헤더 + 단일 `BEGIN; ... COMMIT;`.
+
+### Institutional Learnings
+
+- [deferred-unique-constraint-retry-requires-new-2026-05-10.md](docs/solutions/architecture-patterns/deferred-unique-constraint-retry-requires-new-2026-05-10.md) — **핵심 함정**: Hibernate가 표현 못하는 제약(DEFERRABLE/partial)은 엔티티 `@UniqueConstraint`를 두면 `ddl-auto=update`가 NOT-special 중복 제약을 silent 재생성해 SQL 관리를 깨뜨린다. → 엔티티에서 제약 어노테이션을 **반드시 제거**.
+- [jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md](docs/solutions/architecture-patterns/jpa-version-passthrough-ddl-auto-not-null-backfill-2026-04-28.md) — 같은 `portfolio_item` 테이블. `ddl-auto=update`는 제약 DROP/특수 인덱스 생성 불가 → 수동 SQL 필수. (status 컬럼 default 컨벤션 출처)
+
+## Key Technical Decisions
+
+- **Partial unique index 채택**: `CREATE UNIQUE INDEX uk_portfolio_item_active ON portfolio_item (user_id, item_name, asset_type) WHERE status = 'ACTIVE'`. 이름은 기존 `uk_*` 컨벤션 + `_active` 접미사.
+- **엔티티에서 `@UniqueConstraint` 제거**: partial(WHERE)은 Hibernate `@UniqueConstraint`로 표현 불가. 어노테이션을 남기면 ddl-auto가 full 제약을 재생성하는 함정(위 learning). `uniqueConstraints` 배열을 비우고, partial index는 SQL로만 관리한다는 주석을 엔티티에 남긴다.
+- **앱 코드 무변경**: `validateDuplicate`는 이미 ACTIVE 한정. partial index는 앱 검사와 INSERT 사이 TOCTOU race(동시 ACTIVE 등록)도 DB가 방어 → 그 경우 409가 정답.
+- **적용 순서(중요)**: 자바 배포(어노테이션 제거) → 그 다음 SQL 적용.
+  - 사유: ddl-auto는 기존 `uk_portfolio_item`을 자동 DROP하지 않는다. 반대 순서(SQL 먼저)면 어노테이션이 남은 구버전 앱이 재기동될 때 ddl-auto가 full 제약을 재생성(silent re-add)할 위험. 어노테이션을 먼저 제거한 버전이 떠 있어야 안전.
+  - dev도 동일: 어노테이션 제거만으로는 기존 DB의 `uk_portfolio_item`이 사라지지 않으므로(ddl-auto는 DROP 안 함), 같은 SQL을 수동 적용하거나 dev 스키마 재생성 필요.
+- **기존 데이터 안전성**: 현재 full 제약상 조합별 row 최대 1개 → partial index 생성 시 ACTIVE 중복 충돌 없음. backfill 불필요.
+- **롤백 제약 명시**: partial index 적용 후 사용자가 새 ACTIVE를 추가하면 (CLOSED + ACTIVE) 중복 조합이 생긴다. 이 시점 이후 full 제약 복원은 실패한다. 롤백은 "재등록 발생 전"에만 무손실. 마이그레이션 헤더에 경고.
+
+## Implementation Units
+
+### Unit 1 — 엔티티 어노테이션 제거
+
+- [ ] [PortfolioItemEntity.java:11-22](src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemEntity.java) `@Table`의 `uniqueConstraints` 제거.
+- [ ] `idx_portfolio_item_user_id` 인덱스(`indexes`)는 유지.
+- [ ] partial unique index는 `db/migration` SQL로만 관리한다는 한국어 주석 추가 (ddl-auto 재생성 함정 경고 포함).
+
+변경 후 `@Table`:
+```java
+@Table(
+        name = "portfolio_item",
+        // (user_id, item_name, asset_type) 유일성은 status='ACTIVE' partial unique index로만 관리한다.
+        // Hibernate @UniqueConstraint는 WHERE 절(partial)을 표현 못하므로 여기 두지 않는다.
+        // 어노테이션으로 두면 ddl-auto=update가 full unique 제약을 silent 재생성해 issue #66이 재발한다.
+        // -> src/main/resources/db/migration/portfolio_item_active_partial_unique.sql
+        indexes = {
+                @Index(name = "idx_portfolio_item_user_id", columnList = "user_id")
+        }
+)
+```
+
+### Unit 2 — 마이그레이션 SQL 신규
+
+- [ ] `src/main/resources/db/migration/portfolio_item_active_partial_unique.sql` 생성.
+- [ ] 헤더: 목적/적용 순서/주의(롤백 제약)/plan 참조. favorite SQL 헤더 컨벤션 준수.
+- [ ] 단일 `BEGIN; ... COMMIT;` — full 제약 DROP + partial index 생성을 원자 적용.
+- [ ] 별도 롤백 SQL 스니펫(헤더 주석 내)도 명시.
+
+SQL 본문(초안):
+```sql
+-- portfolio_item: ACTIVE 자산만 유일하도록 partial unique index 전환 (issue #66)
+--
+-- 배경:
+--   기존 full UNIQUE(user_id, item_name, asset_type)는 status를 보지 않아
+--   CLOSED row가 남으면 동일 자산 재등록(새 ACTIVE row)이 23505 -> 409로 막힌다.
+--   앱 중복검사는 이미 ACTIVE 한정이므로 DB도 ACTIVE만 유일하게 맞춘다.
+--
+-- 적용 순서(중요):
+--   1) 자바 배포 — PortfolioItemEntity 의 @UniqueConstraint(uk_portfolio_item) 제거본
+--      (ddl-auto=update 는 기존 uk_portfolio_item 을 DROP 하지 않으며,
+--       어노테이션이 남은 구버전이 떠 있으면 full 제약을 silent 재생성한다.)
+--   2) 본 SQL 적용 (운영자 수동 psql, dev 도 동일 적용 필요)
+--
+-- 주의(롤백):
+--   본 index 적용 후 사용자가 CLOSED 가 있는 조합에 새 ACTIVE 를 등록하면
+--   (CLOSED+ACTIVE) 중복 조합이 생긴다. 그 이후 full 제약 복원은 실패한다.
+--   롤백은 재등록 발생 전에만 무손실. 롤백 SQL:
+--     BEGIN;
+--     DROP INDEX IF EXISTS uk_portfolio_item_active;
+--     ALTER TABLE portfolio_item
+--         ADD CONSTRAINT uk_portfolio_item UNIQUE (user_id, item_name, asset_type);
+--     COMMIT;
+--
+-- plan: docs/plans/2026-05-30-001-fix-portfolio-asset-reregister-409-plan.md
+-- 적용: psql -v ON_ERROR_STOP=1 -f portfolio_item_active_partial_unique.sql
+
+BEGIN;
+
+ALTER TABLE portfolio_item
+    DROP CONSTRAINT IF EXISTS uk_portfolio_item;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_portfolio_item_active
+    ON portfolio_item (user_id, item_name, asset_type)
+    WHERE status = 'ACTIVE';
+
+COMMIT;
+```
+
+## Verification
+
+dev에서 SQL 적용 후 수동 검증:
+
+- [ ] 자산 등록 → 전량 매도(CLOSED) → 동일 자산 재등록 → **200/201 성공** (기존엔 409).
+- [ ] 등록 → 매도 → 재등록 → 매도 반복 시 CLOSED 다수 누적 + ACTIVE 최대 1개 유지.
+- [ ] ACTIVE 상태에서 동일 자산 재등록 시도 → 앱 검사 `IllegalArgumentException`("이미 등록된 포트폴리오 항목입니다.") 또는 DB partial index 위반 → 정상 거부.
+- [ ] 부팅 후 ddl-auto가 `uk_portfolio_item`을 재생성하지 않는지 확인 (`\d portfolio_item`).
+- [ ] 기존 GET 흐름(보유 자산 목록 등) 회귀 없음.
+
+검증 쿼리:
+```sql
+\d portfolio_item   -- uk_portfolio_item 없음, uk_portfolio_item_active partial index 존재 확인
+SELECT user_id, item_name, asset_type, count(*) FILTER (WHERE status='ACTIVE') active_cnt
+FROM portfolio_item GROUP BY 1,2,3 HAVING count(*) FILTER (WHERE status='ACTIVE') > 1;  -- 0행 기대
+```
+
+## Risks / Open Questions
+
+- **롤백 비대칭성**: 재등록 발생 후 롤백 불가(위 헤더 경고). 운영 적용 전 인지 필요.
+- **적용 순서 누락 위험**: 자바 배포 전 SQL을 먼저 적용 + 구버전 재기동 시 ddl-auto가 full 제약 재생성 가능. 순서 준수 필수.
+- **partial index 이름 컨벤션**: `uk_portfolio_item_active` — 확정 필요(plan 검토 시).
+- **prod 적용 주체/시점**: 운영자 수동 psql. 배포 파이프라인에 SQL 자동 적용 단계 없음 — 수동 체크리스트로 관리.
+
+## 작업 위치
+
+- worktree: `/Users/app/Documents/subProject/wt-fix-issue-66-portfolio-asset-reregister-409`
+- 본 plan/brainstorm 문서는 위 브랜치 diff에 포함되어야 한다 (pre-push documented workflow 검사).

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/infrastructure/persistence/PortfolioItemEntity.java
@@ -10,12 +10,10 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
         name = "portfolio_item",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_portfolio_item",
-                        columnNames = {"user_id", "item_name", "asset_type"}
-                )
-        },
+        // (user_id, item_name, asset_type) 유일성은 status='ACTIVE' partial unique index로만 관리한다 (issue #66).
+        // Hibernate @UniqueConstraint는 WHERE 절(partial)을 표현하지 못하므로 여기 두지 않는다.
+        // 어노테이션으로 두면 ddl-auto=update가 full unique 제약을 silent 재생성해 CLOSED 재등록 409가 재발한다.
+        // -> src/main/resources/db/migration/portfolio_item_active_partial_unique.sql
         indexes = {
                 @Index(name = "idx_portfolio_item_user_id", columnList = "user_id")
         }

--- a/src/main/resources/db/migration/portfolio_item_active_partial_unique.sql
+++ b/src/main/resources/db/migration/portfolio_item_active_partial_unique.sql
@@ -1,0 +1,42 @@
+-- portfolio_item: ACTIVE 자산만 유일하도록 partial unique index 전환 (issue #66)
+--
+-- 배경:
+--   기존 full UNIQUE(user_id, item_name, asset_type)는 status를 보지 않아
+--   전량 매도로 CLOSED가 된 row가 남으면 동일 자산 재등록(새 ACTIVE row)이
+--   23505 -> DataIntegrityViolationException -> 409 CONFLICT로 막힌다.
+--   앱 중복검사(PortfolioService.validateDuplicate)는 이미 ACTIVE 한정이므로
+--   DB 제약도 ACTIVE만 유일하게 맞춰 의도와 일치시킨다.
+--   불변식: (user_id, item_name, asset_type)별 ACTIVE 최대 1개, CLOSED 무제한 누적.
+--
+-- 적용 순서(중요):
+--   1) 자바 배포 — PortfolioItemEntity의 @UniqueConstraint(uk_portfolio_item) 제거본.
+--      (ddl-auto=update는 기존 uk_portfolio_item을 DROP하지 않으며,
+--       어노테이션이 남은 구버전이 재기동되면 full 제약을 silent 재생성한다.)
+--   2) 본 SQL 적용 (운영자 수동 psql). dev도 동일 적용 필요 —
+--      어노테이션 제거만으로는 기존 DB의 uk_portfolio_item이 사라지지 않는다.
+--
+-- 주의(롤백 비대칭):
+--   본 index 적용 후 사용자가 CLOSED가 있는 조합에 새 ACTIVE를 등록하면
+--   (CLOSED + ACTIVE) 중복 조합이 생긴다. 그 이후 full 제약 복원은 실패한다.
+--   롤백은 재등록이 발생하기 전에만 무손실. 롤백 SQL:
+--     BEGIN;
+--     DROP INDEX IF EXISTS uk_portfolio_item_active;
+--     ALTER TABLE portfolio_item
+--         ADD CONSTRAINT uk_portfolio_item UNIQUE (user_id, item_name, asset_type);
+--     COMMIT;
+--
+-- plan: docs/plans/2026-05-30-001-fix-portfolio-asset-reregister-409-plan.md
+-- 적용 권장: psql -v ON_ERROR_STOP=1 -f portfolio_item_active_partial_unique.sql
+-- 본 SQL은 단일 트랜잭션으로 적용한다 — DROP/CREATE 중 하나라도 실패하면 전체 롤백되어
+-- 'full 제약은 빠졌지만 partial index는 없는' 어색한 중간 상태를 회피한다.
+
+BEGIN;
+
+ALTER TABLE portfolio_item
+    DROP CONSTRAINT IF EXISTS uk_portfolio_item;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_portfolio_item_active
+    ON portfolio_item (user_id, item_name, asset_type)
+    WHERE status = 'ACTIVE';
+
+COMMIT;


### PR DESCRIPTION
## Summary

전량 매도로 `CLOSED`가 된 포트폴리오 자산이 DB에 남아 있으면, 동일 `(user_id, item_name, asset_type)` 자산 재등록이 `409 CONFLICT`로 실패하던 문제를 해결한다.

원인은 앱 중복검사(`ACTIVE` 한정)와 DB 제약(상태 무시 full unique)의 범위 불일치였다. DB 제약을 `status='ACTIVE'` partial unique index로 전환해 의도와 일치시킨다.

불변식: `(user_id, item_name, asset_type)`별 **ACTIVE 최대 1개, CLOSED 무제한 누적**.

## 변경

- `PortfolioItemEntity`: `@UniqueConstraint(uk_portfolio_item)` 제거. Hibernate가 partial(WHERE)을 표현 못해, 어노테이션을 남기면 `ddl-auto=update`가 full 제약을 silent 재생성하는 함정을 회피 (SQL로만 관리).
- `db/migration/portfolio_item_active_partial_unique.sql` 신규: full 제약 DROP + partial unique index 생성 (단일 트랜잭션).
- 앱 로직(`validateDuplicate`)은 이미 ACTIVE 한정이라 **변경 없음**.

## 적용 순서 / 리스크 (운영)

- **순서 필수**: 자바 배포(어노테이션 제거) → SQL 적용. 역순 시 구버전 재기동에서 ddl-auto가 full 제약 재생성 위험.
- **dev/prod 모두 SQL 수동 적용 필요**: ddl-auto는 기존 `uk_portfolio_item`을 DROP하지 않음.
- **롤백 비대칭**: partial index 적용 후 재등록이 발생하면 (CLOSED+ACTIVE) 중복이 생겨 full 제약 복원 불가. 롤백은 재등록 발생 전에만 무손실 (SQL 헤더에 명시).

## Test plan

- [ ] dev DB에 SQL 적용 후 `\d portfolio_item`로 `uk_portfolio_item` 없음 + `uk_portfolio_item_active` partial index 확인
- [ ] 등록 → 전량 매도(CLOSED) → 동일 자산 재등록 → 200/201 성공 (기존 409)
- [ ] 등록→매도→재등록 반복 시 CLOSED 다수 + ACTIVE 1개 유지
- [ ] ACTIVE 상태에서 동일 자산 재등록 → 정상 거부
- [ ] 부팅 후 ddl-auto가 full 제약 재생성하지 않음 확인
- [ ] 기존 보유 자산 목록 GET 회귀 없음

Closes #66