### PR TITLE
feat(companyreport): 기업 리포트 UX 개선 — 주가지표 통합·DART 원문 바로가기·경쟁사 여러줄 (#88)

### DIFF
--- a/docs/brainstorms/2026-07-19-company-report-ux-round2-brainstorm.md
+++ b/docs/brainstorms/2026-07-19-company-report-ux-round2-brainstorm.md
@@ -1,0 +1,71 @@
+# 기업 리포트 UX 개선 2차 - Brainstorm
+
+**Date:** 2026-07-19
+**Status:** Decided (태형님 확인 완료, 2026-07-19 — AskUserQuestion 2건)
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+**선행 기능:** 기업분석리포트 #81 / 기업 리포트 입력 개선 #84 (docs/brainstorms/2026-07-19-company-report-input-improvements-brainstorm.md)
+
+## 배경
+
+기업분석리포트(#81, #84) 사용 중 태형님이 세 가지 불편을 지적.
+
+1. **주가지표 자동/내 계산 분리** — 값이 누락돼 사용자가 찾아 입력해도, "자동"은 그 값을 반영하지 않고 `—`/옛 값을 그대로 보여 준다. "자동"과 "내 계산"이 한 화면에 병기돼 헷갈림. 누락 시 `—`보다 사용자가 입력한 값을 쓰는 게 맞음. → 필드를 나누지 말고 **하나의 표에서 처음엔 자동으로 보여주고 그 칸을 사용자가 수정**하는 형태로.
+2. **DART 원문 이동 불편** — 리포트 작성 중 누락 항목을 확인하려면 종목평가로 이동해 DART 문서를 찾아야 함. → 최상단에 해당 종목 **10년치 DART 정기보고서(사업·분기·반기)를 원문 바로가기**로.
+3. **경쟁사 비교 여러 줄 입력** — 경쟁사 "비교 내용"도 여러 줄 입력이 가능하면 좋겠음.
+
+## 확정된 결정 (태형님 확인 완료, 2026-07-19)
+
+| # | 항목 | 결정 |
+|---|------|------|
+| 범위 | Issue/worktree 단위 | **1개 이슈 3작업** — 하나의 Issue·worktree에서 ①②③ 순차 진행 |
+| ① | 주가지표 편집 방식 | **재료를 셀에서 인라인 편집** — 하나의 표에 지표 나열, 재료(주가·유통주식수·당기순이익·자본총계·매출액·영업CF)를 표 안에서 인라인 편집. 자동값은 기본 표시, 수정 시 즉시 파생지표 재계산. EV/EBITDA·ROIC·발생액/총자산은 재료 매핑이 없어 자동 전용 표시 |
+
+## 현재 구조
+
+| 대상 | 위치 | 현재 |
+|------|------|------|
+| 주가지표(자동) 그리드 | `company-report.html:475-495`(작성 5단계), `:1197-1215`(상세 6번) | `preview/detail.snapshot.priceMetrics` 11개 카드. 누락 시 `—` |
+| 주가지표 계산기(내 계산) | `company-report.html:496-617`(작성 5단계), `:1221-1250`(상세, `crHasCustomMetrics` 조건부 파란 블록) | 재료 6칸 입력 + 파생 표. **자동 그리드와 별도**로 병기 |
+| 계산 엔진 | `company-report.js:876 crMetricBase`, `:907 crCalcMetrics`, `:844 _crPerShare` | 이미 "입력값 우선 → 자동 폴백". `metricInputs = {price, shares, netIncome, equity, revenue, operatingCf, (legacy eps/bps)}` (schemaVersion 2) |
+| 공시 조회 API | `api.js:408 getDisclosures`, `DisclosureQueryService`, `DisclosureResponse(reportName, viewerUrl…)` | `/api/stocks/{code}/disclosures?fromDate&toDate&types=A` → 정기공시 + DART 원문 `viewerUrl` 반환. **작성 화면에는 미노출** |
+| 경쟁사 비교 `competitors(name, segment, note)` | `company-report.html:369-375`(편집), `:1093-1099`(상세) | `note`가 단일행 `<input>`(500자). 상세 셀은 `whitespace` 미적용 |
+
+## 개선 방향 (초안 — 상세 설계는 plan에서)
+
+### ① 주가지표 자동/내 계산 통합 (재료 인라인 편집)
+- 자동 그리드 + 계산기 두 블록을 **하나의 표**로 통합. 각 지표를 한 행으로 나열하고, 그 지표를 만드는 **재료를 표 안에서 인라인 편집**.
+- 재료(리프) 값: `price(주가)`, `shares(유통주식수)`, `netIncome(당기순이익)`, `equity(자본총계)`, `revenue(매출액)`, `operatingCf(영업CF)`. — #84에서 이미 공식형 입력 구조로 전환됨.
+- 파생 지표(시가총액·EPS·BPS·PER·PBR·PSR·PCFR·PER×PBR)는 `crCalcMetrics`/`crMetricBase` 그대로 재사용 — 재료 편집 시 연쇄 재계산.
+- 자동값은 회색 기본 표시(placeholder/prefill), 사용자가 고치면 그 값이 표시·계산에 사용. 누락(`—`)이던 값도 입력하면 반영.
+- **자동 전용 행**: EV/EBITDA(근사)·ROIC(근사)·발생액/총자산 — 재료 매핑이 없어 스냅샷 자동값만 표시(편집 불가).
+- 적용 위치: **작성 5단계 + 상세 6번 섹션 둘 다** 통합.
+- 상세 뷰의 조건부 파란 "내 계산" 블록(`crHasCustomMetrics`)은 통합 표로 흡수.
+
+### ② DART 10년 정기보고서 바로가기
+- **프론트 전용.** 백엔드·API 무변경(`getDisclosures` 재사용).
+- 종목 선택/리포트 로드 시 `types=A`(정기공시), 기간 10년으로 조회 → `reportName`이 사업보고서/분기보고서/반기보고서인 항목만 필터 → 최상단 **링크 바**로 렌더(최신순/연도 그룹), `viewerUrl` 새 탭.
+- `financial.js`의 `_disclosureFromDate`/`_formatYmd`/`formatDisclosureDate` 로직 참고(중복 없이 company-report 전용 헬퍼로 최소 구현).
+
+### ③ 경쟁사 비교 "비교 내용" 여러 줄
+- 편집: `note` `<input>` → `<textarea>`(rows 2, resize-y). 레이아웃 `items-center` → `items-start`.
+- 상세: note 셀에 `whitespace-pre-wrap` 추가(줄바꿈 보존).
+- 백엔드/JS 무변경(`_crBuildManual`의 `rows()` trim은 내부 줄바꿈 보존).
+
+## Edge Cases
+- 통합 표: 재료 일부만 입력(예: shares만) 시 파생지표 부분 재계산 — 기존 `_crPerShare` 우선순위(input→legacy→auto numerator→snapshot) 유지, 값 없으면 `—`.
+- 통합 표: 당기순이익·자본총계 음수(적자·자본잠식) 입력 유지(`crSignedAmountInput`). shares=0/음수 방어.
+- 통합 표: 구 스키마(legacy eps/bps 직접 입력) 리포트를 새 통합 UI로 열 때 값 손실 없이 표시.
+- DART 링크: 10년 범위 정기공시만이라 단일 페이지(≈40건, DART 100건/page 이내)로 충분한지 확인. 정정 보고서(remark) 표기.
+- DART 링크: 비상장/신규 상장 등 10년 미만 종목 — 있는 만큼만.
+- 경쟁사: 여러 줄 입력 후 기존 저장 리포트(단일행) 조회 정상.
+
+## 범위 밖 (하지 않음)
+- 백엔드 스냅샷 산출 로직(`SnapshotFinancialExtractor`) 및 주가지표 자동 계산 변경.
+- 공시 조회 백엔드/신규 API — 기존 `getDisclosures` 재사용만.
+- `metricInputs` 저장 스키마 변경 — 이미 v2(netIncome/equity 보유). **UI 통합만**, Entity·record 무변경.
+- 투자판단·재무지표·청산가치·DCF 섹션 동작 변경.
+
+## Open Questions (plan에서 확정)
+1. **①** 통합 표에서 "재료 미입력(자동)" 상태의 EPS/BPS 표시 기준 — 보고 기준값(`pm.eps/pm.bps`) vs 계산값(`재료÷주식수`). `_crPerShare` 우선순위 그대로 채택할지.
+2. **①** 자동 전용 행(EV/EBITDA·ROIC·발생액)을 통합 표에 함께 둘지, 별도 소섹션으로 분리할지.
+3. **②** DART 링크 바 노출 위치(작성 위저드 상단 / 상세 상단 / 둘 다), 표시 형태(연도 그룹 접이식 vs 단순 최신순 리스트), 로드 시점(종목 선택 즉시 vs 버튼).

--- a/docs/commits/2026-07-19-company-report-ux-round2-commit.md
+++ b/docs/commits/2026-07-19-company-report-ux-round2-commit.md
@@ -1,0 +1,31 @@
+# 기업 리포트 UX 개선 2차 - Commit
+
+**Date:** 2026-07-20
+**Issue:** #88
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+**Branch:** feat/issue-88-company-report-ux-round2 (base main 79a43fe)
+
+## 포함 파일
+- 코드
+  - `src/main/resources/static/js/components/company-report.js`
+  - `src/main/resources/static/partials/company-report.html`
+- 문서 (workflow 산출물)
+  - docs/brainstorms/2026-07-19-company-report-ux-round2-brainstorm.md
+  - docs/issues/2026-07-19-company-report-ux-round2-issue.md
+  - docs/plans/2026-07-19-company-report-ux-round2-plan.md
+  - docs/works/2026-07-19-company-report-ux-round2-work.md
+  - docs/reviews/2026-07-19-company-report-ux-round2-review.md
+  - docs/validations/2026-07-19-company-report-ux-round2-validation.md
+  - docs/commits/2026-07-19-company-report-ux-round2-commit.md (본 문서)
+  - docs/pushes/2026-07-19-company-report-ux-round2-push.md
+  - docs/gates/2026-07-19-company-report-ux-round2-gates.md
+
+## 제외 파일
+- `.claude/launch.json` — 검증용 로컬 dev 기동 설정(포트/경로 로컬 종속). 커밋 대상 아님.
+- `build/**` — 빌드 산출물(gitignore).
+
+## 커밋 메시지
+`feat(companyreport): 기업 리포트 UX 개선 — 주가지표 자동/내계산 통합·DART 원문 바로가기·경쟁사 여러줄 (#88)`
+
+## 태형님 승인
+- 2026-07-20 "push하고 pr 올려서 main 병합까지 해줘" — commit·push·PR·병합 승인.

--- a/docs/gates/2026-07-19-company-report-ux-round2-gates.md
+++ b/docs/gates/2026-07-19-company-report-ux-round2-gates.md
@@ -1,0 +1,27 @@
+# 기업 리포트 UX 개선 2차 게이트 로그
+
+## 원칙
+- 각 단계 시작 전 태형님에게 작업 내용을 제시한다.
+- 다음 단계로 넘어갈지에 대한 판단은 태형님에게 넘긴다.
+- 단계별 산출물은 이 게이트 로그를 `gate: docs/gates/2026-07-19-company-report-ux-round2-gates.md`로 참조한다.
+
+## Stage Decisions
+- start: approved (2026-07-19, 불편함 3건 제시 — 현재 구조 탐색·정리 승인)
+- brainstorm: 완료 (2026-07-19, 태형님 확정 — AskUserQuestion "1개 이슈 3작업" + "재료를 셀에서 인라인 편집")
+- issue: 완료 (2026-07-19, AskUserQuestion "1개 이슈 3작업" = 등록 승인 — Issue #88 등록, worktree 생성)
+- plan: approved (2026-07-19, AskUserQuestion "② 작성+상세 상단 둘 다" = plan 승인 — ① placeholder 방식·자동 전용 3행 동일 표 배치 확정)
+- work: 완료 (2026-07-19, ③②① 순 구현 완료 — 정적 검증 통과, docs/works/2026-07-19-company-report-ux-round2-work.md). 실동작 검증은 validation 단계.
+- review: 완료 (2026-07-19, /code-review xhigh — high 없음, low~low/med 6건, docs/reviews/2026-07-19-company-report-ux-round2-review.md)
+- review 반영: 태형님 "권장 4건(F1·F2·F4·F5) 반영" (2026-07-19) — F1 gen 증가, F2 reportName 정정 병행 감지, F4 자동안내값 crAmt 통일, F5 crAutoMaterials/crMaterialAutoHint manual 제거(호출부 12곳 치환). F3·F6 보류.
+- validation: 완료 (2026-07-20, bootRun(dev,8082) 기동+compileJava 성공. ② 공시 실 API 200, ①③ 독립 하니스 렌더/재계산/줄바꿈 통과, 신규 콘솔 에러 없음. dev 인증 제약으로 user-scoped 저장/preview 실데이터는 미검증. docs/validations/2026-07-19-company-report-ux-round2-validation.md)
+- commit: 진행 (2026-07-20, 태형님 "push하고 pr 올려서 main 병합까지" — 코드 2파일 + workflow 문서 단일 커밋, .claude/launch.json 제외, docs/commits/2026-07-19-company-report-ux-round2-commit.md)
+- push: 진행 (2026-07-20, origin feat/issue-88 push → PR → main 병합, docs/pushes/2026-07-19-company-report-ux-round2-push.md)
+
+## Notes
+- 선행 기능: 기업분석리포트 #81, 기업 리포트 입력 개선 #84 (docs/gates/2026-07-19-company-report-input-improvements-gates.md).
+- documented workflow 대상: 주가지표 표시(자동/내 계산 통합) 동작 변경 + 신규 데이터 페치 흐름(공시 재사용).
+- 3작업: ① 주가지표 자동/내 계산 통합(재료 인라인 편집), ② DART 10년 정기보고서 바로가기(프론트 전용), ③ 경쟁사 비교 여러 줄 입력(마크업 전용).
+- 백엔드·Entity·API 변경 없음 (기존 `getDisclosures` 재사용, `metricInputs` v2 스키마 유지).
+- Approval Gate 예정 항목:
+  - ① 통합 표의 자동 EPS/BPS 표시 기준 및 자동 전용 행 배치 — 표시 동작 변경.
+  - ② DART 링크 바 노출 위치/형태/로드 시점.

--- a/docs/issues/2026-07-19-company-report-ux-round2-issue.md
+++ b/docs/issues/2026-07-19-company-report-ux-round2-issue.md
@@ -1,0 +1,22 @@
+# 기업 리포트 UX 개선 2차 Issue 기록
+
+gate: docs/gates/2026-07-19-company-report-ux-round2-gates.md
+
+## GitHub Issue
+- status: created
+- issue_number: 88
+- issue_url: https://github.com/osnet-th/stock-market/issues/88
+- title: [enhancement] 기업분석리포트 UX 개선 — 주가지표 자동/내 계산 통합 · DART 10년 정기보고서 바로가기 · 경쟁사 비교 여러 줄
+- label: enhancement
+
+## 근거
+- brainstorm: docs/brainstorms/2026-07-19-company-report-ux-round2-brainstorm.md (Status: Decided)
+- 태형님 확정(2026-07-19, AskUserQuestion 2건): "1개 이슈 3작업" + "재료를 셀에서 인라인 편집".
+- 3작업: ① 주가지표 자동/내 계산 통합(재료 인라인 편집), ② DART 10년 정기보고서 바로가기(프론트 전용), ③ 경쟁사 비교 여러 줄(마크업 전용).
+- 백엔드·Entity·API 변경 없음 — 기존 `getDisclosures` 재사용, `metricInputs` v2 스키마 유지.
+- 선행 #81(기업분석리포트), #84(입력 개선)와 연속. 별도 worktree.
+
+## Worktree
+- branch: feat/issue-88-company-report-ux-round2
+- base: main (79a43fe)
+- 생성 명령: `scripts/create-worktree.sh --issue 88 feat/issue-88-company-report-ux-round2`

--- a/docs/plans/2026-07-19-company-report-ux-round2-plan.md
+++ b/docs/plans/2026-07-19-company-report-ux-round2-plan.md
@@ -1,0 +1,95 @@
+# 기업 리포트 UX 개선 2차 - Plan
+
+**Date:** 2026-07-19
+**Issue:** #88 (docs/issues/2026-07-19-company-report-ux-round2-issue.md)
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+**Brainstorm:** docs/brainstorms/2026-07-19-company-report-ux-round2-brainstorm.md (Status: Decided)
+
+## 범위 확정
+- 3작업, 1 worktree. 모두 프론트(`company-report.html` / `company-report.js`) 중심. **백엔드·Entity·API·저장 스키마 변경 없음.**
+- 권장 구현 순서: Phase 3(가벼움) → Phase 2 → Phase 1(무거움). 문서 번호는 brainstorm과 맞춰 ①②③로 유지.
+
+---
+
+## Phase 1 (①) — 주가지표 자동/내 계산 통합 (재료 인라인 편집)
+
+### 설계
+"주가지표(자동)" 그리드 + "주가지표 계산기(내 계산)" 두 블록을 **하나의 카드/표**로 통합. 세 구역:
+
+- **재료 (편집):** 주가 · 유통주식수 · 당기순이익 · 자본총계 · 매출액 · 영업CF — 인라인 입력. 각 칸의 placeholder에 **실제 자동값**을 숫자로 표시(비우면 자동값 사용). 음수 입력(적자·자본잠식) 유지.
+- **파생 지표 (자동 계산):** 시가총액 · EPS · BPS · PER · PBR · PSR · PCFR · PER×PBR — `crCalcMetrics`/`crMetricBase` 그대로. 재료 편집 시 즉시 재계산. 계산식 + 대입값 병기(`crFormulaText`).
+- **자동 전용 (편집 불가):** EV/EBITDA(근사) · ROIC(근사) · 발생액/총자산 — 스냅샷값만 표시(재료 매핑 없음).
+
+### 저장 의미(무변경)
+- `metricInputs`(v2: price/shares/netIncome/equity/revenue/operatingCf + legacy eps/bps) 그대로. **빈 칸 = 자동** 규칙 유지 → "데이터 새로고침" 시 자동값 갱신 정상, 사용자가 고친 칸만 override 저장.
+- 자동값을 칸에 미리 채워 넣지 않음(prefill 안 함) — placeholder로 자동값을 보여줘 "처음엔 자동, 고치면 override" 규칙을 안전하게 유지.
+
+### 표시 기준 (Open Q1·Q2 확정)
+- 파생 EPS/BPS의 "자동 상태" 값은 기존 `_crPerShare` 우선순위(입력 → legacy → 자동 분자÷주식수 → 스냅샷 지표) 그대로 채택. 현재 계산기 동작과 동일.
+- 자동 전용 3행은 통합 표 하단에 "자동 전용" 소구분으로 함께 배치(별도 카드 분리 안 함).
+
+### 변경 위치
+- 작성 5단계: `company-report.html:475-495`(자동 그리드) + `:496-617`(계산기) → 통합 표 1개로 재구성. 재료 입력 그리드(`:499-542`)를 표 안 인라인 입력으로 흡수. 예상매출 기반 지표 표(`:594-616`)는 유지.
+- 상세 6번: `company-report.html:1197-1215`(자동 그리드) + `:1221-1250`(조건부 파란 "내 계산" 블록) → 통합 표 1개(읽기 전용, 저장된 override 반영한 **유효값** + 자동 전용 3행). `crHasCustomMetrics` 조건부 블록 제거·흡수.
+- JS: 계산 엔진 재사용, UI 조립용 헬퍼만 소폭 추가 가능(예: 재료 행 메타 배열). 로직 변경 없음.
+
+### 체크리스트
+- [ ] 작성 5단계 통합 표 마크업 (재료 인라인 + 파생 + 자동 전용)
+- [ ] 상세 6번 통합 표 마크업 (유효값 + 자동 전용, 조건부 블록 제거)
+- [ ] 재료 placeholder에 자동값 숫자 표시, 빈칸=자동 규칙 확인
+- [ ] 툴팁(`crHintShow`/`crBreakdownText`) 통합 표에서 정상 동작
+- [ ] 구 스키마(legacy eps/bps) 리포트 열람 시 값 손실 없음 확인
+
+---
+
+## Phase 2 (②) — DART 10년 정기보고서 바로가기
+
+### 설계 (프론트 전용)
+- 기존 `API.getDisclosures(stockCode, from, to, ['A'])` 재사용. `from = 오늘−10년`, `to = 오늘`. 어댑터는 1페이지 100건 → 10년 정기공시(~40건) 단일 페이지 충분(확인됨, DartFinancialAdapter.java:80).
+- `reportName` 필터: **사업보고서 / 분기보고서 / 반기보고서**만. `viewerUrl` 새 탭.
+- 정렬: 접수일 최신순(백엔드 기본). 정정 보고서는 remark 마커 표기(재사용 `isCorrectionDisclosure` 유사).
+
+### 노출 위치/형태/시점 (Open Q3 — 확정 제안, plan 승인 시 조정 가능)
+- **위치:** 작성 위저드 최상단(스텝 인디케이터 아래, 전 단계 공통) + 상세 뷰 상단. 태형님 요청 "최상단"에 맞춤.
+- **형태:** 연도별 그룹 접이식(기본 접힘), 각 연도에 사업/분기/반기 링크. 종목·연도 많아도 컴팩트.
+- **시점:** 종목 선택 즉시 자동 로드(무거운 preview와 별개의 가벼운 호출).
+
+### 변경 위치
+- `company-report.js`: 상태 `companyReport.disclosures = { loading, error, byYear }` 추가. 메서드 `companyReportLoadDisclosures(stockCode)`, 헬퍼 `_crReportKind(reportName)`, `_crDisclosureFromDate()`. `companyReportSelectStock`·`_crEnterWizardFrom`·`companyReportOpenDetail`에서 호출.
+- `company-report.html`: 위저드 상단 + 상세 상단에 링크 바 템플릿 추가.
+
+### 체크리스트
+- [ ] JS 상태·로드·필터·연도 그룹 헬퍼 추가
+- [ ] 종목 선택/재개/상세 진입 시 로드 연결
+- [ ] 위저드 상단 + 상세 상단 링크 바 마크업
+- [ ] 10년 미만/공시 없음/오류 상태 처리
+
+---
+
+## Phase 3 (③) — 경쟁사 비교 "비교 내용" 여러 줄
+
+### 변경 위치
+- 편집(`company-report.html:369-375`): `note` `<input>` → `<textarea>`(rows 2, resize-y), 행 컨테이너 `items-center` → `items-start`.
+- 상세(`company-report.html:1097`): note 셀에 `whitespace-pre-wrap` 추가.
+- JS/백엔드 무변경(`_crBuildManual`의 `rows()` trim은 내부 줄바꿈 보존).
+
+### 체크리스트
+- [ ] 편집 textarea 전환 + 레이아웃
+- [ ] 상세 줄바꿈 보존
+- [ ] 기존 단일행 저장분 조회 정상
+
+---
+
+## Validation 계획
+- `./gradlew compileJava` (프론트 정적파일 변경이라 컴파일 영향 없음 확인용) + 앱 기동 후 Browser pane 실동작:
+  - ① 재료 편집 시 파생지표 재계산, 빈칸=자동, 자동 전용 3행 표시, 상세 단일 표.
+  - ② 종목 선택 시 10년 사업/분기/반기 링크 렌더 + 원문 이동.
+  - ③ 경쟁사 여러 줄 입력·저장·상세 줄바꿈.
+  - 구 스키마(v1/legacy) 리포트 열람 하위호환.
+
+## Approval Gates (work 진입 전 확인)
+- ① 통합 표: 자동값 prefill 안 함(placeholder 표시) + 자동 전용 3행 동일 표 배치 — 표시 동작 변경.
+- ② 링크 바: 작성+상세 상단 / 연도 그룹 접이식 / 종목 선택 시 자동 로드 — 위 제안대로 진행할지.
+
+## 범위 밖
+- 백엔드 스냅샷·주가지표 자동 산출 로직, 공시 백엔드/신규 API, `metricInputs` 저장 스키마, 투자판단·재무지표·청산가치·DCF 동작.

--- a/docs/pushes/2026-07-19-company-report-ux-round2-push.md
+++ b/docs/pushes/2026-07-19-company-report-ux-round2-push.md
@@ -1,0 +1,18 @@
+# 기업 리포트 UX 개선 2차 - Push
+
+**Date:** 2026-07-20
+**Issue:** #88
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+
+## 대상
+- remote: origin (git@github.com:osnet-th/stock-market.git)
+- branch: feat/issue-88-company-report-ux-round2 → main
+
+## 의도
+- feature 브랜치를 origin에 push하고 PR 생성 후 main에 병합(merge commit).
+
+## 태형님 승인
+- 2026-07-20 "push하고 pr 올려서 main 병합까지 해줘" — push·PR·병합 승인.
+
+## 결과
+- (push/PR/merge 실행 후 기록)

--- a/docs/reviews/2026-07-19-company-report-ux-round2-review.md
+++ b/docs/reviews/2026-07-19-company-report-ux-round2-review.md
@@ -1,0 +1,30 @@
+# 기업 리포트 UX 개선 2차 - Review
+
+**Date:** 2026-07-19
+**Issue:** #88
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+**대상:** work diff (company-report.js +156 / company-report.html +397−139), /code-review xhigh
+
+## Findings (심각도 순) — 명시적 high 없음
+
+| # | 심각도 | 위치 | 내용 |
+|---|--------|------|------|
+| F1 | low/med (correctness) | company-report.js:229 `_crResetDisclosures` | `_disclosureGen` 미증가 → 빠른 종목 전환 시 진행 중이던 이전 종목 공시 로드가 리셋 이후 패널에 잘못 채워질 수 있음 |
+| F2 | low (correctness) | company-report.js:253 | 정정 배지가 `remark`에만 의존. DART는 정정 정기보고서를 `reportName`의 `[기재정정]` 접두로 표기하는 경우가 많아 배지 누락 |
+| F3 | low (consistency) | company-report.js:1037 `crMaterialValue` | legacy/스냅샷 폴백 시 재료(당기순이익/자본총계)는 `—`인데 파생 EPS/BPS 행엔 값이 떠 모순처럼 보임 |
+| F4 | low (ui) | company-report.js:1028 `crMaterialAutoHint` | 자동 안내값(선택 단위 평문)과 값 열(crAmt 조/억 접미)의 표기 형식이 한 행에서 불일치 |
+| F5 | low (cleanup) | company-report.js:1012 `crAutoMaterials` | `manual` 파라미터 미사용(dead param) |
+| F6 | low (efficiency) | company-report.js:1037 | 통합 표가 렌더마다 crMetricBase/crCalcMetrics ~20회 재호출(데이터 소량이라 체감 영향은 작음) |
+
+## Open Questions / Assumptions
+- ① 통합 표에서 자동 EPS/BPS 표시 기준을 "계산값(_crPerShare 우선순위)"으로 채택 → 기존 상세의 "보고 기준값(pm.eps)" 표시와 값이 달라질 수 있음(설계상 의도, brainstorm Open Q1 확정). 회귀 아님.
+- 보안/성능 심각 findings 없음. 백엔드·저장 스키마 무변경으로 하위호환 리스크 낮음.
+
+## Change Summary
+- ③ 경쟁사 note textarea + 상세 줄바꿈 보존.
+- ② DART 10년 정기공시 링크 바(작성+상세), 기존 API 재사용.
+- ① 자동 그리드+계산기 → 단일 통합 표(작성 5단계·상세 6번), 재료 인라인 편집.
+
+## 반영 권장
+- 반영: F1(gen 증가), F2(reportName 정정 감지 병행), F4(자동 안내값도 crAmt 형식), F5(dead param 제거).
+- 선택: F3(폴백 시 재료 표기 명확화), F6(렌더당 1회 계산 캐시) — 영향 작아 후순위.

--- a/docs/validations/2026-07-19-company-report-ux-round2-validation.md
+++ b/docs/validations/2026-07-19-company-report-ux-round2-validation.md
@@ -1,0 +1,43 @@
+# 기업 리포트 UX 개선 2차 - Validation
+
+**Date:** 2026-07-20 (KST, work 세션 2026-07-19 연속)
+**Issue:** #88
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+
+## 실행 명령/환경
+- `./gradlew bootRun` (worktree, SPRING_PROFILES_ACTIVE=dev, SERVER_PORT=8082) — 빌드+부팅 성공: "Started StockMarketApplication in 4.272s" (compileJava 포함 성공).
+  - PostgreSQL(5432) 연결 정상. Elasticsearch(9200) 다운 → 경고만, 크래시 없음(정상 degrade).
+- dev 프로파일 = permitAll + anonymous. company-report **사용자 스코프 API(list/create/get/preview)는 `InsufficientAuthenticationException`(401)** → 로그인 없이 실데이터 불가.
+- 대응: (a) **비-사용자스코프 공시 API는 실호출**, (b) ①③ 렌더는 **실제 partial + 실제 company-report.js + mock 스냅샷** 독립 하니스(`_harness.html`, 검증 후 삭제)로 검증.
+
+## 검증 결과 (Browser pane)
+
+### ② DART 정기보고서 바로가기 — 통과
+- **실 API** `GET /api/stocks/005930/disclosures?fromDate=20150101&toDate=20260720&types=A` → **200**, 정기보고서 반환: `분기보고서 (2026.03)`, `사업보고서 (2025.12)` + `viewerUrl`(DART 원문). `_crReportKind`/`_crReportPeriod` 파싱 대상 확인.
+- 렌더(하니스): 연도 그룹(2025→2024 desc), 라벨 `분기 1Q`/`분기 3Q`/`반기`/`사업`, `[기재정정]` 정정 배지 표시, 원문 새 탭 링크.
+
+### ① 주가지표 자동/내 계산 통합 — 통과
+- 구 마커 제거 확인: "주가지표 (자동)"·"주가지표 계산기 (내 계산)"·"내 계산 (입력 재료 기반" 모두 미존재.
+- 작성 5단계 통합 표: 재료 6행이 **자동값 기본 표시**(주가 75,000원·유통 60.0억주·당기순이익 34조 등), 파생 8행 정확(시총 450조, EPS 5,667=34조÷60억, BPS 55,000, PER 13.24배, PBR 1.36배, PSR 1.8배, PCFR 8.04배, PER×PBR 18.05), 자동 전용 3행(EV/EBITDA 6.5·ROIC 12.3%·발생액 -2.1%).
+- **재료 편집→즉시 재계산**: 유통주식수 override 30억주 → EPS 11,333·PER 6.62배·BPS 110,000·시총 225조로 연쇄 재계산 확인.
+- 상세 6번 통합 표: 조건부 파란 "내 계산" 블록 제거, `detail.manual`(빈값→자동 60억주) 사용해 EPS 5,667·시총 450조, 가운데 열 자동값 안내("자동 60.0억주", F4 포맷 통일 반영).
+
+### ③ 경쟁사 비교 여러 줄 — 통과
+- 편집(3단계): `비교 내용`이 `<textarea>`(placeholder "여러 줄 입력 가능"), 행 컨테이너 `items-start`, 3줄 입력 반영.
+- 상세: 경쟁사 note 셀 `white-space: pre-wrap`, 줄바꿈 3줄 보존 확인.
+
+### 리뷰 반영(F1·F2·F4·F5) 확인
+- F4: 자동 안내값 "자동 60.0억주"(주 접미) 형식 통일 렌더 확인. F5: crMaterialAutoHint/crAutoMaterials manual 제거 후 호출부 12곳 정상 동작.
+- F1(gen 증가)·F2(reportName 정정 병행)는 코드 반영 확인(런타임 회귀 없음).
+
+## 콘솔/에러
+- 신규 Alpine 표현식 평가 에러 **없음**(crMaterialValue/crMaterialAutoHint/crCalcMetrics/crMetricBase/crFormulaText/crDisclosureByYear/crReportKindLabel 전부 클린).
+- 잔여 콘솔 500(프로필/관심)은 이전 앱셸 로드 로그, 본 변경과 무관.
+- 하니스 한정 `_formatYmd is not a function`: 하니스가 FinancialComponent 미로딩 탓. 실제 앱은 app.js가 전 컴포넌트를 한 Alpine 루트로 병합(financial.js에 `_formatYmd`(3)·`isCorrectionDisclosure`(1) 정의 확인) → 프로덕션 안전.
+
+## 미검증/제약
+- dev 인증 제약으로 **실제 preview 스냅샷 기반 ① 실데이터**와 **리포트 저장/재조회(user-scoped)**는 미검증. → 실계정 로그인 환경(스테이징/로컬 로그인)에서 최종 확인 권장.
+- ② 10년 범위 100건 초과(정정 다수) 시 첫 페이지만 조회되는 어댑터 제약은 설계상 수용(정기공시 ~40건).
+
+## 정리
+- 검증용 `_harness.html`(src/build) 삭제, 8082 검증 인스턴스 종료. 변경 잔존: company-report.js·company-report.html 2파일.

--- a/docs/works/2026-07-19-company-report-ux-round2-work.md
+++ b/docs/works/2026-07-19-company-report-ux-round2-work.md
@@ -1,0 +1,42 @@
+# 기업 리포트 UX 개선 2차 - Work
+
+**Date:** 2026-07-19
+**Issue:** #88
+**Gate:** docs/gates/2026-07-19-company-report-ux-round2-gates.md
+**Plan:** docs/plans/2026-07-19-company-report-ux-round2-plan.md
+**Branch/worktree:** feat/issue-88-company-report-ux-round2
+
+구현 순서: Phase 3(③ 경쟁사 여러 줄) → Phase 2(② DART 링크) → Phase 1(① 주가지표 통합).
+
+## 진행 로그
+
+### Phase 3 (③) 경쟁사 비교 여러 줄
+- 상태: 완료
+- 편집: competitors `note` `<input>` → `<textarea rows=2 resize-y>`, 행 `items-center`→`items-start` (company-report.html:369-376)
+- 상세: note 셀 `whitespace-pre-wrap`, name/segment `align-top` (company-report.html:1096-1098)
+- JS/백엔드 무변경.
+
+### Phase 2 (②) DART 10년 정기보고서 바로가기
+- 상태: 완료 (프론트 전용)
+- JS(company-report.js): `disclosures` 상태 + `_disclosureGen`; `companyReportLoadDisclosures`(types=A, 10년, 레이스 가드·같은 종목 재로드 방지), `_crResetDisclosures`, `_crYearsAgo`, `_crReportKind`(사업/반기/분기 필터), `_crReportPeriod`((YYYY.MM) 파싱), `crDisclosureByYear`(연도 desc·월 asc), `crReportKindLabel`(분기 1Q/3Q), `crReportKindClass`.
+- 재사용: FinancialComponent의 `_formatYmd`·`isCorrectionDisclosure`(병합된 순수 헬퍼).
+- 배선: `companyReportSelectStock`(preview와 병렬)·`_crEnterWizardFrom`·`companyReportOpenDetail`에서 로드, `companyReportOpenCreate`에서 리셋.
+- HTML: 작성 위저드 상단(스텝 인디케이터 아래) + 상세 상단에 접이식 링크 바(연도 그룹, 종류별 색, 정정 마커, 원문 새 탭).
+- 백엔드·API 무변경. 10년·정기공시 단일 페이지(≤100건) 충분.
+
+### Phase 1 (①) 주가지표 자동/내 계산 통합
+- 상태: 완료
+- JS(company-report.js): `_crPerf`(공유), `crAutoMaterials`(입력무관 자동 재료), `crMaterialAutoHint`(편집칸 placeholder=자동값), `crMaterialValue`(유효값=override 우선). `crMetricBase`의 `perf`를 `_crPerf`로 정리(동작 동일). 미참조가 된 `crHasCustomMetrics` 제거.
+- 작성 5단계(company-report.html 511~): "주가지표(자동)" 그리드 + "주가지표 계산기(내 계산)" 두 블록 → **단일 카드 통합 표**(재료 인라인 편집 6행 + 파생 8행 + 자동전용 3행 + 예상매출 지표). 재료 placeholder=자동값, 비우면 자동, 편집 즉시 재계산.
+- 상세 6번(company-report.html 1258~): 자동 그리드 + 조건부 파란 "내 계산" 블록 → **단일 유효값 표**(재료 유효값·가운데 열 자동값 참고 + 파생 유효값 + 자동전용 + warnings + 예상 지표). 이중 표시 제거.
+- 저장 스키마(`metricInputs` v2)·백엔드 무변경. 구 스키마(legacy eps/bps) 폴백은 `_crPerShare` 우선순위로 유지.
+- 정적 검증: 구 마커 제거 확인, `<template>` 78/78 균형, 신규 참조 헬퍼 전부 정의 확인. (실동작은 validation 단계에서)
+
+## 리뷰 반영 (F1·F2·F4·F5, 2026-07-19)
+- F1: `_crResetDisclosures`에서 `_disclosureGen++`로 진행 중 로드 무효화.
+- F2: 정정 감지를 `isCorrectionDisclosure(remark) || reportName.indexOf('정정')`로 병행.
+- F4: `crMaterialAutoHint` 금액 안내값을 `crAmt`(조/억)로 통일, price/shares에 원/주 접미.
+- F5: `crAutoMaterials`·`crMaterialAutoHint`에서 `manual` 파라미터 제거 → HTML 호출부 12곳 `(key, snapshot)`으로 치환.
+
+## 검증 (2026-07-20)
+- bootRun(dev, 8082) 기동 성공(compileJava 포함). ② 공시 실 API 200. ①③ 독립 하니스로 렌더·재계산·줄바꿈 통과. 신규 콘솔 에러 없음. 상세: docs/validations/2026-07-19-company-report-ux-round2-validation.md

--- a/src/main/resources/static/js/components/company-report.js
+++ b/src/main/resources/static/js/components/company-report.js
@@ -68,6 +68,10 @@ const CompanyReportComponent = {
         detailError: null,
         refreshing: false,
 
+        // ==== DART 정기보고서 바로가기 (최근 10년) ====
+        disclosures: { open: false, loading: false, error: null, stockCode: null, items: [] },
+        _disclosureGen: 0,
+
         _charts: [],
 
         // 정적 설정
@@ -193,6 +197,7 @@ const CompanyReportComponent = {
         cr.selected = stock;
         cr.searchResults = [];
         cr.searchQuery = '';
+        this.companyReportLoadDisclosures(stock.stockCode); // preview와 병렬(가벼운 호출)
         await this.companyReportLoadPreview();
     },
 
@@ -217,6 +222,101 @@ const CompanyReportComponent = {
         } finally {
             if (gen === cr._previewGen) cr.previewLoading = false;
         }
+    },
+
+    // ==================== DART 정기보고서 바로가기 (최근 10년) ====================
+    // preview(최대 1분)와 별개의 가벼운 호출. 정기공시(A)만 조회 후 사업/반기/분기만 필터.
+    _crResetDisclosures() {
+        const cr = this.companyReport;
+        cr._disclosureGen++; // 진행 중이던 이전 로드 무효화 (리셋 후 stale 결과 유입 방지)
+        const d = cr.disclosures;
+        d.loading = false; d.error = null; d.stockCode = null; d.items = [];
+    },
+
+    async companyReportLoadDisclosures(stockCode) {
+        const cr = this.companyReport;
+        if (!stockCode) return;
+        if (cr.disclosures.stockCode === stockCode && cr.disclosures.items.length > 0) return; // 같은 종목 재로드 방지
+        const gen = ++cr._disclosureGen;
+        const d = cr.disclosures;
+        d.loading = true;
+        d.error = null;
+        d.stockCode = stockCode;
+        d.items = [];
+        try {
+            const from = this._formatYmd(this._crYearsAgo(10));
+            const to = this._formatYmd(new Date());
+            const rows = await API.getDisclosures(stockCode, from, to, ['A']) || [];
+            if (gen !== cr._disclosureGen) return;
+            d.items = rows
+                .map(r => ({
+                    reportName: r.reportName, receiptDate: r.receiptDate, viewerUrl: r.viewerUrl,
+                    kind: this._crReportKind(r.reportName), period: this._crReportPeriod(r.reportName),
+                    // 정정은 remark 또는 보고서명 '[기재정정]' 등 접두 양쪽에서 감지
+                    correction: this.isCorrectionDisclosure(r.remark) || (r.reportName || '').indexOf('정정') !== -1
+                }))
+                .filter(r => r.kind);
+        } catch (e) {
+            if (gen !== cr._disclosureGen) return;
+            console.error('정기보고서 조회 실패:', e);
+            d.error = '정기보고서 목록을 불러오지 못했습니다.';
+        } finally {
+            if (gen === cr._disclosureGen) d.loading = false;
+        }
+    },
+
+    _crYearsAgo(years) {
+        const d = new Date();
+        d.setFullYear(d.getFullYear() - years);
+        return d;
+    },
+
+    // 보고서명 → 종류 (사업/반기/분기), 그 외는 null(제외)
+    _crReportKind(name) {
+        const n = name || '';
+        if (n.indexOf('사업보고서') !== -1) return '사업';
+        if (n.indexOf('반기보고서') !== -1) return '반기';
+        if (n.indexOf('분기보고서') !== -1) return '분기';
+        return null;
+    },
+
+    // 보고서명의 대상 기간 "(YYYY.MM)" 추출 → {year, month}. 없으면 null
+    _crReportPeriod(name) {
+        const m = /\((\d{4})\.(\d{2})/.exec(name || '');
+        return m ? { year: m[1], month: m[2] } : null;
+    },
+
+    // 연도별 그룹(최신 연도 우선), 연도 내는 기간(월) 오름차순
+    crDisclosureByYear() {
+        const items = this.companyReport.disclosures.items || [];
+        const map = {};
+        items.forEach(r => {
+            const year = (r.period && r.period.year) || (r.receiptDate ? r.receiptDate.slice(0, 4) : '—');
+            (map[year] = map[year] || []).push(r);
+        });
+        return Object.keys(map).sort((a, b) => b.localeCompare(a)).map(year => ({
+            year,
+            reports: map[year].sort((a, b) => {
+                const ma = (a.period && a.period.month) || '99';
+                const mb = (b.period && b.period.month) || '99';
+                return ma !== mb ? ma.localeCompare(mb) : (a.receiptDate || '').localeCompare(b.receiptDate || '');
+            })
+        }));
+    },
+
+    // 링크 라벨: 분기는 1Q/3Q 구분해 표시
+    crReportKindLabel(r) {
+        if (r.kind === '분기' && r.period) {
+            if (r.period.month === '03') return '분기 1Q';
+            if (r.period.month === '09') return '분기 3Q';
+        }
+        return r.kind;
+    },
+
+    crReportKindClass(kind) {
+        if (kind === '사업') return 'bg-indigo-50 text-indigo-700 border-indigo-200';
+        if (kind === '반기') return 'bg-emerald-50 text-emerald-700 border-emerald-200';
+        return 'bg-gray-50 text-gray-600 border-gray-200'; // 분기
     },
 
     // ==================== 위저드 이동 ====================
@@ -261,6 +361,7 @@ const CompanyReportComponent = {
         cr.draftNotice = '';
         cr.searchQuery = '';
         cr.searchResults = [];
+        this._crResetDisclosures();
         this._crResetForm();
     },
 
@@ -296,6 +397,8 @@ const CompanyReportComponent = {
         cr.previewError = null;
         cr.formError = null;
         cr.draftNotice = '';
+        this._crResetDisclosures();
+        this.companyReportLoadDisclosures(detail.stockCode);
         this._crPopulateForm(detail);
         cr.step = step;
         this._crRenderStepChart();
@@ -361,8 +464,10 @@ const CompanyReportComponent = {
         cr.detailLoading = true;
         cr.detailError = null;
         this._crDestroyCharts();
+        this._crResetDisclosures();
         try {
             cr.detail = await API.getCompanyReport(id);
+            this.companyReportLoadDisclosures(cr.detail?.stockCode);
             this.$nextTick(() => this._crRenderPerfChart(cr.detail?.snapshot, 'report-detail-perf', cr.detail?.manual));
         } catch (e) {
             cr.detailError = e?.message || '리포트 조회에 실패했습니다.';
@@ -872,16 +977,19 @@ const CompanyReportComponent = {
         return label + ' ÷ 유통주식수 = ' + this.crAmt(numerator) + ' ÷ ' + Format.compactNumber(b.shares) + '주';
     },
 
+    // 스냅샷 실적 최신 사업연도(baseYear) 값(원). 없으면 null
+    _crPerf(snapshot, key) {
+        const row = (snapshot?.performance || []).find(r => r.key === key);
+        const baseYear = snapshot?.valuationInputs?.baseYear;
+        return (row && baseYear != null) ? this._crNum(row.values[baseYear]) : null;
+    },
+
     // 계산기 재료: 사용자 입력 우선, 비면 스냅샷 자동값 폴백. 금액은 원 환산
     crMetricBase(manual, snapshot) {
         const pm = snapshot?.priceMetrics || {};
         const mi = manual?.metricInputs || {};
         const unit = this.crUnitMult(manual);
-        const perf = key => {
-            const row = (snapshot?.performance || []).find(r => r.key === key);
-            const baseYear = snapshot?.valuationInputs?.baseYear;
-            return row && baseYear != null ? this._crNum(row.values[baseYear]) : null;
-        };
+        const perf = key => this._crPerf(snapshot, key);
         const autoPrice = this._crNum(pm.referencePrice);
         const autoCap = this._crNum(pm.marketCap);
         const price = this._crNum(mi.price) ?? autoPrice;
@@ -901,6 +1009,40 @@ const CompanyReportComponent = {
             revenue: this._crNum(mi.revenue) != null ? this._crNum(mi.revenue) * unit : perf('revenue'),
             operatingCf: this._crNum(mi.operatingCf) != null ? this._crNum(mi.operatingCf) * unit : perf('operatingCf')
         };
+    },
+
+    // 통합 표: 입력과 무관한 순수 자동값(재료). 편집칸 placeholder(회색 안내값)용
+    crAutoMaterials(snapshot) {
+        const pm = snapshot?.priceMetrics || {};
+        const autoPrice = this._crNum(pm.referencePrice);
+        const autoCap = this._crNum(pm.marketCap);
+        const snapshotShares = (autoCap != null && autoPrice) ? autoCap / autoPrice : null;
+        return {
+            price: autoPrice,
+            shares: snapshotShares,
+            netIncome: this._crPerf(snapshot, 'netIncome'),
+            equity: this._crAutoEquity(pm, snapshotShares),
+            revenue: this._crPerf(snapshot, 'revenue'),
+            operatingCf: this._crPerf(snapshot, 'operatingCf')
+        };
+    },
+
+    // 통합 표 재료 편집칸 placeholder: 자동값(값 열과 동일 포맷 — 주가=원, 유통주식수=주, 금액=조/억)
+    crMaterialAutoHint(key, snapshot) {
+        const v = this.crAutoMaterials(snapshot)[key];
+        if (v == null) return '자동값 없음';
+        if (key === 'price') return '자동 ' + Format.number(v, 0) + '원';
+        if (key === 'shares') return '자동 ' + Format.compactNumber(v) + '주';
+        return '자동 ' + this.crAmt(v); // 금액: 값 열과 동일하게 조/억 형식
+    },
+
+    // 통합 표 재료 유효값(입력 override 우선, 없으면 자동). 표시 문자열
+    crMaterialValue(key, manual, snapshot) {
+        const b = this.crMetricBase(manual, snapshot);
+        if (key === 'price') return b.price != null ? Format.number(b.price, 0) + '원' : '—';
+        if (key === 'shares') return b.shares != null ? Format.compactNumber(b.shares) + '주' : '—';
+        const v = { netIncome: b.netIncome, equity: b.equity, revenue: b.revenue, operatingCf: b.operatingCf }[key];
+        return v != null ? this.crAmt(v) : '—';
     },
 
     // 계산기 결과 (재료 기반 즉시 계산)
@@ -927,13 +1069,6 @@ const CompanyReportComponent = {
             psr: (b.marketCap != null && f.annual > 0) ? b.marketCap / f.annual : null,
             per: (b.marketCap != null && f.netIncome != null && f.netIncome > 0) ? b.marketCap / f.netIncome : null
         }));
-    },
-
-    // 계산기 사용 여부 (상세 화면 "내 계산" 블록 노출 조건)
-    crHasCustomMetrics(manual) {
-        const mi = manual?.metricInputs || {};
-        const hasInput = Object.values(mi).some(v => v != null && String(v).trim() !== '');
-        return hasInput || this._crForecastSeries(manual).length > 0;
     },
 
     crTimes(value) {

--- a/src/main/resources/static/partials/company-report.html
+++ b/src/main/resources/static/partials/company-report.html
@@ -118,6 +118,41 @@
             </div>
         </div>
 
+        <!-- DART 정기보고서 바로가기 (최근 10년) -->
+        <div x-show="companyReport.selected" class="bg-white border border-gray-200 rounded mb-4">
+            <button type="button" @click="companyReport.disclosures.open = !companyReport.disclosures.open"
+                    class="w-full flex items-center gap-2 px-4 py-2.5 text-left">
+                <span class="text-sm font-semibold text-gray-700">DART 정기보고서 바로가기</span>
+                <span class="text-xs text-gray-400">최근 10년 · 사업/반기/분기 원문</span>
+                <span x-show="companyReport.disclosures.loading" class="text-xs text-gray-400"><span class="spinner inline-block mr-1"></span>불러오는 중...</span>
+                <span x-show="!companyReport.disclosures.loading && companyReport.disclosures.items.length > 0" class="text-xs text-gray-400" x-text="companyReport.disclosures.items.length + '건'"></span>
+                <div class="flex-1"></div>
+                <span class="text-gray-400 text-xs" x-text="companyReport.disclosures.open ? '접기 ▲' : '펼치기 ▼'"></span>
+            </button>
+            <div x-show="companyReport.disclosures.open" class="border-t border-gray-100 px-4 py-3">
+                <div x-show="companyReport.disclosures.error" class="text-xs text-amber-700" x-text="companyReport.disclosures.error"></div>
+                <div x-show="!companyReport.disclosures.loading && !companyReport.disclosures.error && companyReport.disclosures.items.length === 0" class="text-xs text-gray-400">최근 10년 정기보고서가 없습니다.</div>
+                <div class="space-y-1.5">
+                    <template x-for="grp in crDisclosureByYear()" :key="grp.year">
+                        <div class="flex items-start gap-2 text-xs">
+                            <span class="w-12 shrink-0 font-mono font-medium text-gray-600 pt-0.5" x-text="grp.year"></span>
+                            <div class="flex flex-wrap gap-1.5">
+                                <template x-for="r in grp.reports" :key="r.viewerUrl">
+                                    <a :href="r.viewerUrl" target="_blank" rel="noopener noreferrer"
+                                       class="inline-flex items-center gap-1 px-2 py-0.5 rounded border hover:brightness-95"
+                                       :class="crReportKindClass(r.kind)"
+                                       :title="r.reportName + ' · 접수 ' + crRawDate(r.receiptDate)">
+                                        <span x-text="crReportKindLabel(r)"></span>
+                                        <span x-show="r.correction" class="text-[10px] text-red-600 font-medium">정정</span>
+                                    </a>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </div>
+
         <!-- 공통 상태 배너 (1단계 로딩은 검색창 아래 자리 안 카드로 표시) -->
         <div x-show="companyReport.previewLoading && companyReport.step >= 2" class="bg-white border border-gray-200 rounded p-4 mb-4 text-center text-sm text-gray-400">
             <span class="spinner inline-block mr-2"></span>자동 산출 데이터 조회 중... (DART 10개년 + 주가/지분 공시, 최대 1분)
@@ -367,10 +402,11 @@
                 <p class="text-xs text-gray-400 mb-2">경쟁사와는 개별 사업부문끼리 비교 (예: 삼성전자 반도체 ↔ 하이닉스 반도체)</p>
                 <div class="space-y-2">
                     <template x-for="(row, idx) in companyReport.form.manual.competitors" :key="idx">
-                        <div class="flex gap-2 items-center">
+                        <div class="flex gap-2 items-start">
                             <input type="text" x-model="row.name" placeholder="경쟁사" maxlength="500" class="w-40 text-sm border border-gray-300 rounded px-2 py-1.5" />
                             <input type="text" x-model="row.segment" placeholder="비교 사업부문" maxlength="500" class="w-40 text-sm border border-gray-300 rounded px-2 py-1.5" />
-                            <input type="text" x-model="row.note" placeholder="비교 내용" maxlength="500" class="flex-1 text-sm border border-gray-300 rounded px-2 py-1.5" />
+                            <textarea x-model="row.note" placeholder="비교 내용 — 여러 줄 입력 가능" maxlength="500" rows="2"
+                                      class="flex-1 text-sm border border-gray-300 rounded px-2 py-1.5 resize-y"></textarea>
                             <button @click="companyReportRemoveRow('competitors', idx)" class="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded">삭제</button>
                         </div>
                     </template>
@@ -472,122 +508,113 @@
 
         <!-- ===== 5단계: 기업가치 ===== -->
         <div x-show="companyReport.step === 5" class="space-y-4">
-            <template x-if="companyReport.preview && companyReport.preview.snapshot && companyReport.preview.snapshot.priceMetrics">
-                <div class="bg-white border border-gray-200 rounded p-4">
-                    <div class="flex items-center gap-2 mb-3">
-                        <div class="text-sm font-semibold text-gray-700">주가지표 (자동)</div>
-                        <span class="text-xs text-gray-400">기준가: <span x-text="crNum(companyReport.preview.snapshot.priceMetrics.referencePrice, 0)"></span>원 (<span x-text="companyReport.preview.snapshot.priceMetrics.referencePriceDate || '—'"></span>)</span>
-                    </div>
-                    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 text-xs">
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">시가총액(근사)</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'marketCap')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'marketCap')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crAmt(companyReport.preview.snapshot.priceMetrics.marketCap)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">EPS</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'eps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'eps')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.eps, 0)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">BPS</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'bps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'bps')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.bps, 0)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PER</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'per')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'per')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.per)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PBR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'pbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pbr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.pbr)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PSR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'psr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'psr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.psr)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PCFR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'pcfr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pcfr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.pcfr)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PER × PBR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'perTimesPbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'perTimesPbr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.perTimesPbr)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">EV/EBITDA(근사)</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'evEbitda')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'evEbitda')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.preview.snapshot.priceMetrics.evEbitda)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">ROIC(근사)</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'roic')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'roic')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crPct(companyReport.preview.snapshot.priceMetrics.roic)"></div></div>
-                        <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">발생액/총자산</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'accrual')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'accrual')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crPct(companyReport.preview.snapshot.priceMetrics.accrualRatio)"></div></div>
-                    </div>
-                </div>
-            </template>
+            <!-- 주가지표: 자동값 기본 표시 + 재료 인라인 편집 통합 (자동/내 계산 단일화) -->
             <div class="bg-white border border-gray-200 rounded p-4">
