### PR TITLE
fix(stock-financial): 재무 타임라인 계정 taxonomy 값 누락 보강 + 조 단위 2자리 버림 (#85)

### DIFF
--- a/docs/brainstorms/2026-07-19-timeline-account-taxonomy-brainstorm.md
+++ b/docs/brainstorms/2026-07-19-timeline-account-taxonomy-brainstorm.md
@@ -1,0 +1,42 @@
+# 재무 타임라인 계정 taxonomy 불일치 - Brainstorm
+
+**Date:** 2026-07-19
+**Status:** Decided (원인 실측 확정 + 수정 범위 "근본 수정" 승인, 2026-07-19)
+**Gate:** docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+**Issue:** https://github.com/osnet-th/stock-market/issues/85
+
+## 배경
+현대차(005380) 기업 리포트/타임라인에서 연도별 당기순이익·영업활동현금흐름이 "—"로 누락되어 파생 계산이 끊긴다는 태형님 지적. 원천 DART까지 실측해 원인을 확정.
+
+## 확정 원인 (원천 DART 실측)
+
+### A. 영업활동현금흐름 2017·2018 "—" — 세부계정 id 접두사 불일치
+- 2017·2018 사업보고서(11011, CFS): `id=ifrs_CashFlowsFromUsedInOperatingActivities` (구 접두사), 값 3.92조·3.76조 존재.
+- 2019~: `id=ifrs-full_CashFlowsFromUsedInOperatingActivities` (신 접두사).
+- `FinancialTimelineAssembler.detailRowKey`(FinancialTimelineAssembler.java:172)가 accountId로 키잉 → 구/신 접두사 **별도 행 분리**.
+- `SnapshotFinancialExtractor.detailSeries(CF, "ifrs-full_…", "영업활동")`가 `findFirst()`로 신 접두사 행만 선택 → 2017·2018 누락.
+
+### B. 당기순이익 2018~2022 "—" — 요약 소스(주요계정) 결측
+- `fnlttSinglAcnt`(주요계정)에 현대차 2018~2022 당기순이익 행 **부재**(2020 실측). 2024는 "당기순이익(손실)"로 존재.
+- 값은 `fnlttSinglAcntAll`(전체재무제표) IS "연결당기순이익"에 존재(2020=1.92조, id="-표준계정코드 미사용-").
+- 요약(`toSummaryRows`, accountName 키잉) 기반 `summarySeries("당기순이익")`가 결측 연도 보강 못함.
+
+### (버그 아님) 영업CF 음수 2020~2025
+- DART 실제 값. 현대차 연결은 캐피탈/금융리스 채권 증가가 영업활동 유출로 반영 → 연결 OCF 음수/소액. 정상.
+
+## 수정 방향 (근본 — 조립기, 태형님 "근본 수정" 승인)
+1. **A**: IFRS 계정 id 접두사 정규화(`ifrs_` ↔ `ifrs-full_` 동일 요소)로 세부행 병합 → BS/IS/CF 전체 세부계정 적용. 종목 평가·재무 타임라인·기업 리포트 모두 정상화.
+2. **B**: 요약 당기순이익 결측 시 전체재무제표 IS의 **연결 총계 당기순이익**(`ifrs-full_ProfitLoss` / "연결당기순이익")으로 보강. 지배·비지배·계속영업 하위 라인 제외.
+
+## Open Questions (plan에서 확정)
+1. id 정규화 지점: `detailRowKey` + `matches`/`detailSeries`만? 아니면 파싱 단계에서 canonical id? `dart_` 접두사·"-표준계정코드 미사용-"는 이름 키 유지.
+2. B의 보강을 조립기(summaryRows에 net income backfill)에서 할지, 추출기에서 detail 참조로 할지. 근본 수정 취지상 조립기.
+3. B에서 "총계 당기순이익" 식별 규칙: id `ifrs-full_ProfitLoss` 우선, 무표준코드면 이름 "당기순이익"/"연결당기순이익"이되 "지배기업소유주지분"·"비지배지분"·"계속영업" 제외.
+4. 요약 결측이 당기순이익 외 다른 계정(매출액·영업이익·자산총계 등)에도 있는지 → 연도별 실측 후 보강 범위 결정.
+
+## 검증 기준
+- 현대차 005380: 영업CF·당기순이익 2017~2026 전부 채워짐, FCF·성장률·EPS 파생 정상.
+- 회귀 없음: 삼성전자 등 기존 정상 종목 값 불변(스냅샷 재검증).
+
+## 범위 밖
+- 영업CF 음수(정상), #84.

--- a/docs/commits/2026-07-19-timeline-account-taxonomy-commit.md
+++ b/docs/commits/2026-07-19-timeline-account-taxonomy-commit.md
@@ -1,0 +1,28 @@
+# 재무 타임라인 taxonomy + 조 버림 Commit 기록
+
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+issue: https://github.com/osnet-th/stock-market/issues/85
+branch: fix/issue-85-timeline-account-taxonomy
+
+## 승인
+- 태형님 승인 (2026-07-19, "커밋 3개로 분리해서 진행해") — #85는 2개 커밋으로 분리(taxonomy / 조버림).
+
+## 커밋 A — taxonomy 보강
+메시지: fix(stock-financial): 연도별 DART 계정 taxonomy 불일치 값 누락 보강 — 영업CF·당기순이익·영업이익·매출액 (#85)
+포함:
+- src/main/java/.../stock/application/FinancialTimelineAssembler.java
+- docs/brainstorms·issues·plans·works·reviews·validations·gates·commits/2026-07-19-timeline-account-taxonomy-*.md
+
+## 커밋 B — 조 단위 표시 2자리 버림 (번들, 무관)
+메시지: fix(ui): 금액 조 단위 표시 반올림 → 2자리 버림 — 종목평가·기업리포트 (#85)
+포함:
+- src/main/resources/static/js/utils/format.js (truncTo2 + compactNumber trunc 옵션)
+- src/main/resources/static/js/components/company-report.js (crAmt)
+- src/main/resources/static/js/components/stock-eval.js (fmtAmountByUnit)
+
+## 제외 파일
+- .env(비추적), 기타 없음.
+
+## 비고
+- 커밋 순서: A(taxonomy) → B(조버림).
+- 푸시는 별도 게이트(미승인) — 커밋까지만.

--- a/docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+++ b/docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
@@ -1,0 +1,27 @@
+# 재무 타임라인 계정 taxonomy 불일치 게이트 로그
+
+## 원칙
+- 각 단계 시작 전 태형님에게 작업 내용을 제시한다.
+- 다음 단계로 넘어갈지에 대한 판단은 태형님에게 넘긴다.
+- 단계별 산출물은 이 게이트 로그를 `gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md`로 참조한다.
+
+## Stage Decisions
+- start: approved (2026-07-19, 현대차 값 누락 원인 확인 요청 → 원천 DART 진단)
+- brainstorm: approved (2026-07-19, "방금 나온 두가지 이슈 한번에 처리하고싶어") / 완료 (2026-07-19, 원인 실측 확정 + 수정 범위 "근본 수정" 선택)
+- issue: approved (2026-07-19, 근본 수정 선택 = 등록 승인 — Issue #85 등록, worktree 생성)
+- plan: approved (2026-07-19, "진행해" — 결정1 공유 canonical 헬퍼·결정2 결측 보강(a) 포함, 공유 타임라인 Approval Gate 승인)
+- work: approved (2026-07-19, plan 승인과 함께 work 진입 — Phase 1~2 구현) / 완료 (2026-07-19, 조립기만 수정·compileJava exit 0, docs/works/2026-07-19-timeline-account-taxonomy-work.md)
+- review: approved (2026-07-19, "ce:review 로") / 완료 (2026-07-19, 4관점 — MED 1·LOW 4, 보안/성능 findings 없음, docs/reviews/2026-07-19-timeline-account-taxonomy-review.md)
+- review 반영: 태형님 결정 (2026-07-19) — F1 하드닝(ifrs-full_ProfitLoss id 우선 + 주당 제외) + F4 nit. work 복귀 반영·재컴파일 exit 0 (work 문서 "리뷰 반영")
+- validation: approved (2026-07-19, "진행해" — wt-85 재기동) / 완료 (2026-07-19, 현대차 netIncome·operatingCf·fcf 2017~2026 전부 채워짐·DART 값 일치, 삼성 회귀 없음(기존 값 불변)+2017·2018 영업CF 개선, docs/validations/2026-07-19-timeline-account-taxonomy-validation.md). priceMetrics EPS 경고는 ValuationMetricService 선행 별개 항목(범위 밖)
+- 범위 확장: 태형님 지적 (2026-07-19 "영업이익 없는데? 매출액도 같이") — validation 중 영업이익 2018·2019 결측 발견. 보강을 매출액·영업이익·당기순이익 3종으로 일반화(work 범위 확장). 재기동 재검증: 현대차 영업이익 2018=2.42조·2019=3.61조 채워짐(DART 일치), 삼성 불변. compileJava exit 0.
+- 번들 추가: 태형님 요청 (2026-07-19) — "조 2자리 버림" 통일. ① 공용 Format.truncTo2 신설 ② 종목평가 토글(stock-eval.js) ③ 기업리포트 crAmt(company-report.js, Format.compactNumber trunc 옵션). compactNumber 기본 동작 무변경(차트/재무 축 불변). 검증: 현대차 자본금 1.48조(이전 1.5조), 앱 재기동 새 JS 서빙 확인. 성격 달라 커밋 분리 예정.
+- commit: pending
+- push: pending
+
+## Notes
+- 원인: (A) 영업CF 2017·2018 — 세부계정 id 접두사(ifrs_ vs ifrs-full_) 별도 행 분리. (B) 당기순이익 2018~2022 — 주요계정(fnlttSinglAcnt) 결측(값은 전체재무제표 IS "연결당기순이익"에 존재).
+- 영업CF 음수(2020~2025)는 DART 실제 값 → 범위 밖.
+- Approval Gate 예정: 공유 타임라인(FinancialTimelineAssembler) 비즈니스 로직 변경 — 종목 평가·재무 타임라인 영향. plan 승인으로 확정.
+- 관련 코드: FinancialTimelineAssembler(detailRowKey·toSummaryRows·mergeRows), SnapshotFinancialExtractor(summarySeries·detailSeries).
+- 선행 무관 작업: #84(feat/issue-84, commit 게이트 대기).

--- a/docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+++ b/docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
@@ -16,8 +16,8 @@
 - validation: approved (2026-07-19, "진행해" — wt-85 재기동) / 완료 (2026-07-19, 현대차 netIncome·operatingCf·fcf 2017~2026 전부 채워짐·DART 값 일치, 삼성 회귀 없음(기존 값 불변)+2017·2018 영업CF 개선, docs/validations/2026-07-19-timeline-account-taxonomy-validation.md). priceMetrics EPS 경고는 ValuationMetricService 선행 별개 항목(범위 밖)
 - 범위 확장: 태형님 지적 (2026-07-19 "영업이익 없는데? 매출액도 같이") — validation 중 영업이익 2018·2019 결측 발견. 보강을 매출액·영업이익·당기순이익 3종으로 일반화(work 범위 확장). 재기동 재검증: 현대차 영업이익 2018=2.42조·2019=3.61조 채워짐(DART 일치), 삼성 불변. compileJava exit 0.
 - 번들 추가: 태형님 요청 (2026-07-19) — "조 2자리 버림" 통일. ① 공용 Format.truncTo2 신설 ② 종목평가 토글(stock-eval.js) ③ 기업리포트 crAmt(company-report.js, Format.compactNumber trunc 옵션). compactNumber 기본 동작 무변경(차트/재무 축 불변). 검증: 현대차 자본금 1.48조(이전 1.5조), 앱 재기동 새 JS 서빙 확인. 성격 달라 커밋 분리 예정.
-- commit: pending
-- push: pending
+- commit: 완료 (2026-07-19, "커밋 3개로 분리해서 진행해" — A d0db287 taxonomy / B 9fcf31d 조버림, docs/commits/2026-07-19-timeline-account-taxonomy-commit.md)
+- push: approved (2026-07-19, "push 해서 pr 올리고 메인에 다 병합까지" — origin push + PR 생성·main 병합 진행, docs/pushes/2026-07-19-timeline-account-taxonomy-push.md)
 
 ## Notes
 - 원인: (A) 영업CF 2017·2018 — 세부계정 id 접두사(ifrs_ vs ifrs-full_) 별도 행 분리. (B) 당기순이익 2018~2022 — 주요계정(fnlttSinglAcnt) 결측(값은 전체재무제표 IS "연결당기순이익"에 존재).

--- a/docs/issues/2026-07-19-timeline-account-taxonomy-issue.md
+++ b/docs/issues/2026-07-19-timeline-account-taxonomy-issue.md
@@ -1,0 +1,21 @@
+# 재무 타임라인 계정 taxonomy 불일치 Issue 기록
+
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+
+## GitHub Issue
+- status: created
+- issue_number: 85
+- issue_url: https://github.com/osnet-th/stock-market/issues/85
+- title: [fix] 재무 타임라인 — 연도별 DART 계정 taxonomy 불일치로 값 누락 (영업CF 2017·2018, 당기순이익 2018~2022)
+- label: bug
+
+## 근거
+- brainstorm: docs/brainstorms/2026-07-19-timeline-account-taxonomy-brainstorm.md (Status: Decided)
+- 원인: 원천 DART 실측 — 영업CF는 id 접두사(ifrs_ vs ifrs-full_) 세부행 분리, 당기순이익은 주요계정 API 결측(값은 전체재무제표에 존재).
+- 수정 범위: 태형님 "근본 수정" 선택(2026-07-19 AskUserQuestion) — 조립기(FinancialTimelineAssembler) 수정, 종목 평가·재무 타임라인 공유.
+- #84(기업 리포트 입력 개선)과 독립. 별도 worktree.
+
+## Worktree
+- branch: fix/issue-85-timeline-account-taxonomy
+- base: main (d03e4a1)
+- 생성 명령: `scripts/create-worktree.sh --issue 85 fix/issue-85-timeline-account-taxonomy`

--- a/docs/plans/2026-07-19-001-fix-timeline-account-taxonomy-plan.md
+++ b/docs/plans/2026-07-19-001-fix-timeline-account-taxonomy-plan.md
@@ -1,0 +1,54 @@
+---
+title: "fix: 재무 타임라인 연도별 DART 계정 taxonomy 불일치 값 누락"
+type: fix
+status: active
+date: 2026-07-19
+origin: docs/brainstorms/2026-07-19-timeline-account-taxonomy-brainstorm.md
+issue: https://github.com/osnet-th/stock-market/issues/85
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+---
+
+# fix: 재무 타임라인 계정 taxonomy 불일치
+
+## Overview
+현대차(005380) 등에서 연도별 DART 계정 표기가 해마다 달라(구 `ifrs_` vs 신 `ifrs-full_` 접두사, 주요계정 결측) 타임라인 조립 시 값이 "—"로 빠지는 문제를 **조립기(FinancialTimelineAssembler)** 에서 근본 수정한다. 타임라인은 기업 리포트·종목 평가·재무 타임라인이 공유하므로 세 곳 모두 정상화된다.
+
+## Approval Gate (본 plan 승인으로 확정)
+- 공유 컴포넌트 `FinancialTimelineAssembler`(stock.application)의 계정 병합/요약 로직 동작 변경 → 종목 평가·재무 타임라인·기업 리포트 스냅샷 영향. 회귀 검증(삼성 등) 필수.
+- `SnapshotFinancialExtractor`의 매칭이 조립기 canonical id에 맞춰 동작하도록 동반 수정.
+
+## 확정 원인 (원천 DART 실측, 현대차)
+- **A 영업CF 2017·2018**: 세부계정 `id=ifrs_...`(≤2018) vs `ifrs-full_...`(≥2019) → `detailRowKey`(accountId 키잉)가 두 행으로 분리 → 추출기 `findFirst()`가 신 접두사 행만 선택.
+- **B 당기순이익 2018~2022**: 주요계정(`fnlttSinglAcnt`)에 해당 연도 당기순이익 부재. 값은 전체재무제표 IS "연결당기순이익"에 존재(2018 1.65조·2019 3.19조·2020 1.93조·2021 5.69조·2022 7.98조; ≤2022 무표준코드, ≥2023 `ifrs-full_ProfitLoss`). 지배·비지배·계속영업 제외 시 연도당 총계 1개.
+
+## 수정 설계
+
+### Phase 1 — Bug A: IFRS 계정 id 접두사 정규화
+- `canonicalAccountId(id)` 헬퍼 신설: `ifrs-full_` / `ifrs_` 접두사를 **동일 canonical**로 정규화(예: `ifrs-full_` → `ifrs_`). `null`·`-표준계정코드 미사용-`·`dart_`·기타는 이름 키 유지(기존 동작 보존).
+- 적용: `FinancialTimelineAssembler.detailRowKey`가 canonical id로 키잉 → `ifrs_X`/`ifrs-full_X` 세부행 병합(BS/IS/CF 전체).
+- 동반: `SnapshotFinancialExtractor.matches`/`detailSeries`, `FinancialTimelineAssembler.findCashFlowAmount`가 canonical id로 비교(상수는 `ifrs-full_...` 유지하되 비교 시 정규화).
+- **결정 필요**: canonical 헬퍼 배치 위치(공유 util — stock.application 또는 공통 지점). extractor(companyreport)와 assembler(stock) 양쪽에서 동일 규칙 사용해야 하므로 단일 소스로 둔다.
+
+### Phase 2 — Bug B: 당기순이익 총계 보강(요약 결측 시 상세에서 채움)
+- 조립기에 **총계 당기순이익 시리즈** resolver 신설: 전체재무제표 IS에서 이름 정규화가 "당기순이익"/"당기순이익(손실)"/"연결당기순이익"이고 "지배기업소유주지분"·"비지배지분"·"계속영업"·"중단영업" **미포함**인 행의 연도별 값(id 우선 `ifrs-full_ProfitLoss`, 없으면 이름 규칙).
+- 요약 당기순이익 행에 **결측 연도만 보강**(기존 값 우선 → 회귀 최소). 요약 자체가 없으면 상세 총계로 행 생성.
+- **결정 필요**: (a) 결측 보강만 vs (b) 당기순이익 요약을 상세 총계로 일원화. 회귀 안전상 (a) 권장.
+
+## Phase별 작업 (work 체크리스트)
+- [ ] `canonicalAccountId` 헬퍼 + 배치 결정, 단위 동작 확인
+- [ ] `FinancialTimelineAssembler.detailRowKey` canonical 적용
+- [ ] `SnapshotFinancialExtractor.matches`/`detailSeries` canonical 비교 + `findCashFlowAmount` 동반
+- [ ] 총계 당기순이익 resolver + 요약 결측 보강
+- [ ] 컴파일
+
+## 검증 계획 (validation)
+- 앱 기동 후 현대차 005380 스냅샷: 영업CF·당기순이익·FCF **2017~2026 전부** 채워짐, 성장률/EPS 파생 정상.
+- 회귀: 삼성전자 등 기존 정상 종목 스냅샷 값 불변(수정 전후 비교), 종목 평가 재무 타임라인 세부계정 트리 중복/누락 없음.
+
+## 리스크
+- id 정규화가 서로 다른 계정을 오병합할 위험 → `ifrs`/`ifrs-full` 접두사만 정규화(suffix 동일 = 동일 요소), `dart_`·무표준코드는 이름 키 유지로 한정.
+- 당기순이익 총계 선택 시 지배/비지배/계속영업 라인 오선택 위험 → 제외 규칙 명시 + 연도별 실측 검증.
+- 공유 타임라인 변경 → 종목 평가 회귀 반드시 확인.
+
+## 범위 밖
+- 영업CF 음수(정상 DART 값), #84.

--- a/docs/pushes/2026-07-19-timeline-account-taxonomy-push.md
+++ b/docs/pushes/2026-07-19-timeline-account-taxonomy-push.md
@@ -1,0 +1,19 @@
+# 재무 타임라인 taxonomy + 조 버림 Push 기록
+
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+issue: https://github.com/osnet-th/stock-market/issues/85
+
+## 승인
+- 태형님 승인 (2026-07-19, "push 해서 pr 올리고 메인에 다 병합까지 끝내서 확인해줘").
+
+## 대상
+- remote: origin, branch: fix/issue-85-timeline-account-taxonomy
+- 흐름: origin push → PR 생성 → PR 머지(main) → 확인.
+
+## 커밋
+- d0db287 fix(stock-financial): taxonomy 값 누락 보강 (#85)
+- 9fcf31d fix(ui): 금액 조 단위 2자리 버림 (#85)
+- (+ 게이트/푸시 원장 docs 커밋)
+
+## 결과
+- push/PR/merge 결과는 실행 후 최종 응답에 기록.

--- a/docs/reviews/2026-07-19-timeline-account-taxonomy-review.md
+++ b/docs/reviews/2026-07-19-timeline-account-taxonomy-review.md
@@ -1,0 +1,40 @@
+# 재무 타임라인 계정 taxonomy 불일치 Review 기록 (ce:review)
+
+work: docs/works/2026-07-19-timeline-account-taxonomy-work.md
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+issue: https://github.com/osnet-th/stock-market/issues/85
+review_agents: code-simplicity-reviewer, security-sentinel, performance-oracle, architecture-strategist
+
+## Findings (심각도 순)
+
+### F1 [MED · 정확성] 당기순이익 총계 매칭이 이름 contains + 무정렬 findFirst
+- 근거: `FinancialTimelineAssembler.isTotalNetIncome`/`detailNetIncomeTotal`. `contains("당기순이익")` + `지배/비지배/계속영업/중단영업` 제외 + DART 응답순 `findFirst`.
+- 위험: 비표준 라벨 **"주당당기순이익"(EPS, 주당값)** 은 contains에 걸리고 제외어에도 안 걸림. 응답순에서 총계보다 앞서면 결측 연도에 **주당값(수천 원)** 이 backfill → 요약 당기순이익 오표기 + snapshot ROE/ROA/EPS폴백/발생액/실효세율 전파. (실무상 총계가 EPS보다 앞서 오면 무해하나 순서 의존.)
+- 완화안: `canonicalAccountId(id) == "ifrs-full_ProfitLoss"`(정확 총계 요소) 우선 매칭 + 무표준코드 연도는 이름 매칭(`!contains("주당")` 추가)으로 폴백.
+
+### F2 [LOW · 정확성] backfill 대상 행 선택 startsWith("당기순이익")
+- `normalize(name).startsWith("당기순이익")` findFirst — "당기순이익률"(비율) 앞서면 오선택 가능. 단 요약계정(fnlttSinglAcnt)은 비율 행 미반환 + 소비자 `SnapshotFinancialExtractor.summarySeries`가 **동일 기준** 사용 → 실질 위험 없음(기준 일치는 강점).
+
+### F3 [LOW · 정합성] putIfAbsent null 값 의미
+- `putIfAbsent(year, currentTermAmount())`에 null 저장 가능(DART 금액 null). Map은 null을 "부재"로 취급 → 기존 셀 null인 연도는 상세 총계로 덮어써짐. 크래시 아님, "기존 값 보존" 주석과 미묘한 불일치(대체로 결측 보강 의도엔 부합).
+
+### F4 [LOW · 단순성] 네이밍/상수/주석 nit
+- `detailNetIncomeTotal`은 Map<연도,값> 반환 → `...ByYear`/`Series`가 정확(지역변수 `total`도 Map). "IS"/"CIS" 리터럴 인라인(파일 내 `CASH_FLOW_DIV` 등과 스타일 불일치). "연결 총계" 주석은 OFS(별도)일 때 부정확.
+
+### F5 [LOW · cosmetic] netRow==null 신규 행 append
+- 어느 해에도 당기순이익 요약 행이 없던 종목: 신규 행이 리스트 맨 뒤 → 종목평가/타임라인에서 IS 자연 위치가 아닌 뒤에 표시(값·매칭 정상).
+
+### 보안 (security-sentinel): 명시적 findings 없음
+- canonicalAccountId(null)·normalize(null)·substring 경계·isTotalNetIncome null 필드·details() non-null(서비스가 List.of() 보장)·mutable 맵/리스트 전부 안전, 신규 크래시 표면 없음.
+
+### 성능 (performance-oracle): 명시적 findings 없음
+- `detailNetIncomeTotal`은 assemble당 1회, ≤10컬럼 × IS/CIS 행. DART 70콜 대비 반올림 오차. N+1/DB 없음, 재계산 없음.
+
+## Open Questions / Assumptions
+1. F1 완화 여부(EPS 오매칭 방지) — id 우선 매칭 + `주당` 제외. 태형님 결정.
+2. 확인된 blast radius(개선): 구접두사 종목이 이제 BS/CF 앵커에 정상 편입 → 이전 빈 값이던 `borrowings`/`cashAndSecurities`/`valuationInputs`가 채워짐. validation에서 회귀 아닌 개선으로 확인.
+3. 정규화 `ifrs_`→`ifrs-full_`는 injective(서로 다른 요소 오병합 불가), raw `ifrs_` 키 소비자 없음(4관점 공통 확인).
+
+## Change Summary
+- 심각한 버그·보안·성능·회귀 없음. `putIfAbsent` 기존 값 보존이라 이미 맞던 셀 불변, 표준접두사(현대 등) 종목 주경로 무변화.
+- 핵심 개선 후보: **F1(당기순이익 총계 매칭 하드닝, MED)** + 저위험 nit(F4).

--- a/docs/validations/2026-07-19-timeline-account-taxonomy-validation.md
+++ b/docs/validations/2026-07-19-timeline-account-taxonomy-validation.md
@@ -1,0 +1,34 @@
+# 재무 타임라인 계정 taxonomy 불일치 Validation 기록
+
+work: docs/works/2026-07-19-timeline-account-taxonomy-work.md
+review: docs/reviews/2026-07-19-timeline-account-taxonomy-review.md
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+issue: https://github.com/osnet-th/stock-market/issues/85
+
+## 환경 (태형님 승인 "진행해" — wt-85 재기동)
+- wt-84 앱 종료 → wt-85 `SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun` 기동. health 200, 기존 `local-postgres` 연동. dev 사용자(id=1) JWT 주입으로 API 검증.
+- `./gradlew compileJava` → exit 0.
+
+## 실행/결과 (preview 스냅샷 API)
+
+### 버그 수정 확인 — 현대차 005380
+| 항목 | 2017~2026 | 검증 |
+|------|-----------|------|
+| netIncome | **전부 채워짐**(이전 2018~2022 누락) | 2018=1.645조·2020=1.925조·2022=7.984조 → DART 정확 일치 |
+| operatingCf | **전부 채워짐**(이전 2017·2018 누락) | 2017=3.922조·2018=3.764조 → DART 정확 일치 |
+| fcf | **전부 채워짐** | 영업CF 복구로 파생 정상 |
+| operatingProfit(영업이익) | **전부 채워짐**(이전 2018·2019 누락 — 범위 확장분) | 2018=2.422조·2019=3.606조 → DART 정확 일치 |
+| revenue(매출액) | 전부 채워짐(원래 결측 없음, 방어적 보강 무해) | — |
+
+### 회귀 — 삼성전자 005930
+- netIncome 2024=34.5조·2025=45.2조 **기존 값 불변**(putIfAbsent 보존 확인).
+- operatingCf 2017=62.2조·2018=67.0조 **채워짐**(삼성도 2017·2018 구 `ifrs_` 접두사 → id 정규화로 개선), 2024=73.0조 그대로.
+- operatingProfit 2018=58.9조·2019=27.8조 **불변**(삼성은 원래 완전 → 보강 무해).
+- revenue·operatingProfit·netIncome 결측(2017~2025) NONE.
+
+## 미해결/범위 밖 (별개 선행 항목)
+- `priceMetrics.eps` 경고 "당기순이익 값을 찾지 못했습니다"는 삼성·현대 **둘 다** 표시되며 출처가 `ValuationMetricService.java:101`(타임라인과 별개 KRX 밸류에이션 컴포넌트). EPS 값 자체는 정상 산출(현대 51,031·삼성 7,757). **#85 범위 밖 선행 이슈** — 필요 시 후속 이슈 후보.
+
+## 정리
+- preview 엔드포인트 사용(리포트 영속 없음, 정리 불필요).
+- wt-85 앱은 기동 상태로 둠(수정본, 태형님 사용 가능). `local-postgres`·Docker Desktop 유지.

--- a/docs/works/2026-07-19-timeline-account-taxonomy-work.md
+++ b/docs/works/2026-07-19-timeline-account-taxonomy-work.md
@@ -1,0 +1,52 @@
+# 재무 타임라인 계정 taxonomy 불일치 Work 기록
+
+plan: docs/plans/2026-07-19-001-fix-timeline-account-taxonomy-plan.md
+gate: docs/gates/2026-07-19-timeline-account-taxonomy-gates.md
+issue: https://github.com/osnet-th/stock-market/issues/85
+
+## 구현 요약 (조립기만 수정 — FinancialTimelineAssembler)
+
+### Phase 1 — Bug A: IFRS id 접두사 정규화 (영업CF 2017·2018)
+- `canonicalAccountId(id)` 신설: 구 `ifrs_X` → 신 `ifrs-full_X`(표준형)로 정규화. `ifrs-full_`·`dart_`·`-표준계정코드 미사용-`·기타는 그대로.
+- `detailRowKey`: account_id를 canonical로 키잉 → 구/신 접두사 세부행이 **한 행으로 병합**(BS/IS/CF 전체). 병합 행 id가 표준 `ifrs-full_`이라 트리 빌더 앵커·BS 앵커·추출기 매칭이 그대로 동작.
+- `findCashFlowAmount`(FCF): `canonicalAccountId(item.accountId())` 비교 → 2017·2018 영업CF·유형/무형취득 인식(FCF도 복구).
+- **설계 정정(plan 대비)**: 정규화 방향을 `ifrs-full_`(표준형)로 잡아 다운스트림(FinancialDetailTreeBuilder 앵커, SnapshotFinancialExtractor 상수 모두 `ifrs-full_`)이 유지됨 → **추출기·트리빌더 수정 불필요**. canonical은 조립기 private 메서드(단일 소스).
+
+### Phase 2 — Bug B: 당기순이익 총계 보강 (2018~2022)
+- `detailNetIncomeTotal(data)`: 전체재무제표 IS/CIS에서 이름에 "당기순이익" 포함 + "지배"·"비지배"·"계속영업"·"중단영업" 제외인 총계를 연도별 수집(id 무관, 무표준코드 연도 포함).
+- `backfillNetIncome(rows, data)`: 요약(주요계정) 당기순이익 행의 **결측 연도만** `putIfAbsent`로 보강(기존 값 보존 = 회귀 최소). 요약에 당기순이익 행 자체가 없으면 상세 총계로 신설.
+- `toSummaryRows`를 mutable 리스트로 바꿔 보강 적용.
+
+## 변경 파일
+- src/main/java/com/thlee/stock/market/stockmarket/stock/application/FinancialTimelineAssembler.java (유일)
+
+## 영향/하위호환
+- 정규화 방향이 표준형이라 기존 `ifrs-full_` 매칭 전부 유지. 구 `ifrs_` 행은 이제 표준 앵커에 정상 편입(개선).
+- 당기순이익은 결측 연도만 채워 기존 표시값 불변(회귀 없음 설계).
+- 공유 타임라인 → 종목 평가·재무 타임라인도 동일 개선.
+
+## 리뷰 반영 (ce:review, 2026-07-19 태형님 결정 "F1 하드닝 + F4 nit")
+- **F1 (MED, 당기순이익 총계 매칭 하드닝)**: `netIncomeTotalOf` 신설 — 표준 id `ifrs-full_ProfitLoss`(접두사 정규화) 우선 매칭, 없을 때만(무표준코드 연도) 이름 폴백. 이름 폴백에 **`주당` 제외** 추가 → "주당당기순이익"(EPS) 오매칭 방지. `isTotalNetIncome` → `netIncomeTotalOf` + `isTotalNetIncomeName`으로 분리.
+- **F4 (nit)**: `detailNetIncomeTotal` → `detailNetIncomeByYear`(반환이 연도별 Map), 지역변수 `total`→`byYear`, "IS"/"CIS"/총계 id를 상수화(`INCOME_STMT_DIV`·`COMPREHENSIVE_INCOME_DIV`·`NET_INCOME_ID`), "연결 총계" 주석 완화.
+- F2·F3·F5(LOW): 실질 위험 없음/설계 의도 부합으로 유지(리뷰 문서 기록).
+
+## 범위 확장 (validation 중, 태형님 지적 "영업이익 없는데? 매출액도 같이" 2026-07-19)
+- 현대차 검증 중 **영업이익 2018·2019 "—"** 발견 — 당기순이익과 동일 계열(주요계정 결측, 값은 전체재무제표에 존재). brainstorm Open Question #4(매출액·영업이익 등) 실현.
+- 보강 로직을 **일반화**: `backfillNetIncome` → `backfillSummaryAmounts`(매출액·영업이익·당기순이익 3종). 계정별 `(요약 이름 prefix, 표준 id, 이름 매처)` 구성 — `backfillSummaryRow`/`detailTotalByYear`/`incomeStatementTotal` 공통화.
+- 표준 id: 매출액 `ifrs-full_Revenue`·영업이익 `ifrs-full_ProfitLossFromOperatingActivities`·당기순이익 `ifrs-full_ProfitLoss`. 무표준코드 연도는 이름 폴백(매출액 "매출액"·영업이익 "영업이익", 둘 다 "률" 제외).
+- 전부 `putIfAbsent` 결측 보강 → 기존 값 불변(회귀 안전 유지).
+
+## 번들 추가 (무관 · 태형님 요청 "#85 worktree에 포함", 2026-07-19) — "조 2자리 버림" 통일
+성격이 #85(타임라인)과 다른 프론트 표시 수정. **커밋은 별도로 분리** 예정.
+- 공용 헬퍼 **`Format.truncTo2`** 신설(문자열 절단 `toFixed(6)`→2자리, 부동소수 오차 방지).
+- **종목평가 억↔조 토글**: `stock-eval.js` `fmtAmountByUnit` — 조 변환 1자리 반올림 → 2자리 버림. `Format.truncTo2` 사용.
+- **기업리포트**: `Format.compactNumber(value, trunc)`에 옵션 추가(기본 false=기존 1자리 반올림 유지 → **차트 축·재무 화면 불변**), `company-report.js` `crAmt`가 `trunc=true`로 조 2자리 버림.
+- 검증(로직): 현대차 자본금 1,488,993,000,000 → **1.48조**(이전 1.5조), 45.206조→45.2, 1,862.54조(콤마), 종목평가 45.28→45.28. 앱 재기동 후 새 JS 서빙 확인.
+- 범위: compactNumber 기본 동작 무변경(차트/재무 축 영향 없음), 기업리포트 crAmt만 버림 적용.
+
+## work 검증
+- `./gradlew compileJava` → exit 0 (리뷰 반영·범위 확장 후 재컴파일 포함). stock-eval.js는 정적 리소스(컴파일 무관).
+
+## 미검증 (validation 단계 대상)
+- 앱(wt-85) 기동 후 현대차 005380: 영업CF·당기순이익·FCF 2017~2026 전부 채워짐.
+- 회귀: 삼성전자 등 기존 정상 종목 스냅샷 값 불변, 종목 평가 재무 타임라인 세부계정 트리 중복/누락 없음.

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/application/FinancialTimelineAssembler.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/application/FinancialTimelineAssembler.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * 수집된 연도별 데이터를 "항목 × 연도" 매트릭스로 병합한다.
@@ -26,6 +27,12 @@ public class FinancialTimelineAssembler {
 
     private static final String UNUSED_ACCOUNT_ID = "-표준계정코드 미사용-";
     private static final String CASH_FLOW_DIV = "CF";
+    private static final String INCOME_STMT_DIV = "IS";
+    private static final String COMPREHENSIVE_INCOME_DIV = "CIS";
+    /** 손익 요약 총계 표준 계정 id (요약 결측 연도 보강용) */
+    private static final String REVENUE_ID = "ifrs-full_Revenue";
+    private static final String OPERATING_PROFIT_ID = "ifrs-full_ProfitLossFromOperatingActivities";
+    private static final String NET_INCOME_ID = "ifrs-full_ProfitLoss";
     private static final String FCF_NAME = "잉여현금흐름";
 
     /** Phase 0 실호출로 확정한 FCF 구성 계정의 IFRS 표준 ID (plan Open Questions 참고) */
@@ -39,6 +46,10 @@ public class FinancialTimelineAssembler {
     private static final String OPERATING_CF_NAME = "영업활동현금흐름";
     private static final String PPE_PURCHASE_NAME = "유형자산의 취득";
     private static final String INTANGIBLE_PURCHASE_NAME = "무형자산의 취득";
+
+    /** IFRS 계정 id 접두사 — 구(ifrs_) 신고분을 신(ifrs-full_) 표준형으로 정규화해 연도 간 병합 */
+    private static final String IFRS_LEGACY_PREFIX = "ifrs_";
+    private static final String IFRS_FULL_PREFIX = "ifrs-full_";
 
     public FinancialTimelineResponse assemble(List<TimelineColumnData> data, String fsDiv, Set<TimelineItem> items) {
         return FinancialTimelineResponse.builder()
@@ -54,14 +65,88 @@ public class FinancialTimelineAssembler {
     // === 요약 재무계정 ===
 
     private List<TimelineRow> toSummaryRows(List<TimelineColumnData> data, String fsDiv) {
-        return mergeRows(data, column -> summaryAccountsOf(column, fsDiv),
-                FinancialAccount::accountName, FinancialAccount::accountName, FinancialAccount::currentTermAmount);
+        List<TimelineRow> rows = new ArrayList<>(mergeRows(data, column -> summaryAccountsOf(column, fsDiv),
+                FinancialAccount::accountName, FinancialAccount::accountName, FinancialAccount::currentTermAmount));
+        backfillSummaryAmounts(rows, data);
+        return rows;
     }
 
     private List<FinancialAccount> summaryAccountsOf(TimelineColumnData column, String fsDiv) {
         return column.accounts().stream()
                 .filter(account -> fsDiv.equals(account.fsDiv()))
                 .toList();
+    }
+
+    /**
+     * 요약 손익 금액(매출액·영업이익·당기순이익) 결측 연도 보강 — 주요계정(fnlttSinglAcnt)에
+     * 없는 연도를 전체재무제표 IS 총계로 채운다. 기존 값은 보존(putIfAbsent).
+     */
+    private void backfillSummaryAmounts(List<TimelineRow> rows, List<TimelineColumnData> data) {
+        backfillSummaryRow(rows, "매출액", detailTotalByYear(data, REVENUE_ID, this::isRevenueTotalName));
+        backfillSummaryRow(rows, "영업이익", detailTotalByYear(data, OPERATING_PROFIT_ID, this::isOperatingProfitTotalName));
+        backfillSummaryRow(rows, "당기순이익", detailTotalByYear(data, NET_INCOME_ID, this::isNetIncomeTotalName));
+    }
+
+    private void backfillSummaryRow(List<TimelineRow> rows, String namePrefix, Map<String, String> byYear) {
+        if (byYear.isEmpty()) {
+            return;
+        }
+        TimelineRow target = rows.stream()
+                .filter(row -> normalize(row.getName()).startsWith(namePrefix))
+                .findFirst()
+                .orElse(null);
+        if (target == null) {
+            rows.add(new TimelineRow(namePrefix, namePrefix, new LinkedHashMap<>(byYear)));
+            return;
+        }
+        byYear.forEach((year, value) -> target.getValues().putIfAbsent(year, value));
+    }
+
+    /** 전체재무제표 IS/CIS에서 연도별 총계 금액 — 표준 id 우선, 무표준코드는 이름 폴백 */
+    private Map<String, String> detailTotalByYear(List<TimelineColumnData> data,
+            String standardId, Predicate<FullFinancialStatement> nameMatch) {
+        Map<String, String> series = new LinkedHashMap<>();
+        for (TimelineColumnData column : data) {
+            incomeStatementTotal(column.details(), standardId, nameMatch)
+                    .ifPresent(item -> series.putIfAbsent(column.year(), item.currentTermAmount()));
+        }
+        return series;
+    }
+
+    /** 손익계산서 총계 행: 표준 id(접두사 정규화) 우선, 없으면(무표준코드) 이름 매칭 폴백 */
+    private Optional<FullFinancialStatement> incomeStatementTotal(List<FullFinancialStatement> details,
+            String standardId, Predicate<FullFinancialStatement> nameMatch) {
+        List<FullFinancialStatement> incomeRows = details.stream()
+                .filter(item -> INCOME_STMT_DIV.equals(item.statementDiv())
+                        || COMPREHENSIVE_INCOME_DIV.equals(item.statementDiv()))
+                .toList();
+        return incomeRows.stream()
+                .filter(item -> standardId.equals(canonicalAccountId(item.accountId())))
+                .findFirst()
+                .or(() -> incomeRows.stream().filter(nameMatch).findFirst());
+    }
+
+    private boolean isRevenueTotalName(FullFinancialStatement item) {
+        String name = normalize(item.accountName());
+        return name.contains("매출액") && !name.contains("률");
+    }
+
+    private boolean isOperatingProfitTotalName(FullFinancialStatement item) {
+        String name = normalize(item.accountName());
+        return name.contains("영업이익") && !name.contains("률");
+    }
+
+    /** 연결 총계 당기순이익: 지배·비지배·계속영업·중단영업·주당(EPS) 라인 제외 */
+    private boolean isNetIncomeTotalName(FullFinancialStatement item) {
+        String name = normalize(item.accountName());
+        return name.contains("당기순이익")
+                && !name.contains("주당")
+                && !name.contains("지배") && !name.contains("비지배")
+                && !name.contains("계속영업") && !name.contains("중단영업");
+    }
+
+    private String normalize(String name) {
+        return name == null ? "" : name.replace(" ", "");
     }
 
     // === 재무지표 (4분류) ===
@@ -118,7 +203,7 @@ public class FinancialTimelineAssembler {
     private BigDecimal findCashFlowAmount(List<FullFinancialStatement> details, String accountId, String accountName) {
         return details.stream()
                 .filter(item -> CASH_FLOW_DIV.equals(item.statementDiv()))
-                .filter(item -> accountId.equals(item.accountId()) || accountName.equals(item.accountName()))
+                .filter(item -> accountId.equals(canonicalAccountId(item.accountId())) || accountName.equals(item.accountName()))
                 .findFirst()
                 .map(item -> parseAmount(item.currentTermAmount()))
                 .orElse(null);
@@ -167,13 +252,25 @@ public class FinancialTimelineAssembler {
     }
 
     /**
-     * 연도 간 행 매칭 키: account_id 우선, 표준계정코드 미사용이면 계정명 폴백
+     * 연도 간 행 매칭 키: account_id(접두사 정규화) 우선, 표준계정코드 미사용이면 계정명 폴백
      */
     private String detailRowKey(FullFinancialStatement item) {
         if (item.accountId() == null || UNUSED_ACCOUNT_ID.equals(item.accountId())) {
             return item.accountName();
         }
-        return item.accountId();
+        return canonicalAccountId(item.accountId());
+    }
+
+    /**
+     * IFRS 계정 id 접두사 정규화: 구 {@code ifrs_} → 신 {@code ifrs-full_}(표준형).
+     * 동일 taxonomy 요소가 연도별로 다른 접두사(2018년 이전 ifrs_, 이후 ifrs-full_)로 신고돼도 한 행으로 병합한다.
+     * {@code ifrs-full_}·{@code dart_}·기타 접두사는 그대로 둔다.
+     */
+    private String canonicalAccountId(String accountId) {
+        if (accountId != null && accountId.startsWith(IFRS_LEGACY_PREFIX)) {
+            return IFRS_FULL_PREFIX + accountId.substring(IFRS_LEGACY_PREFIX.length());
+        }
+        return accountId;
     }
 
     // === 공통 병합 헬퍼 ===

--- a/src/main/resources/static/js/components/company-report.js
+++ b/src/main/resources/static/js/components/company-report.js
@@ -694,7 +694,8 @@ const CompanyReportComponent = {
 
     // ==================== 표시 헬퍼 ====================
     crAmt(value) {
-        return (value == null || value === '') ? '—' : Format.compactNumber(value);
+        // 조 단위는 2자리 버림(반올림 X) — 기업 리포트 표시용
+        return (value == null || value === '') ? '—' : Format.compactNumber(value, true);
     },
 
     crNum(value, decimals = 2) {

--- a/src/main/resources/static/js/components/stock-eval.js
+++ b/src/main/resources/static/js/components/stock-eval.js
@@ -358,9 +358,11 @@ const StockEvalComponent = {
         if (typeof v !== 'string' || !/^-?\d+(\.\d+)?$/.test(v)) return this.fmtNum(v);
         const n = parseFloat(v);
         if (isNaN(n)) return v;
-        const toJo = this.stockEval.amountUnit === '조';
-        const val = toJo ? n / 10000 : n;
-        return val.toLocaleString('ko-KR', { maximumFractionDigits: toJo ? 1 : 2 });
+        if (this.stockEval.amountUnit === '조') {
+            // 조 변환: 반올림하지 않고 소수점 2자리에서 버림 (공용 Format.truncTo2)
+            return Format.truncTo2(n / 10000).toLocaleString('ko-KR', { maximumFractionDigits: 2 });
+        }
+        return n.toLocaleString('ko-KR', { maximumFractionDigits: 2 });
     },
 
     // 재무 표 셀: 결산년월(col0) 원본, 금액 표(대차/손익)는 단위 적용, 비율 표는 일반 콤마

--- a/src/main/resources/static/js/utils/format.js
+++ b/src/main/resources/static/js/utils/format.js
@@ -36,7 +36,8 @@ const Format = {
         });
     },
 
-    compactNumber(value) {
+    // trunc=true면 조 단위를 소수점 2자리에서 버림(반올림 X). 기본(false)은 기존 1자리 반올림 — 차트 축 등 호환.
+    compactNumber(value, trunc) {
         if (!value) return '-';
         var num = typeof value === 'string' ? parseInt(value.replace(/,/g, '')) : value;
         if (isNaN(num)) return value;
@@ -45,7 +46,11 @@ const Format = {
         var sign = num < 0 ? '-' : '';
 
         if (absNum >= 1_0000_0000_0000) {
-            return sign + (absNum / 1_0000_0000_0000).toFixed(1) + '조';
+            var jo = absNum / 1_0000_0000_0000;
+            var joText = trunc
+                ? Format.truncTo2(jo).toLocaleString('ko-KR', { maximumFractionDigits: 2 })
+                : jo.toFixed(1);
+            return sign + joText + '조';
         }
         if (absNum >= 1_0000_0000) {
             return sign + (absNum / 1_0000_0000).toFixed(1) + '억';
@@ -54,6 +59,14 @@ const Format = {
             return sign + (absNum / 1_0000).toFixed(0) + '만';
         }
         return sign + Format.number(absNum);
+    },
+
+    /** 소수점 2자리 버림(반올림 X) — 문자열 절단으로 부동소수 오차 방지 */
+    truncTo2(value) {
+        var n = typeof value === 'number' ? value : parseFloat(value);
+        if (isNaN(n)) return NaN;
+        var s = n.toFixed(6);
+        return parseFloat(s.slice(0, s.indexOf('.') + 3));
     },
 
     /**


### PR DESCRIPTION
## 요약
연도별 DART 계정 taxonomy 불일치로 재무 타임라인 값이 "—"로 누락되던 문제 근본 수정 (#85). 공유 타임라인이라 기업 리포트·종목 평가·재무 타임라인 모두 개선.

### 1) taxonomy 값 누락 보강 (`FinancialTimelineAssembler`)
- IFRS 계정 id 접두사 정규화(`ifrs_` → `ifrs-full_`)로 세부행 병합 → 영업CF 2017·2018 복구
- 주요계정 결측 시 전체재무제표 IS 총계로 보강(매출액·영업이익·당기순이익) → 당기순이익 2018~2022, 영업이익 2018·2019 복구
- 현대차 005380: 2017~2026 전부 채워짐(DART 값 일치), 삼성 회귀 없음

### 2) 금액 조 단위 표시 2자리 버림 (번들)
- `Format.truncTo2` 공용 헬퍼, 종목평가 토글·기업리포트 crAmt에 적용(차트/재무 축 기본 동작 무변경)
- 현대차 자본금 1.48조(이전 1.5조 반올림)

## 검증
- compileJava exit 0, 앱 기동 후 현대차·삼성 스냅샷 실검증 통과.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)