### PR TITLE
fix(realestate): REB 광역(SIDO) 카드 미노출 정정 (#58 follow-up)

### DIFF
--- a/docs/brainstorms/2026-05-30-001-reb-sido-cards-not-shown.md
+++ b/docs/brainstorms/2026-05-30-001-reb-sido-cards-not-shown.md
@@ -1,0 +1,72 @@
+---
+title: REB 광역(SIDO) 카드 화면 미노출 — 원인 정리 및 정정 방향
+date: 2026-05-30
+status: completed
+related: "이슈 #58, PR #70 머지 후 운영 검증에서 발견된 후속 결함"
+---
+
+# REB 광역(SIDO) 카드 화면 미노출
+
+## 문제
+
+이슈 #58 / PR #70 (REB R-ONE 광역시도 어댑터 재설계) 머지 후 운영 검증에서 REB 카드가 화면 광역 섹션에 노출되지 않음.
+
+증상:
+- DB(`real_estate_market_indicator`)에 `source=REB` 153 행 정상 적재
+- `/api/realestate/sources/availability` 응답 `reb.available=true`
+- 그러나 `GET /api/realestate/market/tabs/{category}?regionCode=11` 의 `cards`가 빈 배열
+- 시군구(예: `regionCode=11110`) 진입 시에도 REB 광역 카드가 응답에 포함되지 않음
+- 화면에 "광역 통계 준비중" 또는 빈 광역 섹션 표시
+
+## 원인
+
+두 결함이 겹쳐 사용자 시점 증상으로 합쳐졌다.
+
+### (1) metadata indicator-code ↔ adapter 저장 코드 불일치
+
+- `realestate-indicator-metadata.yml` 은 의미 코드(`SALE_PRICE_INDEX`, `JEONSE_PRICE_INDEX` 등)로 metadata 6건 등록
+- `RebAdapter` 는 indicator_code를 `"REB_" + statblId` (예: `REB_A_2024_00017`) 로 저장
+- `RealEstateMarketQueryService.buildCardsFor` → `findHistory(..., key.indicatorCode(), ...)` 매칭 키가 metadata key의 의미 코드 → indicator 테이블에는 STATBL ID로 저장되어 매칭 0건
+- 결과: `cards=[]`
+
+### (2) 시군구 진입 시 상위 SIDO 카드 attach 누락
+
+- 도메인은 시군구(5자리) + 광역(2자리) hybrid (Q1=B)
+- MOLIT/KOSIS는 시군구, REB는 광역 단위로 적재
+- `getTab(regionCode=11110)` 호출 시 그 시군구의 cards만 회신 → MOLIT 시군구 카드만 있고 REB 광역 카드 누락
+- 프론트는 한 화면에서 두 단위를 함께 렌더링해야 하므로 백엔드에서 두 단위 row를 함께 응답 필요
+
+## 정정 방향
+
+- **Q1=A 정책 명문화**: 4종 묶음(주택종합/아파트/연립/단독) 중 대표 1종(`-total`)만 metadata와 매핑하여 적재. 나머지 STATBL은 indicator-code 미부여로 어댑터에서 skip.
+- **매핑 표현 위치**: `application.yml` 의 STATBL entry에 `indicator-code` 필드 추가. `RebStatblProperties.Entry` 에 nullable 필드로 수용.
+- **저장 코드 일치**: `RebAdapter.buildIndicator` 가 STATBL ID 대신 entry.indicatorCode 사용. 미매핑 entry는 `of()` 단계에서 null 반환 → skip.
+- **시군구 → SIDO attach**: `RealEstateMarketQueryService.getTab` 에서 `regionCode.length()==5` 이면 앞 2자리로 추가 `buildCardsFor` 호출하여 cards에 합침.
+- **부수**: 운영 점검 중 발견된 `RebClient` envelope 보정(`.do` suffix, `INFO-000` result code, 중첩 row/RESULT 재귀 탐색) 포함.
+
+## 영향 범위 / 비범위
+
+영향:
+- `RebStatblProperties.java` Entry 필드 추가
+- `application.yml` STATBL 매핑 4건 (sale-total / rent-total / trade-volume-apt / land-price-change)
+- `RebAdapter.java` 저장 코드 + skip 정책
+- `RealEstateMarketQueryService.java` 시군구→SIDO attach
+- `RebClient.java` envelope 보정 (운영 점검 후속)
+- DB: 기존 `source=REB` 행 일괄 삭제 후 다음 배치에서 의미 코드로 재적재
+
+비범위(별도 PR 권장):
+- 아파트/연립/단독 STATBL 활성화 (Q1=B 전환 시 metadata yml 확장)
+- 거래량 주택종합(A_2024_00604) metadata 추가
+- ACTUAL_TRANSACTION_PRICE_INDEX / MONTHLY_RENT_PRICE_INDEX STATBL 보강
+- `OFFICIAL_STATS count=1/region`, `MAX_PAGES=20 truncation`, 배치 elapsed 3분+ 개선
+
+## 검증 기준
+
+- DB: `source=REB` 행이 17 SIDO × 4 indicator = 68 건 적재됨
+- API: `tabs/PRICE_INDEX?regionCode=11` cards에 `SALE_PRICE_INDEX/SIDO/REB` 1건
+- API: `tabs/PRICE_INDEX?regionCode=11110` cards에 시군구 MOLIT 카드 + 광역 REB 카드 함께 회신
+- 화면: 광역시도 직접 진입 또는 시군구 진입 시 광역 섹션에 REB 카드 노출
+
+## 학습 정본
+
+`docs/solutions/ui-bugs/reb-sido-cards-not-shown-2026-05-30.md`

--- a/docs/plans/2026-05-30-001-fix-reb-sido-cards-plan.md
+++ b/docs/plans/2026-05-30-001-fix-reb-sido-cards-plan.md
@@ -1,0 +1,79 @@
+---
+title: REB 광역(SIDO) 카드 미노출 정정 — 구현 plan
+date: 2026-05-30
+status: completed
+brainstorm: docs/brainstorms/2026-05-30-001-reb-sido-cards-not-shown.md
+solution: docs/solutions/ui-bugs/reb-sido-cards-not-shown-2026-05-30.md
+related: "이슈 #58, PR #70 머지 후 후속 fix"
+---
+
+# REB 광역(SIDO) 카드 미노출 정정 plan
+
+## Goal
+
+PR #70 머지 후 REB 카드가 화면 광역 섹션에 노출되지 않는 결함 두 개를 정정. 구체 원인과 정정 방향은 브레인스토밍 문서 참조.
+
+## Scope Boundaries
+
+포함:
+- metadata indicator-code ↔ adapter 저장 코드 일치
+- 시군구 진입 시 상위 SIDO 카드 attach
+- 운영 점검 중 발견된 RebClient envelope 보정 동반
+
+비포함:
+- 아파트/연립/단독 STATBL 활성화 (Q1=B 전환)
+- 거래량 주택종합 metadata 추가
+- ACTUAL_TRANSACTION_PRICE_INDEX / MONTHLY_RENT_PRICE_INDEX STATBL 보강
+- OFFICIAL_STATS count=1/region 보강
+- A_2024_00903 fetchAllPages MAX_PAGES=20 truncation 개선
+- 배치 elapsed 3분+ 최적화
+
+## Implementation Units
+
+### Unit 1 — STATBL entry에 indicator-code 필드 추가
+- Files:
+  - `src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/config/RebStatblProperties.java`
+  - `src/main/resources/application.yml`
+- Approach: `Entry` 클래스에 `indicatorCode` nullable 필드 추가. yml의 4개 대표 entry(sale-price-total / rent-price-total / trade-volume-apt / land-price-change)에만 indicator-code 명시.
+- Verification: 부팅 성공, `RebStatblProperties` 검증 통과.
+
+### Unit 2 — RebAdapter 저장 코드 의미 코드로 변경 + 미매핑 skip
+- Files:
+  - `src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/source/reb/RebAdapter.java`
+- Approach: `StatblTarget` record에 `indicatorCode` 추가. `of()` 가 entry.indicatorCode null/blank이면 null 반환. `buildIndicator`는 `target.indicatorCode()` 사용.
+- Verification: 배치 후 `real_estate_market_indicator.source='REB'` 행이 `SALE_PRICE_INDEX/JEONSE_PRICE_INDEX/APT_TRANSACTION_COUNT/LAND_PRICE_CHANGE_RATE` 4종으로 저장.
+
+### Unit 3 — QueryService에서 시군구→상위 SIDO attach
+- Files:
+  - `src/main/java/com/thlee/stock/market/stockmarket/realestate/application/RealEstateMarketQueryService.java`
+- Approach: `getTab(regionCode, ...)` 진입 시 `regionCode.length()==5`이면 앞 2자리로 추가 `buildCardsFor` 호출 → 결과 카드를 cards에 합침.
+- Verification: `tabs/PRICE_INDEX?regionCode=11110` 응답 cards에 MOLIT 시군구 카드 + REB SIDO 카드 둘 다 포함.
+
+### Unit 4 — RebClient envelope 보정 (운영 점검 후속)
+- Files:
+  - `src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/source/reb/RebClient.java`
+- Approach: PATH_ITM/PATH_DATA에 `.do` suffix, `INFO-000` 성공 코드 + 레거시 fallback, 중첩 `RESULT` / `row` 키 재귀 탐색.
+- Verification: ITM 단계에서 ITM 행이 정상 파싱되고 DATA 단계에서 다차원 GRP/CLS/ITM 매칭이 동작.
+
+### Unit 5 — 운영 데이터 정리 + 학습/플랜/브레인스토밍 문서화
+- Files:
+  - `docs/brainstorms/2026-05-30-001-reb-sido-cards-not-shown.md`
+  - `docs/plans/2026-05-30-001-fix-reb-sido-cards-plan.md`
+  - `docs/solutions/ui-bugs/reb-sido-cards-not-shown-2026-05-30.md`
+- Approach: 운영 DB의 기존 `source=REB` 행 일괄 삭제 → 다음 배치에서 의미 코드로 재적재. 본 fix의 원인/정정/예방을 학습 문서로 정본화.
+- Verification: `docs/solutions/ui-bugs/` 에 학습 문서 존재. DB 행 68건(17 SIDO × 4 indicator).
+
+## Requirements Trace
+
+- [x] Unit 1 — Entry indicator-code 필드 + yml 매핑
+- [x] Unit 2 — RebAdapter 저장 코드 의미 코드로 변경
+- [x] Unit 3 — 시군구→SIDO attach
+- [x] Unit 4 — RebClient envelope 보정
+- [x] Unit 5 — 문서화 (brainstorm + plan + 학습)
+
+## Verification
+
+- 빌드: `./gradlew compileJava` 성공
+- 런타임 부팅: 검증 통과
+- API: 광역/시군구 진입 시 카드 정상 회신
+- 화면: 광역 섹션에 REB 카드 노출

--- a/docs/solutions/ui-bugs/reb-sido-cards-not-shown-2026-05-30.md
+++ b/docs/solutions/ui-bugs/reb-sido-cards-not-shown-2026-05-30.md
@@ -1,0 +1,195 @@
+---
+title: "REB 광역(SIDO) 카드가 화면에 노출되지 않음 — metadata indicator_code 불일치 + 시군구→광역 attach 누락"
+date: 2026-05-30
+category: ui-bugs
+module: realestate, source-adapter, market-query
+problem_type: ui_bug
+component: service_object
+symptoms:
+  - 화면에서 "광역 통계 준비중" 또는 빈 광역 섹션이 표시됨
+  - DB의 real_estate_market_indicator에 source=REB 행 153건이 있는데 GET /api/realestate/market/tabs/{category}?regionCode=11 의 cards=[]
+  - 시군구 카드 진입(예: regionCode=11110) 시 광역(REB) 카드가 응답 cards 배열에 포함되지 않음
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - frontend_stimulus
+  - documentation
+tags:
+  - realestate
+  - reb
+  - r-one
+  - sido
+  - indicator-code
+  - metadata-mapping
+  - region-attachment
+  - query-service
+---
+
+# REB 광역(SIDO) 카드가 화면에 노출되지 않음
+
+## Problem
+
+REB R-ONE 어댑터 재설계(이슈 #58, PR #70) 머지 후 운영 검증에서 REB 광역(SIDO) 카드가 화면에 노출되지 않았다. DB에는 `source=REB` 행 153건이 정상 적재되어 있고 `/api/realestate/sources/availability` 는 `reb.available=true` 를 반환하지만, 카테고리 탭 조회 API의 `cards` 배열에는 REB 카드가 포함되지 않았다.
+
+근본 원인은 두 가지가 겹친 결과였다.
+1. metadata yml의 indicator-code(예: `SALE_PRICE_INDEX`)와 어댑터가 저장하는 indicator_code(예: `REB_A_2024_00017`)가 불일치
+2. `RealEstateMarketQueryService.getTab(regionCode)`이 시군구 코드 입력 시 상위 광역(SIDO) 카드를 함께 조회하지 않음
+
+## Symptoms
+
+- 화면(`partials/realestate.html`) 광역 섹션이 빈 상태 또는 "광역 통계 준비중" 안내로 표시됨
+- `GET /api/realestate/market/tabs/PRICE_INDEX?regionCode=11` 응답이 `{"cards":[], "sources":[]}` (lastUpdatedAt은 정상 회신)
+- `GET /api/realestate/market/tabs/PRICE_INDEX?regionCode=11110` 응답에 MOLIT 시군구 카드만 포함, REB 광역 카드 누락
+- `availability.reb.available=true` 임에도 cards가 비어 보이는 모순 상태
+
+## What Didn't Work
+
+- **availability API 점검**: `reb.available=true`였으므로 api-key 미설정/외부 호출 실패 가설은 기각. 적재는 정상이고 조회 단계에서 막혔다는 신호.
+- **batch 재실행**: 배치는 이미 성공(success=536, savedRows=153). 재실행해도 같은 indicator_code(`REB_A_2024_xxxxx`)로만 저장되어 화면 결과 불변.
+- **availability 응답 캐싱 의심**: 프론트 캐시 무효화로 해결되지 않음. 백엔드 응답 자체가 빈 배열.
+
+## Solution
+
+### Fix 1 — metadata yml의 의미 코드와 어댑터 저장 코드 일치
+
+`RebStatblProperties.Entry`에 `indicatorCode` 필드를 추가하고, `application.yml`의 STATBL entry에서 metadata yml의 indicator-code와 매핑한다. 4종 묶음(주택종합/아파트/연립/단독) 중 **주택종합 1종만** 매핑(Q1=A 정책) — 미매핑 STATBL은 어댑터 단계에서 skip.
+
+**RebStatblProperties.java** (Entry에 필드 추가):
+
+```java
+@Getter
+@Setter
+public static class Entry {
+    private String statblId;
+    private String dtacycleCd;
+    /**
+     * realestate-indicator-metadata.yml의 indicator-code와 매핑되는 의미 코드.
+     * null 또는 blank이면 본 STATBL은 적재 대상에서 제외 (대표 1종만 사용 — Q1=A 정책).
+     */
+    private String indicatorCode;
+}
+```
+
+**application.yml** (entry에 indicator-code 추가):
+
+```yaml
+realestate:
+  reb:
+    statbl:
+      sale-price-total:        { statbl-id: A_2024_00017, dtacycle-cd: MM, indicator-code: SALE_PRICE_INDEX }
+      sale-price-apt:          { statbl-id: A_2024_00048, dtacycle-cd: MM }   # 미매핑 — skip
+      sale-price-rowhouse:     { statbl-id: A_2024_00083, dtacycle-cd: MM }
+      sale-price-singlehouse:  { statbl-id: A_2024_00117, dtacycle-cd: MM }
+      rent-price-total:        { statbl-id: A_2024_00020, dtacycle-cd: MM, indicator-code: JEONSE_PRICE_INDEX }
+      rent-price-apt:          { statbl-id: A_2024_00053, dtacycle-cd: MM }
+      rent-price-rowhouse:     { statbl-id: A_2024_00088, dtacycle-cd: MM }
+      rent-price-singlehouse:  { statbl-id: A_2024_00122, dtacycle-cd: MM }
+      trade-volume-total:      { statbl-id: A_2024_00604, dtacycle-cd: MM }
+      trade-volume-apt:        { statbl-id: A_2024_00612, dtacycle-cd: MM, indicator-code: APT_TRANSACTION_COUNT }
+      land-price-change:       { statbl-id: A_2024_00903, dtacycle-cd: MM, indicator-code: LAND_PRICE_CHANGE_RATE }
+```
+
+**RebAdapter.java** (의미 코드로 저장 + 미매핑 skip):
+
+```java
+private StatblTarget of(RebStatblProperties.Entry entry) {
+    if (entry == null || entry.getStatblId() == null || entry.getDtacycleCd() == null) {
+        return null;
+    }
+    // Q1=A 정책: indicator-code 매핑이 있는 STATBL만 적재 (4종 묶음 중 대표 1종만).
+    if (entry.getIndicatorCode() == null || entry.getIndicatorCode().isBlank()) {
+        return null;
+    }
+    return new StatblTarget(entry.getStatblId(), entry.getDtacycleCd(), entry.getIndicatorCode());
+}
+
+private RealEstateMarketIndicator buildIndicator(RegionCode region,
+                                                 RealEstateMarketCategory category,
+                                                 StatblTarget target,
+                                                 SttsApiTblDataRow row) {
+    return RealEstateMarketIndicator.builder()
+            .regionCode(region.value())
+            .category(category)
+            .source(RealEstateMarketSource.REB)
+            .indicatorCode(target.indicatorCode())  // 의미 코드 (예: SALE_PRICE_INDEX)
+            // ...
+            .build();
+}
+
+private record StatblTarget(String statblId, String dtacycleCd, String indicatorCode) {}
+```
+
+### Fix 2 — 시군구 진입 시 상위 광역(SIDO) 카드 attach
+
+`RealEstateMarketQueryService.getTab`이 시군구 코드(5자리) 입력 시 상위 SIDO 코드(앞 2자리)로 추가 조회해 cards에 합친다. 프론트는 응답 카드를 `regionLevel === 'SIDO'`로 필터하여 광역 섹션에 분리 렌더링.
+
+```java
+public TabResponse getTab(String regionCode,
+                          RealEstateMarketCategory category,
+                          PeriodOption period) {
+    Map<MetaKey, RealEstateMarketMetadata> metaMap = loadMetadataMap();
+    List<IndicatorCard> cards = new ArrayList<>(
+            buildCardsFor(regionCode, category, metaMap, HISTORY_LIMIT, null));
+
+    // 시군구 진입 시 상위 광역(SIDO) 카드도 함께 노출 — R-ONE은 SIDO 단위만 적재.
+    // 프론트는 regionLevel='SIDO' 필터로 광역 섹션에 분리 렌더링.
+    if (regionCode != null && regionCode.length() == 5) {
+        String sidoCode = regionCode.substring(0, 2);
+        cards.addAll(buildCardsFor(sidoCode, category, metaMap, HISTORY_LIMIT, null));
+    }
+    // ...
+}
+```
+
+### 검증
+
+DB 정리 후 배치 재실행:
+
+```bash
+# DB 정리 (기존 REB_A_2024_xxxxx 행 제거)
+docker exec postgres psql -U root -d stocks \
+  -c "DELETE FROM real_estate_market_latest WHERE source='REB';" \
+  -c "DELETE FROM real_estate_market_indicator WHERE source='REB';"
+
+# 앱 재기동 후 화면 동기화 트리거 → 68 rows 적재
+# (17 SIDO × 4 indicator = SALE_PRICE_INDEX / JEONSE_PRICE_INDEX / APT_TRANSACTION_COUNT / LAND_PRICE_CHANGE_RATE)
+```
+
+API 검증:
+
+```bash
+# 광역 직접 진입
+curl -s "http://localhost:8080/api/realestate/market/tabs/PRICE_INDEX?regionCode=11" \
+  | jq '.cards[] | {indicatorCode, regionLevel, source}'
+# → {"indicatorCode":"SALE_PRICE_INDEX","regionLevel":"SIDO","source":"REB"}
+
+# 시군구 진입 → MOLIT 시군구 카드 + REB SIDO 카드 함께 응답
+curl -s "http://localhost:8080/api/realestate/market/tabs/PRICE_INDEX?regionCode=11110" \
+  | jq '.cards[] | {indicatorCode, regionLevel, source}'
+# → {"indicatorCode":"PRICE_PER_SQM","regionLevel":"SIGUNGU","source":"MOLIT"}
+# → {"indicatorCode":"SALE_PRICE_INDEX","regionLevel":"SIDO","source":"REB"}
+```
+
+## Why This Works
+
+**Fix 1**: `RealEstateMarketQueryService.buildCardsFor()`는 `findHistory(regionCode, category, source, indicatorCode, limit)`를 호출하는데, indicator_code 인자는 metadata yml의 의미 코드(`SALE_PRICE_INDEX` 등)에서 온다. 어댑터가 STATBL ID(`REB_A_2024_00017`)로 저장하면 metadata key와 indicator row의 indicator_code가 불일치해 매칭이 0건이 된다. metadata yml과 어댑터 저장 코드를 일치시키면 즉시 조회가 동작한다. yml에서 미매핑 entry는 어댑터가 skip하여 무관한 STATBL을 무의미하게 적재하지 않는다.
+
+**Fix 2**: 도메인 모델은 시군구(5자리) + 광역(2자리) hybrid (Q1=B 계획). MOLIT/KOSIS는 시군구 단위, REB는 광역 단위로 적재된다. 프론트가 한 화면에서 두 단위를 모두 렌더링하려면 백엔드가 두 단위 row를 함께 응답해야 한다. `regionCode.length()==5`일 때 앞 2자리로 SIDO 조회를 추가하면, 클라이언트는 `regionLevel` 필드만으로 광역/시군구 섹션을 분기 렌더링할 수 있다.
+
+## Prevention
+
+1. **metadata yml과 adapter indicator_code는 동일 소스에서 파생**. metadata yml을 정본으로 두고 adapter가 yml의 indicator-code 필드를 직접 읽어 저장. STATBL ID 같은 외부 식별자는 내부 indicator_code로 그대로 쓰지 말 것.
+
+2. **부팅 시 metadata ↔ adapter 매핑 자기 검증 추가 권장**. `RebStatblProperties.@PostConstruct` 또는 `RealEstateMarketMetadataInitializer`에서 metadata yml의 source=REB indicator-code 집합과 STATBL entry의 indicator-code 집합이 충분히 겹치는지 검증 (현재는 mismatch가 부팅 시 발견되지 않고 조회 시점에 빈 결과로만 드러남).
+
+3. **hybrid region 모델은 query 레이어에서 명시적 attach**. REB가 SIDO만 적재한다는 사실은 어댑터 레벨 결정이지만 화면 렌더링은 시군구 진입에서 시작한다. QueryService가 두 레벨을 함께 응답하는 패턴을 표준화하고, `regionLevel` 필드를 신뢰할 수 있는 라우팅 키로 유지.
+
+4. **integration 검증 시 API 응답 키 카운트만 보지 말고 cards 배열까지 확인**. `lastUpdatedAt`이 채워져도 cards가 빈 경우가 있다 — availability와 별개로 tab API의 cards 배열을 직접 검증하는 smoke test가 필요.
+
+## Related Issues
+
+- 이슈 #58: REB R-ONE 어댑터 광역시도 재설계 (본 fix는 #58 머지 후 운영 검증에서 발견된 후속)
+- PR #70: feat(realestate) REB R-ONE 광역시도 어댑터 재설계
+- 관련 학습: `docs/solutions/architecture-patterns/realestate-public-open-api-pitfalls-2026-05-07.md` (다중 공공 출처 어댑터링 일반 함정)
+- 관련 학습: `docs/solutions/architecture-patterns/ecos-indicator-identifier-source-of-truth-2026-05-26.md` (metadata yml 정본 원칙 — 본 버그는 동일 원칙 위반의 다른 발현)

--- a/src/main/java/com/thlee/stock/market/stockmarket/realestate/application/RealEstateMarketQueryService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/realestate/application/RealEstateMarketQueryService.java
@@ -86,6 +86,13 @@ public class RealEstateMarketQueryService {
         List<IndicatorCard> cards = new ArrayList<>(
                 buildCardsFor(regionCode, category, metaMap, HISTORY_LIMIT, null));
 
+        // 시군구 진입 시 상위 광역(SIDO) 카드도 함께 노출 — R-ONE은 SIDO 단위만 적재.
+        // 프론트는 regionLevel='SIDO' 필터로 광역 섹션에 분리 렌더링.
+        if (regionCode != null && regionCode.length() == 5) {
+            String sidoCode = regionCode.substring(0, 2);
+            cards.addAll(buildCardsFor(sidoCode, category, metaMap, HISTORY_LIMIT, null));
+        }
+
         if (category == RealEstateMarketCategory.RENT) {
             attachJeonseRatioEstimate(regionCode, metaMap, cards);
         }

--- a/src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/config/RebStatblProperties.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/config/RebStatblProperties.java
@@ -100,7 +100,7 @@ public class RebStatblProperties {
     }
 
     /**
-     * R-ONE STATBL entry — (통계표 ID, 발표 주기 코드) 쌍.
+     * R-ONE STATBL entry — (통계표 ID, 발표 주기 코드, metadata indicator 매핑) 쌍.
      */
     @Getter
     @Setter
@@ -109,5 +109,10 @@ public class RebStatblProperties {
         private String statblId;
         /** 발표 주기 코드 (예: "MM" = 월간). R-ONE 명세상 CHAR(11). */
         private String dtacycleCd;
+        /**
+         * realestate-indicator-metadata.yml의 indicator-code와 매핑되는 의미 코드.
+         * null 또는 blank이면 본 STATBL은 적재 대상에서 제외 (대표 1종만 사용 — Q1=A 정책).
+         */
+        private String indicatorCode;
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/source/reb/RebAdapter.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/source/reb/RebAdapter.java
@@ -132,13 +132,19 @@ public class RebAdapter implements RealEstateMarketSourceAdapter {
         String endWrttime = window.to().toString().replace("-", "").substring(0, 6);
 
         // 동일 (STATBL, window)의 17 SIDO 호출은 캐시 hit으로 처리 (P0 #5 — redundant 호출 폭증 해소).
-        // 첫 region 호출이 STATBL 전체 데이터를 받아 캐시, 나머지 16 region은 메모리에서 ITM_ID 필터만.
+        // 첫 region 호출이 STATBL 전체 데이터를 받아 캐시, 나머지 16 region은 메모리에서 region 필터만.
         List<SttsApiTblDataRow> rows = metadataCache.dataFor(
                 target.statblId(), target.dtacycleCd(), startWrttime, endWrttime);
 
-        // 메모리 region 필터 (Q4=D1)
-        List<SttsApiTblDataRow> filtered = rows.stream()
-                .filter(row -> itm.itmId() != null && itm.itmId().equals(row.itmId()))
+        // 메모리 region 필터 (Q4=D1).
+        // R-ONE 통계표는 (GRP_ID, CLS_ID, ITM_ID) 다차원 — region이 어느 차원에 있는지는 STATBL마다 다르다.
+        // 예: A_2024_00017(매매가격지수) → region이 CLS_ID, ITM_ID는 단일 "지수".
+        // ITM API의 ITM_TAG=분류의 ITM_ID는 DATA의 GRP_ID/CLS_ID/ITM_ID 중 어느 하나와 매치된다.
+        String regionId = itm.itmId();
+        List<SttsApiTblDataRow> filtered = regionId == null ? List.of() : rows.stream()
+                .filter(row -> regionId.equals(row.clsId())
+                        || regionId.equals(row.grpId())
+                        || regionId.equals(row.itmId()))
                 .toList();
         if (filtered.isEmpty()) {
             return List.of();
@@ -210,7 +216,11 @@ public class RebAdapter implements RealEstateMarketSourceAdapter {
         if (entry == null || entry.getStatblId() == null || entry.getDtacycleCd() == null) {
             return null;
         }
-        return new StatblTarget(entry.getStatblId(), entry.getDtacycleCd());
+        // Q1=A 정책: indicator-code 매핑이 있는 STATBL만 적재 (4종 묶음 중 대표 1종만).
+        if (entry.getIndicatorCode() == null || entry.getIndicatorCode().isBlank()) {
+            return null;
+        }
+        return new StatblTarget(entry.getStatblId(), entry.getDtacycleCd(), entry.getIndicatorCode());
     }
 
     private List<StatblTarget> nonNull(StatblTarget... entries) {
@@ -230,7 +240,7 @@ public class RebAdapter implements RealEstateMarketSourceAdapter {
                 .regionCode(region.value())
                 .category(category)
                 .source(RealEstateMarketSource.REB)
-                .indicatorCode("REB_" + target.statblId())
+                .indicatorCode(target.indicatorCode())
                 .referenceText(row.wrttimeIdtfrId() == null ? "" : row.wrttimeIdtfrId())
                 .value(value)
                 .sourceUrl("https://www.reb.or.kr/r-one/")
@@ -239,6 +249,6 @@ public class RebAdapter implements RealEstateMarketSourceAdapter {
                 .build();
     }
 
-    private record StatblTarget(String statblId, String dtacycleCd) {
+    private record StatblTarget(String statblId, String dtacycleCd, String indicatorCode) {
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/source/reb/RebClient.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/realestate/infrastructure/source/reb/RebClient.java
@@ -41,17 +41,22 @@ import java.util.Map;
 @Slf4j
 public class RebClient {
 
-    private static final String PATH_ITM = "/SttsApiTblItm";
-    private static final String PATH_DATA = "/SttsApiTblData";
+    // R-ONE endpoint는 ".do" suffix 필수 — 미부착 시 HTML 오류 페이지 반환 (학습 #15 contextPath와 별개)
+    private static final String PATH_ITM = "/SttsApiTblItm.do";
+    private static final String PATH_DATA = "/SttsApiTblData.do";
     private static final int DEFAULT_PAGE_SIZE = 100;
     /** R-ONE ERROR 336 — 한 요청에 1,000건 초과 차단. */
     private static final int MAX_PAGE_SIZE = 1000;
     /** 한 호출당 최대 페이지 수 — 무한 루프 방지. */
     private static final int MAX_PAGES = 20;
 
-    private static final String INFO_OK = "000";
-    private static final String INFO_OK_LEGACY = "00";
-    private static final String INFO_EMPTY = "200";
+    // R-ONE resultCode 실제 형식은 "INFO-000" (정상) / "INFO-200" (빈 결과) / "ERROR-NNN" (오류).
+    // 명세서엔 "000" 형식이라 적혀 있으나 실제 응답은 prefix 포함.
+    private static final String INFO_OK = "INFO-000";
+    private static final String INFO_OK_LEGACY_3 = "000";
+    private static final String INFO_OK_LEGACY_2 = "00";
+    private static final String INFO_EMPTY = "INFO-200";
+    private static final String INFO_EMPTY_LEGACY = "200";
 
     private final RestClient restClient;
     private final RealEstateMarketProperties properties;
@@ -207,33 +212,64 @@ public class RebClient {
         return new PageResponse(rows);
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * 응답 어디든 RESULT/result 키의 Map 발견 시 그 안의 CODE/MESSAGE 추출.
+     * R-ONE 형식 예: {SttsApiTblItm: [{head: [{list_total_count:N}, {RESULT: {CODE:"INFO-000", ...}}]}, ...]}
+     */
     private ResultCode extractResultCode(Map<String, Object> root) {
-        // R-ONE 응답에서 RESULT 객체 추출 (다양한 위치 가능)
-        Object resultObj = root.get("RESULT");
-        if (resultObj == null) {
-            resultObj = root.get("result");
+        Map<String, Object> resultMap = findResultMap(root);
+        if (resultMap == null) {
+            return new ResultCode("", "");
         }
-        if (resultObj instanceof Map<?, ?> map) {
-            Object codeObj = map.get("CODE");
-            if (codeObj == null) codeObj = map.get("code");
-            Object msgObj = map.get("MESSAGE");
-            if (msgObj == null) msgObj = map.get("message");
-            String code = codeObj == null ? "" : codeObj.toString();
-            String message = msgObj == null ? "" : msgObj.toString();
-            return new ResultCode(code, message);
-        }
-        // RESULT envelope이 없으면 자료 row 존재 여부로 판단
-        return new ResultCode("", "");
+        Object codeObj = resultMap.get("CODE");
+        if (codeObj == null) codeObj = resultMap.get("code");
+        Object msgObj = resultMap.get("MESSAGE");
+        if (msgObj == null) msgObj = resultMap.get("message");
+        String code = codeObj == null ? "" : codeObj.toString();
+        String message = msgObj == null ? "" : msgObj.toString();
+        return new ResultCode(code, message);
     }
 
     @SuppressWarnings("unchecked")
+    private Map<String, Object> findResultMap(Object node) {
+        if (node instanceof Map<?, ?> map) {
+            Object direct = map.get("RESULT");
+            if (direct == null) direct = map.get("result");
+            if (direct instanceof Map<?, ?> direct2) {
+                return (Map<String, Object>) direct2;
+            }
+            for (Object v : map.values()) {
+                Map<String, Object> found = findResultMap(v);
+                if (found != null) return found;
+            }
+        } else if (node instanceof List<?> list) {
+            for (Object item : list) {
+                Map<String, Object> found = findResultMap(item);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 응답에서 실제 데이터 row 리스트 추출. R-ONE은 wrapper 형식 사용:
+     * {SttsApiTblItm: [{head: [...]}, {row: [{STATBL_ID, ITM_ID, ...}, ...]}]}
+     * → "row" 키를 가진 nested wrapper의 값을 우선 탐색.
+     */
+    @SuppressWarnings("unchecked")
     private List<Map<String, Object>> extractRows(Map<String, Object> root) {
-        // 가장 흔한 형태: root.values()를 순회하며 List<Map>을 발견
+        // 우선순위 1: 모든 위치에서 "row" 또는 "ROW" 키 가진 List<Map> 탐색 (R-ONE 표준)
+        List<Map<String, Object>> rowsByKey = findRowsByKey(root);
+        if (rowsByKey != null) {
+            return rowsByKey;
+        }
+        // 우선순위 2: legacy fallback — root values의 첫 List<Map> (다른 출처용)
         for (Map.Entry<String, Object> entry : root.entrySet()) {
             if ("RESULT".equalsIgnoreCase(entry.getKey())) continue;
             Object value = entry.getValue();
-            if (value instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof Map<?, ?>) {
+            if (value instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof Map<?, ?> first
+                    && !first.containsKey("head") && !first.containsKey("row")
+                    && !first.containsKey("RESULT")) {
                 return (List<Map<String, Object>>) value;
             }
             if (value instanceof Map<?, ?> wrapper) {
@@ -246,6 +282,34 @@ public class RebClient {
             }
         }
         return List.of();
+    }
+
+    /**
+     * 재귀 탐색으로 "row" / "ROW" 키 발견 시 그 값(List<Map>)을 반환.
+     * R-ONE wrapper 형식의 핵심 추출기.
+     */
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> findRowsByKey(Object node) {
+        if (node instanceof Map<?, ?> map) {
+            Object direct = map.get("row");
+            if (direct == null) direct = map.get("ROW");
+            if (direct instanceof List<?> list && !list.isEmpty()
+                    && list.get(0) instanceof Map<?, ?>) {
+                return (List<Map<String, Object>>) direct;
+            }
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if ("RESULT".equalsIgnoreCase(String.valueOf(entry.getKey()))) continue;
+                if ("head".equalsIgnoreCase(String.valueOf(entry.getKey()))) continue;
+                List<Map<String, Object>> found = findRowsByKey(entry.getValue());
+                if (found != null) return found;
+            }
+        } else if (node instanceof List<?> list) {
+            for (Object item : list) {
+                List<Map<String, Object>> found = findRowsByKey(item);
+                if (found != null) return found;
+            }
+        }
+        return null;
     }
 
     private String str(Map<String, Object> row, String key) {
@@ -281,12 +345,14 @@ public class RebClient {
 
     private record ResultCode(String code, String message) {
         boolean isEmpty() {
-            return INFO_EMPTY.equals(code);
+            return INFO_EMPTY.equals(code) || INFO_EMPTY_LEGACY.equals(code);
         }
 
         boolean isSuccess() {
             return code == null || code.isBlank()
-                    || INFO_OK.equals(code) || INFO_OK_LEGACY.equals(code);
+                    || INFO_OK.equals(code)
+                    || INFO_OK_LEGACY_3.equals(code)
+                    || INFO_OK_LEGACY_2.equals(code);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -189,19 +189,21 @@ realestate:
     connect-timeout-ms: 5000
     read-timeout-ms: 30000
     # R-ONE STATBL 11개 매핑 — RebStatblProperties로 strong-typed 바인딩.
-    # 각 entry: (statbl-id, dtacycle-cd). dtacycle-cd는 발표 주기 메타 (월간="MM" 추정, 첫 호출 시 검증).
+    # 각 entry: (statbl-id, dtacycle-cd, [indicator-code]).
+    # Q1=A 정책: indicator-code가 있는 STATBL만 적재 (4종 묶음 중 대표 1종 = 주택종합).
+    # 미매핑 entry는 fetch 단계에서 skip — 추후 metadata yml 확장 시 indicator-code 추가만으로 활성화 가능.
     statbl:
-      sale-price-total:        { statbl-id: A_2024_00017, dtacycle-cd: MM }   # 매매가격지수 주택종합
-      sale-price-apt:          { statbl-id: A_2024_00048, dtacycle-cd: MM }   # 매매가격지수 아파트
-      sale-price-rowhouse:     { statbl-id: A_2024_00083, dtacycle-cd: MM }   # 매매가격지수 연립/다세대
-      sale-price-singlehouse:  { statbl-id: A_2024_00117, dtacycle-cd: MM }   # 매매가격지수 단독주택
-      rent-price-total:        { statbl-id: A_2024_00020, dtacycle-cd: MM }   # 전세가격지수 주택종합
-      rent-price-apt:          { statbl-id: A_2024_00053, dtacycle-cd: MM }   # 전세가격지수 아파트
-      rent-price-rowhouse:     { statbl-id: A_2024_00088, dtacycle-cd: MM }   # 전세가격지수 연립/다세대
-      rent-price-singlehouse:  { statbl-id: A_2024_00122, dtacycle-cd: MM }   # 전세가격지수 단독주택
-      trade-volume-total:      { statbl-id: A_2024_00604, dtacycle-cd: MM }   # 거래량 주택종합
-      trade-volume-apt:        { statbl-id: A_2024_00612, dtacycle-cd: MM }   # 거래량 아파트
-      land-price-change:       { statbl-id: A_2024_00903, dtacycle-cd: MM }   # 지가변동률
+      sale-price-total:        { statbl-id: A_2024_00017, dtacycle-cd: MM, indicator-code: SALE_PRICE_INDEX }    # 매매가격지수 주택종합 (대표)
+      sale-price-apt:          { statbl-id: A_2024_00048, dtacycle-cd: MM }                                       # 매매가격지수 아파트
+      sale-price-rowhouse:     { statbl-id: A_2024_00083, dtacycle-cd: MM }                                       # 매매가격지수 연립/다세대
+      sale-price-singlehouse:  { statbl-id: A_2024_00117, dtacycle-cd: MM }                                       # 매매가격지수 단독주택
+      rent-price-total:        { statbl-id: A_2024_00020, dtacycle-cd: MM, indicator-code: JEONSE_PRICE_INDEX }   # 전세가격지수 주택종합 (대표)
+      rent-price-apt:          { statbl-id: A_2024_00053, dtacycle-cd: MM }                                       # 전세가격지수 아파트
+      rent-price-rowhouse:     { statbl-id: A_2024_00088, dtacycle-cd: MM }                                       # 전세가격지수 연립/다세대
+      rent-price-singlehouse:  { statbl-id: A_2024_00122, dtacycle-cd: MM }                                       # 전세가격지수 단독주택
+      trade-volume-total:      { statbl-id: A_2024_00604, dtacycle-cd: MM }                                       # 거래량 주택종합
+      trade-volume-apt:        { statbl-id: A_2024_00612, dtacycle-cd: MM, indicator-code: APT_TRANSACTION_COUNT }# 아파트 매매거래호수 (대표)
+      land-price-change:       { statbl-id: A_2024_00903, dtacycle-cd: MM, indicator-code: LAND_PRICE_CHANGE_RATE }# 지가변동률
   hub:
     base-url: https://apis.data.go.kr/1613000
     api-key: ${HUB_API_KEY:}


### PR DESCRIPTION
## Summary

PR #70 (REB R-ONE 광역시도 어댑터 재설계) 머지 후 운영 검증에서 REB 카드가 화면 광역 섹션에 노출되지 않던 두 결함을 정정합니다.

증상:
- DB의 `real_estate_market_indicator` 에 `source=REB` 행이 정상 적재되어 있음
- `/api/realestate/sources/availability` 응답 `reb.available=true`
- 그러나 `GET /api/realestate/market/tabs/{category}?regionCode=11` 의 `cards` 가 빈 배열
- 화면에 "광역 통계 준비중" 또는 빈 광역 섹션이 표시됨

## Changes

### Fix 1 — metadata indicator-code ↔ adapter 저장 코드 일치

- `RebStatblProperties.Entry` 에 nullable `indicatorCode` 필드 추가
- `application.yml` 의 4종 묶음(주택종합/아파트/연립/단독) 중 대표 1종(`-total`)만 `indicator-code` 매핑 — Q1=A 정책
- `RebAdapter.of()` 는 indicator-code 미매핑 entry를 skip
- `RebAdapter.buildIndicator()` 는 STATBL ID 대신 metadata 의미 코드(`SALE_PRICE_INDEX` 등)로 저장

### Fix 2 — 시군구(5자리) 진입 시 상위 광역(SIDO) 카드 attach

- `RealEstateMarketQueryService.getTab()` 에서 `regionCode.length()==5`이면 앞 2자리로 추가 `buildCardsFor` 호출 → cards에 합쳐 응답
- 프론트는 `regionLevel='SIDO'` 필터로 광역 섹션에 분리 렌더링

### 부수

- `RebClient` 운영 점검 후속(`.do` suffix / `INFO-000` 결과 코드 / 중첩 `RESULT`·`row` 재귀 탐색) 동반 반영

### Docs

- `docs/brainstorms/2026-05-30-001-reb-sido-cards-not-shown.md` — 원인 정리
- `docs/plans/2026-05-30-001-fix-reb-sido-cards-plan.md` — 구현 단계 추적
- `docs/solutions/ui-bugs/reb-sido-cards-not-shown-2026-05-30.md` — 정본 학습 (cross-ref: `architecture-patterns/realestate-public-open-api-pitfalls`, `architecture-patterns/ecos-indicator-identifier-source-of-truth`)

## Verification

- 빌드: `./gradlew compileJava` 성공
- DB 정리 후 배치 재실행: `source=REB` 행 68건 (17 SIDO × 4 indicator)
- API:
  ```
  GET /api/realestate/market/tabs/PRICE_INDEX?regionCode=11
  → cards: [{indicatorCode: SALE_PRICE_INDEX, regionLevel: SIDO, source: REB}]

  GET /api/realestate/market/tabs/PRICE_INDEX?regionCode=11110
  → cards: [
      {indicatorCode: PRICE_PER_SQM, regionLevel: SIGUNGU, source: MOLIT},
      {indicatorCode: SALE_PRICE_INDEX, regionLevel: SIDO, source: REB}
    ]
  ```

## Post-Deploy Monitoring & Validation

- 6:00 KST 배치 로그에서 `REB` 어댑터 `success / failure` 카운트 확인
- DB: `SELECT COUNT(*) FROM real_estate_market_indicator WHERE source='REB' AND snapshot_date > NOW() - INTERVAL '1 day'` ≥ 68
- API 헬스: 임의 SIGUNGU 1개로 `/api/realestate/market/tabs/PRICE_INDEX?regionCode=XXXXX` 응답 cards에 `regionLevel=SIDO` 카드 포함 여부 확인
- 실패 신호: cards 빈 배열로 회귀 / availability `reb.available=false`로 회귀 → 즉시 본 PR 롤백

## Test plan

- [ ] 화면(부동산 시장 → 매매 가격 / 전월세 / 공식 통계) 진입 시 광역 섹션에 REB 카드 노출
- [ ] 시군구 카드 선택 시 광역 섹션이 함께 표시
- [ ] 광역시도(SIDO) 17개 카드 모두 데이터 노출