-                <div class="text-sm font-semibold text-gray-700 mb-1">주가지표 계산기 (내 계산)</div>
-                <p class="text-xs text-gray-400 mb-3">재료를 고치면 지표가 즉시 다시 계산됩니다. 비워두면 자동 산출값 사용. EPS·BPS는 당기순이익·자본총계 ÷ 유통주식수로 산출(유통주식수만 바꿔도 재계산). 위 "자동"은 보고 기준값이라 내 계산과 다를 수 있습니다. 당기순이익·자본총계는 적자·자본잠식(음수) 입력 가능. 금액 단위: <span class="font-medium" x-text="companyReport.form.manual.amountUnit + '원'"></span> (3단계에서 변경)</p>
-                <div class="grid grid-cols-2 lg:grid-cols-3 gap-3 mb-4">
-                    <div>
-                        <label class="block text-xs font-medium text-gray-600 mb-1">주가 (원)</label>
-                        <input type="text" x-model="companyReport.form.manual.metricInputs.price" inputmode="decimal"
-                               @input="crAmountInput(companyReport.form.manual.metricInputs, 'price')"
-                               :placeholder="'자동: ' + crNum(companyReport.preview?.snapshot?.priceMetrics?.referencePrice, 0)"
-                               class="w-full text-sm border border-gray-300 rounded px-2 py-1.5" />
-                    </div>
-                    <div>
-                        <label class="block text-xs font-medium text-gray-600 mb-1">유통주식수 (주)</label>
-                        <input type="text" x-model="companyReport.form.manual.metricInputs.shares" inputmode="decimal"
-                               @input="crAmountInput(companyReport.form.manual.metricInputs, 'shares')"
-                               placeholder="자동: 시총÷주가"
-                               class="w-full text-sm border border-gray-300 rounded px-2 py-1.5" />
-                    </div>
-                    <div>
-                        <label class="block text-xs font-medium text-gray-600 mb-1">당기순이익 (<span x-text="companyReport.form.manual.amountUnit"></span>)</label>
-                        <input type="text" x-model="companyReport.form.manual.metricInputs.netIncome" inputmode="decimal"
-                               @input="crSignedAmountInput(companyReport.form.manual.metricInputs, 'netIncome')"
-                               placeholder="자동: 최신 사업연도 당기순이익"
-                               class="w-full text-sm border border-gray-300 rounded px-2 py-1.5" />
-                    </div>
-                    <div>
-                        <label class="block text-xs font-medium text-gray-600 mb-1">자본총계 (<span x-text="companyReport.form.manual.amountUnit"></span>)</label>
-                        <input type="text" x-model="companyReport.form.manual.metricInputs.equity" inputmode="decimal"
-                               @input="crSignedAmountInput(companyReport.form.manual.metricInputs, 'equity')"
-                               placeholder="자동: 최신 사업연도 자본총계"
-                               class="w-full text-sm border border-gray-300 rounded px-2 py-1.5" />
-                    </div>
-                    <div>
-                        <label class="block text-xs font-medium text-gray-600 mb-1">매출액 (<span x-text="companyReport.form.manual.amountUnit"></span>)</label>
-                        <input type="text" x-model="companyReport.form.manual.metricInputs.revenue" inputmode="decimal"
-                               @input="crAmountInput(companyReport.form.manual.metricInputs, 'revenue')"
-                               placeholder="자동: 최신 사업연도 매출"
-                               class="w-full text-sm border border-gray-300 rounded px-2 py-1.5" />
-                    </div>
-                    <div>
-                        <label class="block text-xs font-medium text-gray-600 mb-1">영업CF (<span x-text="companyReport.form.manual.amountUnit"></span>)</label>
-                        <input type="text" x-model="companyReport.form.manual.metricInputs.operatingCf" inputmode="decimal"
-                               @input="crAmountInput(companyReport.form.manual.metricInputs, 'operatingCf')"
-                               placeholder="자동: 최신 사업연도 영업CF"
-                               class="w-full text-sm border border-gray-300 rounded px-2 py-1.5" />
-                    </div>
+                <div class="flex items-center gap-2 mb-1">
+                    <div class="text-sm font-semibold text-gray-700">주가지표</div>
+                    <span x-show="companyReport.preview && companyReport.preview.snapshot && companyReport.preview.snapshot.priceMetrics" class="text-xs text-gray-400">기준가: <span x-text="crNum(companyReport.preview?.snapshot?.priceMetrics?.referencePrice, 0)"></span>원 (<span x-text="companyReport.preview?.snapshot?.priceMetrics?.referencePriceDate || '—'"></span>)</span>
                 </div>
+                <p class="text-xs text-gray-400 mb-3">재료(주가·유통주식수·당기순이익·자본총계·매출액·영업CF)를 표에서 직접 고치면 파생 지표가 즉시 다시 계산됩니다. 비우면 자동 산출값(칸의 회색 안내값)을 사용합니다. EPS·BPS는 당기순이익·자본총계 ÷ 유통주식수(유통주식수만 바꿔도 재계산). 당기순이익·자본총계는 적자·자본잠식(음수) 입력 가능. 금액 단위: <span class="font-medium" x-text="companyReport.form.manual.amountUnit + '원'"></span> (3단계에서 변경)</p>
                 <table class="w-full text-xs border border-gray-100 rounded mb-3">
                     <thead>
                         <tr class="text-gray-500 border-b border-gray-100 text-left">
-                            <th class="px-2 py-1.5 w-28">지표</th>
-                            <th class="px-2 py-1.5">계산식</th>
-                            <th class="px-2 py-1.5 text-right w-32">내 계산</th>
+                            <th class="px-2 py-1.5 w-36">지표</th>
+                            <th class="px-2 py-1.5">계산식 / 입력</th>
+                            <th class="px-2 py-1.5 text-right w-36">값</th>
                         </tr>
                     </thead>
                     <tbody>
+                        <tr class="bg-gray-50"><td colspan="3" class="px-2 py-1 text-[11px] font-semibold text-gray-500">재료 (직접 입력 · 비우면 자동값)</td></tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">시가총액</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">주가 (원)</td>
+                            <td class="px-2 py-1.5"><input type="text" x-model="companyReport.form.manual.metricInputs.price" inputmode="decimal" @input="crAmountInput(companyReport.form.manual.metricInputs, 'price')" :placeholder="crMaterialAutoHint('price', companyReport.preview?.snapshot)" class="w-full text-sm border border-gray-300 rounded px-2 py-1" /></td>
+                            <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('price', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
+                        </tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">유통주식수 (주)</td>
+                            <td class="px-2 py-1.5"><input type="text" x-model="companyReport.form.manual.metricInputs.shares" inputmode="decimal" @input="crAmountInput(companyReport.form.manual.metricInputs, 'shares')" :placeholder="crMaterialAutoHint('shares', companyReport.preview?.snapshot)" class="w-full text-sm border border-gray-300 rounded px-2 py-1" /></td>
+                            <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('shares', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
+                        </tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">당기순이익 (<span x-text="companyReport.form.manual.amountUnit"></span>)</td>
+                            <td class="px-2 py-1.5"><input type="text" x-model="companyReport.form.manual.metricInputs.netIncome" inputmode="decimal" @input="crSignedAmountInput(companyReport.form.manual.metricInputs, 'netIncome')" :placeholder="crMaterialAutoHint('netIncome', companyReport.preview?.snapshot)" class="w-full text-sm border border-gray-300 rounded px-2 py-1" /></td>
+                            <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('netIncome', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
+                        </tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">자본총계 (<span x-text="companyReport.form.manual.amountUnit"></span>)</td>
+                            <td class="px-2 py-1.5"><input type="text" x-model="companyReport.form.manual.metricInputs.equity" inputmode="decimal" @input="crSignedAmountInput(companyReport.form.manual.metricInputs, 'equity')" :placeholder="crMaterialAutoHint('equity', companyReport.preview?.snapshot)" class="w-full text-sm border border-gray-300 rounded px-2 py-1" /></td>
+                            <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('equity', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
+                        </tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">매출액 (<span x-text="companyReport.form.manual.amountUnit"></span>)</td>
+                            <td class="px-2 py-1.5"><input type="text" x-model="companyReport.form.manual.metricInputs.revenue" inputmode="decimal" @input="crAmountInput(companyReport.form.manual.metricInputs, 'revenue')" :placeholder="crMaterialAutoHint('revenue', companyReport.preview?.snapshot)" class="w-full text-sm border border-gray-300 rounded px-2 py-1" /></td>
+                            <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('revenue', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
+                        </tr>
+                        <tr>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">영업CF (<span x-text="companyReport.form.manual.amountUnit"></span>)</td>
+                            <td class="px-2 py-1.5"><input type="text" x-model="companyReport.form.manual.metricInputs.operatingCf" inputmode="decimal" @input="crAmountInput(companyReport.form.manual.metricInputs, 'operatingCf')" :placeholder="crMaterialAutoHint('operatingCf', companyReport.preview?.snapshot)" class="w-full text-sm border border-gray-300 rounded px-2 py-1" /></td>
+                            <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('operatingCf', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
+                        </tr>
+                    </tbody>
+                    <tbody>
+                        <tr class="bg-gray-50"><td colspan="3" class="px-2 py-1 text-[11px] font-semibold text-gray-500">파생 지표 (자동 계산)</td></tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">시가총액 <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'marketCap')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'marketCap')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400">주가 × 유통주식수</td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crAmt(crCalcMetrics(companyReport.form.manual, companyReport.preview?.snapshot).marketCap)"></td>
                         </tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">EPS</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">EPS <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'eps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'eps')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400" x-text="crFormulaText('eps', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(crMetricBase(companyReport.form.manual, companyReport.preview?.snapshot).eps, 0)"></td>
                         </tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">BPS</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">BPS <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'bps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'bps')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400" x-text="crFormulaText('bps', companyReport.form.manual, companyReport.preview?.snapshot)"></td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(crMetricBase(companyReport.form.manual, companyReport.preview?.snapshot).bps, 0)"></td>
                         </tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">PER</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">PER <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'per')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'per')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400">주가 ÷ EPS</td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.form.manual, companyReport.preview?.snapshot).per)"></td>
                         </tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">PBR</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">PBR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'pbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pbr')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400">주가 ÷ BPS</td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.form.manual, companyReport.preview?.snapshot).pbr)"></td>
                         </tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">PSR</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">PSR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'psr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'psr')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400">시가총액 ÷ 매출액</td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.form.manual, companyReport.preview?.snapshot).psr)"></td>
                         </tr>
                         <tr class="border-b border-gray-50">
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">PCFR</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">PCFR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'pcfr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pcfr')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400">시가총액 ÷ 영업활동현금흐름</td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.form.manual, companyReport.preview?.snapshot).pcfr)"></td>
                         </tr>
                         <tr>
-                            <td class="px-2 py-1.5 text-gray-700 font-medium">PER × PBR</td>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">PER × PBR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'perTimesPbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'perTimesPbr')">?</span></td>
                             <td class="px-2 py-1.5 text-gray-400">PER × PBR (8 이하면 저평가 참고)</td>
                             <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(crCalcMetrics(companyReport.form.manual, companyReport.preview?.snapshot).perTimesPbr)"></td>
+                        </tr>
+                    </tbody>
+                    <tbody x-show="companyReport.preview && companyReport.preview.snapshot && companyReport.preview.snapshot.priceMetrics">
+                        <tr class="bg-gray-50"><td colspan="3" class="px-2 py-1 text-[11px] font-semibold text-gray-500">자동 전용 (재료 없음 · 스냅샷값)</td></tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">EV/EBITDA(근사) <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'evEbitda')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'evEbitda')">?</span></td>
+                            <td class="px-2 py-1.5 text-gray-400">(시총 + 순차입금) ÷ (영업이익 + 상각비)</td>
+                            <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(companyReport.preview?.snapshot?.priceMetrics?.evEbitda)"></td>
+                        </tr>
+                        <tr class="border-b border-gray-50">
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">ROIC(근사) <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'roic')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'roic')">?</span></td>
+                            <td class="px-2 py-1.5 text-gray-400">영업이익×(1−세율) ÷ 투하자본</td>
+                            <td class="px-2 py-1.5 text-right font-mono" x-text="crPct(companyReport.preview?.snapshot?.priceMetrics?.roic)"></td>
+                        </tr>
+                        <tr>
+                            <td class="px-2 py-1.5 text-gray-700 font-medium">발생액/총자산 <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'accrual')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'accrual')">?</span></td>
+                            <td class="px-2 py-1.5 text-gray-400">(순이익 − 영업CF) ÷ 자산총계</td>
+                            <td class="px-2 py-1.5 text-right font-mono" x-text="crPct(companyReport.preview?.snapshot?.priceMetrics?.accrualRatio)"></td>
                         </tr>
                     </tbody>
                 </table>
@@ -896,6 +923,41 @@
         <div x-show="companyReport.detailLoading" class="text-center py-10 text-sm text-gray-400">불러오는 중...</div>
         <div x-show="companyReport.detailError" class="border-l-4 border-red-400 bg-red-50 p-4 rounded mb-4 text-sm text-red-700" x-text="companyReport.detailError"></div>
 
+        <!-- DART 정기보고서 바로가기 (최근 10년) -->
+        <div x-show="companyReport.detail" class="bg-white border border-gray-200 rounded mb-4">
+            <button type="button" @click="companyReport.disclosures.open = !companyReport.disclosures.open"
+                    class="w-full flex items-center gap-2 px-4 py-2.5 text-left">
+                <span class="text-sm font-semibold text-gray-700">DART 정기보고서 바로가기</span>
+                <span class="text-xs text-gray-400">최근 10년 · 사업/반기/분기 원문</span>
+                <span x-show="companyReport.disclosures.loading" class="text-xs text-gray-400"><span class="spinner inline-block mr-1"></span>불러오는 중...</span>
+                <span x-show="!companyReport.disclosures.loading && companyReport.disclosures.items.length > 0" class="text-xs text-gray-400" x-text="companyReport.disclosures.items.length + '건'"></span>
+                <div class="flex-1"></div>
+                <span class="text-gray-400 text-xs" x-text="companyReport.disclosures.open ? '접기 ▲' : '펼치기 ▼'"></span>
+            </button>
+            <div x-show="companyReport.disclosures.open" class="border-t border-gray-100 px-4 py-3">
+                <div x-show="companyReport.disclosures.error" class="text-xs text-amber-700" x-text="companyReport.disclosures.error"></div>
+                <div x-show="!companyReport.disclosures.loading && !companyReport.disclosures.error && companyReport.disclosures.items.length === 0" class="text-xs text-gray-400">최근 10년 정기보고서가 없습니다.</div>
+                <div class="space-y-1.5">
+                    <template x-for="grp in crDisclosureByYear()" :key="grp.year">
+                        <div class="flex items-start gap-2 text-xs">
+                            <span class="w-12 shrink-0 font-mono font-medium text-gray-600 pt-0.5" x-text="grp.year"></span>
+                            <div class="flex flex-wrap gap-1.5">
+                                <template x-for="r in grp.reports" :key="r.viewerUrl">
+                                    <a :href="r.viewerUrl" target="_blank" rel="noopener noreferrer"
+                                       class="inline-flex items-center gap-1 px-2 py-0.5 rounded border hover:brightness-95"
+                                       :class="crReportKindClass(r.kind)"
+                                       :title="r.reportName + ' · 접수 ' + crRawDate(r.receiptDate)">
+                                        <span x-text="crReportKindLabel(r)"></span>
+                                        <span x-show="r.correction" class="text-[10px] text-red-600 font-medium">정정</span>
+                                    </a>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </div>
+
         <template x-if="companyReport.detail && !companyReport.detailLoading">
             <div class="space-y-4 mb-8">
 
@@ -1092,9 +1154,9 @@
                                 <tbody>
                                     <template x-for="(c, idx) in companyReport.detail.manual.competitors" :key="idx">
                                         <tr class="border-b border-gray-50">
-                                            <td class="px-2 py-1 text-gray-700" x-text="c.name"></td>
-                                            <td class="px-2 py-1 text-gray-600" x-text="c.segment"></td>
-                                            <td class="px-2 py-1 text-gray-500" x-text="c.note"></td>
+                                            <td class="px-2 py-1 text-gray-700 align-top" x-text="c.name"></td>
+                                            <td class="px-2 py-1 text-gray-600 align-top" x-text="c.segment"></td>
+                                            <td class="px-2 py-1 text-gray-500 whitespace-pre-wrap" x-text="c.note"></td>
                                         </tr>
                                     </template>
                                 </tbody>
@@ -1196,60 +1258,141 @@
                 <!-- 6. 주가지표 -->
                 <template x-if="companyReport.detail.snapshot && companyReport.detail.snapshot.priceMetrics">
                     <div class="bg-white border border-gray-200 rounded p-4">
-                        <div class="flex items-center gap-2 mb-3">
+                        <div class="flex items-center gap-2 mb-1">
                             <div class="text-sm font-semibold text-gray-700">주가지표</div>
                             <span class="text-xs text-gray-400">기준가: <span x-text="crNum(companyReport.detail.snapshot.priceMetrics.referencePrice, 0)"></span>원 (<span x-text="companyReport.detail.snapshot.priceMetrics.referencePriceDate || '—'"></span>)</span>
                         </div>
-                        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 text-xs">
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">시가총액(근사)</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'marketCap')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'marketCap')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crAmt(companyReport.detail.snapshot.priceMetrics.marketCap)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">EPS</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'eps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'eps')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.eps, 0)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">BPS</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'bps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'bps')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.bps, 0)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PER</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'per')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'per')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.per)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PBR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'pbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pbr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.pbr)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PSR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'psr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'psr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.psr)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PCFR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'pcfr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pcfr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.pcfr)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PER × PBR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'perTimesPbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'perTimesPbr')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.perTimesPbr)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">EV/EBITDA(근사)</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'evEbitda')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'evEbitda')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(companyReport.detail.snapshot.priceMetrics.evEbitda)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">ROIC(근사)</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'roic')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'roic')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crPct(companyReport.detail.snapshot.priceMetrics.roic)"></div></div>
-                            <div class="border border-gray-100 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">발생액/총자산</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'accrual')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'accrual')">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crPct(companyReport.detail.snapshot.priceMetrics.accrualRatio)"></div></div>
-                        </div>
+                        <p class="text-xs text-gray-400 mb-3">재료에 직접 입력한 값이 있으면 그 값으로, 없으면 자동 산출값으로 파생 지표를 계산합니다(가운데 열은 자동값 참고). EV/EBITDA·ROIC·발생액은 자동 전용(스냅샷값).</p>
+                        <table class="w-full text-xs border border-gray-100 rounded">
+                            <thead>
+                                <tr class="text-gray-500 border-b border-gray-100 text-left">
+                                    <th class="px-2 py-1.5 w-36">지표</th>
+                                    <th class="px-2 py-1.5">계산식 / 자동값</th>
+                                    <th class="px-2 py-1.5 text-right w-36">값</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="bg-gray-50"><td colspan="3" class="px-2 py-1 text-[11px] font-semibold text-gray-500">재료 (입력값 우선 · 없으면 자동)</td></tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">주가 (원)</td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crMaterialAutoHint('price', companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('price', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">유통주식수 (주)</td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crMaterialAutoHint('shares', companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('shares', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">당기순이익</td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crMaterialAutoHint('netIncome', companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('netIncome', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">자본총계</td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crMaterialAutoHint('equity', companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('equity', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">매출액</td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crMaterialAutoHint('revenue', companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('revenue', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                </tr>
+                                <tr>
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">영업CF</td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crMaterialAutoHint('operatingCf', companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono text-gray-700" x-text="crMaterialValue('operatingCf', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                </tr>
+                            </tbody>
+                            <tbody>
+                                <tr class="bg-gray-50"><td colspan="3" class="px-2 py-1 text-[11px] font-semibold text-gray-500">파생 지표</td></tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">시가총액 <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'marketCap')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'marketCap')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">주가 × 유통주식수</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crAmt(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).marketCap)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">EPS <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'eps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'eps')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crFormulaText('eps', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(crMetricBase(companyReport.detail.manual, companyReport.detail.snapshot).eps, 0)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">BPS <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'bps')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'bps')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400" x-text="crFormulaText('bps', companyReport.detail.manual, companyReport.detail.snapshot)"></td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(crMetricBase(companyReport.detail.manual, companyReport.detail.snapshot).bps, 0)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">PER <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'per')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'per')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">주가 ÷ EPS</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).per)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">PBR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'pbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pbr')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">주가 ÷ BPS</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).pbr)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">PSR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'psr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'psr')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">시가총액 ÷ 매출액</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).psr)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">PCFR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'pcfr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pcfr')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">시가총액 ÷ 영업활동현금흐름</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).pcfr)"></td>
+                                </tr>
+                                <tr>
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">PER × PBR <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'perTimesPbr')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'perTimesPbr')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">PER × PBR (8 이하면 저평가 참고)</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).perTimesPbr)"></td>
+                                </tr>
+                            </tbody>
+                            <tbody>
+                                <tr class="bg-gray-50"><td colspan="3" class="px-2 py-1 text-[11px] font-semibold text-gray-500">자동 전용 (재료 없음 · 스냅샷값)</td></tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">EV/EBITDA(근사) <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'evEbitda')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'evEbitda')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">(시총 + 순차입금) ÷ (영업이익 + 상각비)</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crNum(companyReport.detail.snapshot.priceMetrics.evEbitda)"></td>
+                                </tr>
+                                <tr class="border-b border-gray-50">
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">ROIC(근사) <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'roic')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'roic')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">영업이익×(1−세율) ÷ 투하자본</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crPct(companyReport.detail.snapshot.priceMetrics.roic)"></td>
+                                </tr>
+                                <tr>
+                                    <td class="px-2 py-1.5 text-gray-700 font-medium">발생액/총자산 <span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold align-middle" @mouseenter="crHintShow($event, 'accrual')" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'accrual')">?</span></td>
+                                    <td class="px-2 py-1.5 text-gray-400">(순이익 − 영업CF) ÷ 자산총계</td>
+                                    <td class="px-2 py-1.5 text-right font-mono" x-text="crPct(companyReport.detail.snapshot.priceMetrics.accrualRatio)"></td>
+                                </tr>
+                            </tbody>
+                        </table>
                         <div x-show="companyReport.detail.snapshot.priceMetrics.warnings && companyReport.detail.snapshot.priceMetrics.warnings.length" class="mt-2">
                             <template x-for="w in companyReport.detail.snapshot.priceMetrics.warnings" :key="w">
                                 <div class="text-[11px] text-amber-600" x-text="'⚠ ' + w"></div>
                             </template>
                         </div>
-                        <div x-show="crHasCustomMetrics(companyReport.detail.manual)" class="mt-3 border-t border-gray-100 pt-3">
-                            <div class="text-xs font-medium text-gray-600 mb-2">내 계산 (입력 재료 기반 공식값 — "자동"과 다를 수 있음, 계산식은 5단계 참고)</div>
-                            <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 text-xs mb-2">
-                                <div class="border border-blue-100 bg-blue-50/40 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">시가총액</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'marketCap', false)" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'marketCap', false)">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crAmt(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).marketCap)"></div></div>
-                                <div class="border border-blue-100 bg-blue-50/40 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PER</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'per', false)" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'per', false)">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).per)"></div></div>
-                                <div class="border border-blue-100 bg-blue-50/40 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PBR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'pbr', false)" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pbr', false)">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).pbr)"></div></div>
-                                <div class="border border-blue-100 bg-blue-50/40 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PSR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'psr', false)" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'psr', false)">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).psr)"></div></div>
-                                <div class="border border-blue-100 bg-blue-50/40 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PCFR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'pcfr', false)" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'pcfr', false)">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crTimes(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).pcfr)"></div></div>
-                                <div class="border border-blue-100 bg-blue-50/40 rounded p-2"><div class="flex items-start justify-between"><div class="text-gray-400">PER × PBR</div><span class="cursor-help select-none w-3.5 h-3.5 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] font-bold" @mouseenter="crHintShow($event, 'perTimesPbr', false)" @mouseleave="crHintHide()" @click.stop="crHintToggle($event, 'perTimesPbr', false)">?</span></div><div class="font-semibold text-gray-800 mt-0.5" x-text="crNum(crCalcMetrics(companyReport.detail.manual, companyReport.detail.snapshot).perTimesPbr)"></div></div>
-                            </div>
-                            <div x-show="crForecastMetrics(companyReport.detail.manual, companyReport.detail.snapshot).length > 0">
-                                <table class="w-full text-xs border border-gray-100 rounded">
-                                    <thead>
-                                        <tr class="text-gray-500 border-b border-gray-100 text-left">
-                                            <th class="px-2 py-1.5">연도</th>
-                                            <th class="px-2 py-1.5 text-right">예상 매출</th>
-                                            <th class="px-2 py-1.5 text-right">예상 PSR</th>
-                                            <th class="px-2 py-1.5 text-right">예상 PER</th>
+                        <div x-show="crForecastMetrics(companyReport.detail.manual, companyReport.detail.snapshot).length > 0" class="mt-3">
+                            <div class="text-xs font-medium text-gray-600 mb-1.5">예상 매출 기반 지표 (예상 실적 입력 연동)</div>
+                            <table class="w-full text-xs border border-gray-100 rounded">
+                                <thead>
+                                    <tr class="text-gray-500 border-b border-gray-100 text-left">
+                                        <th class="px-2 py-1.5">연도</th>
+                                        <th class="px-2 py-1.5 text-right">예상 매출</th>
+                                        <th class="px-2 py-1.5 text-right">예상 PSR</th>
+                                        <th class="px-2 py-1.5 text-right">예상 PER</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <template x-for="f in crForecastMetrics(companyReport.detail.manual, companyReport.detail.snapshot)" :key="f.year">
+                                        <tr class="border-b border-gray-50">
+                                            <td class="px-2 py-1.5 font-mono" x-text="f.year + 'E'"></td>
+                                            <td class="px-2 py-1.5 text-right font-mono" x-text="crAmt(f.annual)"></td>
+                                            <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(f.psr)"></td>
+                                            <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(f.per)"></td>
                                         </tr>
-                                    </thead>
-                                    <tbody>
-                                        <template x-for="f in crForecastMetrics(companyReport.detail.manual, companyReport.detail.snapshot)" :key="f.year">
-                                            <tr class="border-b border-gray-50">
-                                                <td class="px-2 py-1.5 font-mono" x-text="f.year + 'E'"></td>
-                                                <td class="px-2 py-1.5 text-right font-mono" x-text="crAmt(f.annual)"></td>
-                                                <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(f.psr)"></td>
-                                                <td class="px-2 py-1.5 text-right font-mono" x-text="crTimes(f.per)"></td>
-                                            </tr>
-                                        </template>
-                                    </tbody>
-                                </table>
-                            </div>
+                                    </template>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </template>


### PR DESCRIPTION
## 개요
기업분석리포트 UX 불편 3건 개선 (Closes #88). 백엔드·Entity·저장 스키마 무변경, 프론트 2파일.

## 변경
- **① 주가지표 자동/내 계산 통합**: "자동 그리드 + 계산기(내 계산)" 두 블록 → 단일 통합 표(작성 5단계·상세 6번). 재료(주가·유통주식수·당기순이익·자본총계·매출액·영업CF) 인라인 편집(자동값 기본 표시, 비우면 자동) → 파생 지표(시총·EPS·BPS·PER·PBR·PSR·PCFR·PER×PBR) 즉시 재계산. EV/EBITDA·ROIC·발생액은 자동 전용 행.
- **② DART 10년 정기보고서 바로가기**: 작성/상세 상단에 사업/반기/분기 원문 링크 바(연도 그룹 접이식, 정정 배지). 기존 `getDisclosures?types=A` 재사용.
- **③ 경쟁사 "비교 내용" 여러 줄**: `input`→`textarea`, 상세 `pre-wrap` 줄바꿈 보존.

## 리뷰(/code-review xhigh) 반영
- high 없음. F1(공시 로드 gen 무효화)·F2(정정 reportName 병행 감지)·F4(자동 안내값 포맷 통일)·F5(dead param 제거) 반영.

## 검증
- bootRun(dev) 기동 성공(compileJava 포함). ② 공시 실 API 200. ①③ 렌더·재계산·줄바꿈 통과(독립 하니스), 신규 콘솔 에러 없음.
- 제약: dev 인증(anonymous 401)으로 리포트 저장/preview 실데이터는 미검증 — 실계정 환경 최종 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)