### PR TITLE
feat(companyreport): 상장일~현재 전구간 월봉 주가 차트 — 위저드·상세 (#95)

### DIFF
--- a/docs/brainstorms/2026-07-16-company-report-monthly-price-chart-brainstorm.md
+++ b/docs/brainstorms/2026-07-16-company-report-monthly-price-chart-brainstorm.md
@@ -1,0 +1,51 @@
+# 기업분석리포트 월봉 주가 차트 - Brainstorm
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+**Date:** 2026-07-16
+**Status:** Decided
+**Issue:** #95 / Branch: `feat/issue-95-monthly-price-chart`
+
+## What We're Building
+
+기업 분석 리포트(작성 위저드 + 상세 뷰)에 **개별 회사 주가 차트(상장일~현재, 전구간 월봉, 종가 라인)**를 추가한다.
+
+## 사전 실측 (KIS)
+
+- `inquire-daily-itemchartprice` (FHKST03010100), `FID_PERIOD_DIV_CODE` = D/W/M/Y 지원.
+- **호출당 최대 100건 하드 한계** (실측 D·W·M 정확히 100건). 응답은 종료일 기준 최신 100건.
+- 페이징(윈도우 후방 이동)하면 과거 임의 구간 조회 가능 — 삼성전자 실측 1985년(~40년)까지 존재.
+- 월봉 1호출 커버 ≈ 8.2년 → 40년치 ≈ 5회 호출.
+
+## 확정된 결정 (사용자 확인 완료)
+
+| 항목 | 결정 |
+|------|------|
+| 기간/봉 | 상장일~현재 **전구간 월봉** (삼성전자 기준 ~480포인트) |
+| 위치 | **위저드 + 상세 뷰 둘 다** — 위저드 5단계(기업가치) 주가지표 파티션, 상세 "6. 주가지표" 섹션 |
+| 차트 | **종가 라인** (Chart.js, 기존 `_charts` 패턴 재사용) |
+| 상장일 | 별도 상장일 조회 없이 `from`을 과거로 넉넉히(예: 1960-01-01) → KIS가 실데이터 구간만 반환하는 특성 활용. 첫 데이터가 곧 상장 시점 |
+| 저장 | 주가는 스냅샷에 저장하지 않고 **실시간 조회** (서버 캐시로 반복 조회 완충) |
+
+## 현재 상태 (실측)
+
+- KIS 일봉 체인(client→adapter→port→service→DailyPrice)은 구현돼 있으나 **컨트롤러 미연결**, `FID_PERIOD_DIV_CODE="D"` 하드코딩 (`KisStockPriceClient.java:114`).
+- 어댑터 페이징: `DAILY_CHUNK_CALENDAR_DAYS=140`, `DAILY_MAX_CHUNK_ITERATIONS=10` — 일봉 전제라 월봉엔 창 크기 조정 필요.
+- `@Cacheable` 키가 `stockCode:from:to` — period 미포함.
+- 리포트 상세 응답에 stockCode 이미 존재. 위저드도 종목 선택 후 stockCode 보유.
+- Chart.js 전역 로드됨. 기존 차트: `_crRenderPerfChart` + `_charts` push + `_crDestroyCharts`.
+
+## Edge Cases
+
+- 신규 상장(데이터 몇 개월뿐) → 있는 구간만 라인.
+- KIS 실패/부분 실패 → 어댑터 graceful degrade(부분 반환) 유지, 프론트 빈 상태 문구.
+- 리포트 재조회/뷰 전환 시 차트 destroy (기존 패턴).
+- 페이징 반복 한도: 월봉 창 크기 조정으로 40년 ≈ 5회, 가드 10회 내.
+- 당월 진행 중 월봉: KIS가 완성 월 기준으로 반환할 수 있음(실측 7/14 호출 시 최신 6/30) — 그대로 표시.
+
+## 범위 밖 (하지 않음)
+
+- 캔들(OHLC) 차트, 주봉/년봉 토글 UI.
+- 종목평가 화면 변경.
+- 스냅샷 저장 구조 변경(주가 미저장).
+- 해외 종목 지원(국내 KRX만).

--- a/docs/commits/2026-07-16-company-report-monthly-price-chart-commit.md
+++ b/docs/commits/2026-07-16-company-report-monthly-price-chart-commit.md
@@ -1,0 +1,25 @@
+# 기업분석리포트 월봉 주가 차트 Commit 기록
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## 포함 파일
+- src/main/java/.../stock/domain/model/ChartPeriod.java (신규)
+- src/main/java/.../stock/application/dto/PriceHistoryResponse.java (신규)
+- src/main/java/.../stock/domain/service/StockPricePort.java
+- src/main/java/.../stock/infrastructure/stock/kis/KisStockPriceClient.java
+- src/main/java/.../stock/infrastructure/stock/kis/KisStockPriceAdapter.java
+- src/main/java/.../stock/application/StockPriceService.java
+- src/main/java/.../stock/presentation/StockController.java
+- src/main/resources/static/js/api.js
+- src/main/resources/static/js/components/company-report.js
+- src/main/resources/static/partials/company-report.html
+- docs/brainstorms|issues|plans|works|reviews|validations|gates|commits|pushes/2026-07-16-company-report-monthly-price-chart-*.md
+
+## 제외 파일
+- 없음 (worktree 내 변경은 모두 본 작업 범위)
+
+## 커밋 메시지
+feat(companyreport): 상장일~현재 전구간 월봉 주가 차트 — 위저드·상세 (#95)
+
+## 승인
+- 태형님 승인: 예 (commit·push·PR·병합 진행 승인)

--- a/docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+++ b/docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
@@ -1,0 +1,22 @@
+# 기업분석리포트 월봉 주가 차트 게이트 로그
+
+## 원칙
+- 각 단계 시작 전 태형님에게 작업 내용을 제시한다.
+- 다음 단계로 넘어갈지에 대한 판단은 태형님에게 넘긴다.
+- 단계별 산출물은 이 게이트 로그를 `gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md`로 참조한다.
+
+## Stage Decisions
+- start: approved
+- brainstorm: approved
+- issue: approved
+- plan: approved
+- work: approved
+- review: approved
+- validation: approved
+- commit: approved
+- push: approved
+
+## Notes
+- 기간/봉·위치·차트 형태·상장일 처리·실시간 조회는 brainstorm에서 태형님 확정.
+- Issue #95 등록 후 worktree `feat/issue-95-monthly-price-chart`(base main) 생성.
+- 신규 공개 API(price-history 엔드포인트)와 StockPricePort 시그니처 확장은 plan 승인 시 함께 승인된 것으로 본다.

--- a/docs/issues/2026-07-16-company-report-monthly-price-chart-issue.md
+++ b/docs/issues/2026-07-16-company-report-monthly-price-chart-issue.md
@@ -1,0 +1,18 @@
+# 기업분석리포트 월봉 주가 차트 Issue 기록
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## GitHub Issue
+- status: created
+- issue_number: 95
+- issue_url: https://github.com/osnet-th/stock-market/issues/95
+- title: [feat] 기업분석리포트 — 상장일부터 현재까지 월봉 주가 차트 추가
+- label: enhancement
+
+## 요약
+기업 분석 리포트(위저드 5단계 + 상세 6번 섹션)에 상장일~현재 전구간 월봉 종가 라인 차트 추가.
+KIS 기간별시세(FHKST03010100) 주기 파라미터화 + 신규 price-history 엔드포인트 + Chart.js 렌더.
+
+## Worktree
+- `scripts/create-worktree.sh --issue 95 feat/issue-95-monthly-price-chart`
+- path: ../wt-issue-95-feat-issue-95-monthly-price-chart (base main 96528f2, .env 복사됨)

--- a/docs/plans/2026-07-16-001-feat-company-report-monthly-price-chart-plan.md
+++ b/docs/plans/2026-07-16-001-feat-company-report-monthly-price-chart-plan.md
@@ -1,0 +1,119 @@
+---
+title: "feat: 기업분석리포트 월봉 주가 차트 (상장일~현재)"
+type: feat
+status: active
+date: 2026-07-16
+issue: 95
+origin: docs/brainstorms/2026-07-16-company-report-monthly-price-chart-brainstorm.md
+---
+
+# feat: 기업분석리포트 월봉 주가 차트 (상장일~현재)
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## Overview
+
+기업 분석 리포트의 위저드 5단계(기업가치, 주가지표 파티션)와 상세 뷰 "6. 주가지표" 섹션에
+**상장일~현재 전구간 월봉 종가 라인 차트**를 추가한다.
+KIS 기간별시세(FHKST03010100)의 주기 파라미터화 + 페이징으로 데이터를 확보하고,
+신규 REST 엔드포인트로 노출한 뒤 기존 Chart.js 패턴으로 렌더한다.
+(brainstorm: docs/brainstorms/2026-07-16-company-report-monthly-price-chart-brainstorm.md, issue #95)
+
+## 확정된 결정 (brainstorm 승인)
+
+| 항목 | 결정 |
+|------|------|
+| 기간/봉 | 상장일~현재 전구간 월봉 |
+| 위치 | 위저드 5단계 주가지표 파티션 + 상세 "6. 주가지표" 섹션 |
+| 차트 | 종가 라인 (Chart.js `_charts` 패턴) |
+| 상장일 | 별도 조회 없이 from=1960-01-01 폴백 — KIS가 실데이터 구간만 반환 |
+| 저장 | 스냅샷 미저장, 실시간 조회 + 서버 캐시(12h) |
+
+## Proposed Solution — 변경 대상
+
+### 백엔드 (stock 모듈 — companyreport 모듈 변경 없음)
+
+```
+stock/domain/model/
+├── ChartPeriod.java                  # [신규] DAILY("D",140) / WEEKLY("W",690) / MONTHLY("M",3000)
+│                                     #   KIS FID_PERIOD_DIV_CODE + 주기별 페이징 창(캘린더일)
+stock/domain/service/
+├── StockPricePort.java               # [수정] getDailyHistory → getPriceHistory(..., ChartPeriod, from, to)
+stock/infrastructure/stock/kis/
+├── KisStockPriceClient.java          # [수정] getDomesticDailyChart → getDomesticPeriodChart(+period)
+│                                     #   FID_PERIOD_DIV_CODE 하드코딩("D") 제거 (line 114)
+├── KisStockPriceAdapter.java         # [수정] getPriceHistory: 주기별 창 크기 + 캐시 키에 period 포함
+stock/application/
+├── StockPriceService.java            # [수정] getPriceHistory + 응답 DTO 매핑
+├── dto/PriceHistoryResponse.java     # [신규] { stockCode, period, points[{date, close, open, high, low, volume}] }
+stock/presentation/
+├── StockController.java              # [수정] GET /api/stocks/{stockCode}/price-history 추가
+```
+
+- **신규 엔드포인트**: `GET /api/stocks/{stockCode}/price-history?period=M&from=&to=`
+  - `period`: D|W|M (기본 M), `from` 기본 1960-01-01, `to` 기본 오늘. 종목코드 6자리 검증.
+  - 국내 전용(KRX). 내부에서 MarketType.KOSPI/ExchangeCode.KRX 고정 전달(어댑터는 isDomestic만 검사).
+- **시그니처 변경 근거**: `getDailyHistory`는 컨트롤러/타 모듈 호출처 0곳(어댑터·서비스 내부 위임뿐) —
+  period 인자를 추가한 `getPriceHistory`로 일반화. 기존 동작(D)은 ChartPeriod.DAILY로 동일 재현.
+- **페이징**: 기존 슬라이딩 윈도우 로직 유지, 창 크기만 주기별 상수화
+  (M=3000일 ≈ 98개월/호출 → 40년 ≈ 5회, 가드 10회 내 ≈ 최대 82년).
+- **캐시**: 동일 dailyHistoryCacheManager(12h), key = `stockCode:period:from:to`.
+
+### 프론트엔드
+
+```
+static/js/api.js                      # [수정] getStockPriceHistory(stockCode, period='M')
+static/js/components/company-report.js# [수정] priceHistory 상태 + 로드/렌더 헬퍼
+static/partials/company-report.html   # [수정] 위저드 step5 + 상세 6번 섹션에 차트 카드/canvas
+```
+
+- 상태: `companyReport.priceHistory = { stockCode:'', points:[], loading, loaded, error, _gen }`
+  — stockCode 기준 1회 로드 후 위저드/상세 양쪽 canvas에 재사용.
+- 렌더: `_crRenderPriceHistoryChart(canvasId)` — 라벨 YYYY-MM, 종가 라인 1개, `_charts` push,
+  `$nextTick` 후 호출, 뷰 전환 시 기존 `_crDestroyCharts()`가 함께 파기.
+- canvas id: 위저드 `report-wizard-price-history`, 상세 `report-detail-price-history`.
+- 트리거: 상세 열람 시(기존 상세 차트 렌더 지점) + 위저드 5단계 진입 시(`companyReportGoStep`).
+  같은 종목 재진입은 로드 생략(캐시), 종목 변경 시 상태 리셋.
+- 빈 상태: "주가 데이터를 불러올 수 없습니다" / 로딩 문구.
+
+## Implementation Phases
+
+### Phase 1 — 백엔드 (stock 모듈) — 완료
+- [x] `ChartPeriod` enum 신설 (code, chunkCalendarDays: D=140/W=690/M=3000).
+- [x] `KisStockPriceClient.getDomesticPeriodChart(stockCode, from, to, period)` — FID_PERIOD_DIV_CODE 파라미터화.
+- [x] `StockPricePort.getPriceHistory(stockCode, marketType, exchangeCode, period, from, to)` (default 빈 리스트).
+- [x] `KisStockPriceAdapter.getPriceHistory` — 주기별 창 크기, 캐시 키에 period 포함, 기존 dedup/degrade 유지.
+- [x] `StockPriceService.getPriceHistory` + `PriceHistoryResponse` DTO. (compileJava 통과)
+- [x] `StockController` GET `/api/stocks/{stockCode}/price-history` (period 기본 M, from 기본 1960-01-01, to 기본 오늘, 400 검증).
+
+### Phase 2 — 프론트엔드 — 완료
+- [x] `api.js` `getStockPriceHistory` (timeoutMs 30s).
+- [x] `company-report.js` — `priceHistory` 상태, `_crLoadPriceHistory`(종목별 1회 로드·세대 가드), `_crRenderPriceHistoryChart`(Chart.getChart 중복 가드), `_crRenderPriceChartsForCurrentView`, 트리거(상세 open/refresh/onEnter + 위저드 step5 진입).
+- [x] `company-report.html` — 위저드 step5 상단 + 상세 6번 주가지표 섹션 내 차트 카드(canvas/로딩/빈 상태). 태그 균형 검증.
+
+### Phase 3 — 검증 — 완료
+- [x] curl: `/api/stocks/005930/price-history` → **499포인트, 1985-01-31 ~ 2026-07-24 (41년), 0.5초**. 첫 포인트 = 상장 초기(1985).
+- [x] 짧은 구간: `period=D&from=2026-06-01` → 38포인트 정상. 오류 검증: period=X → 400, 종목코드 5자리 → 400.
+- [x] 라이브(dev 프로파일, 삼성전자): 위저드 5단계 + 상세 주가지표 섹션 모두 월봉 차트 렌더 확인(스크린샷). 신규 콘솔 에러 0(부동산 파티션 기존 에러 1건은 무관 확인).
+- [x] 기존 실적 추이 차트 회귀 없음(상세 뷰 정상 렌더 확인).
+
+## Testing Strategy
+
+- 테스트 코드는 명시 요청 없음 → 수동 검증(curl + 라이브 브라우저).
+- 회귀 관찰 대상: 기존 현재가/멀티시세(동일 어댑터 파일), 리포트 실적 추이 차트.
+
+## Risks / Trade-offs
+
+- **Port 시그니처 변경**: 호출처 0곳 확인됨 → 파급 없음. (gate: plan 승인에 포함)
+- **KIS 연쇄 호출**: 월봉 전구간 ≈ 5회 순차 호출(레이트리밋 여유). 12h 캐시로 반복 조회 완충.
+- **당월 미완성 월봉**: KIS가 완성 월까지만 줄 수 있음 — 그대로 표시(실측 기준).
+- **위저드 미리보기 단계 이탈**: 종목 변경 시 priceHistory 리셋 누락하면 이전 종목 차트 잔존 → 리셋 지점 명시 구현.
+
+## Approval Gates (이 작업)
+
+- 신규 공개 API(`/api/stocks/{stockCode}/price-history`) + `StockPricePort` 시그니처 확장 → **본 플랜 승인에 포함**.
+- Entity/DB/스냅샷 스키마 변경 없음. companyreport 백엔드 모듈 변경 없음.
+
+## Out of Scope
+
+- 캔들(OHLC)·주봉/년봉 토글 UI, 해외 종목, 종목평가 화면 변경, 스냅샷 저장 구조 변경.

--- a/docs/pushes/2026-07-16-company-report-monthly-price-chart-push.md
+++ b/docs/pushes/2026-07-16-company-report-monthly-price-chart-push.md
@@ -1,0 +1,18 @@
+# 기업분석리포트 월봉 주가 차트 Push 기록
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## 대상
+- remote: origin (git@github.com:osnet-th/stock-market.git)
+- branch: feat/issue-95-monthly-price-chart
+- base: main
+- issue: #95
+
+## 의도
+- 월봉 주가 차트 기능을 원격에 반영하고 PR 생성 → main 병합.
+
+## 승인
+- 태형님 승인: 예 (push·PR·병합까지 일괄 승인)
+
+## 결과
+- push/PR/병합 결과는 최종 응답 및 후속 기록으로 남김.

--- a/docs/reviews/2026-07-16-company-report-monthly-price-chart-review.md
+++ b/docs/reviews/2026-07-16-company-report-monthly-price-chart-review.md
@@ -1,0 +1,24 @@
+# 기업분석리포트 월봉 주가 차트 Review
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## Findings (심각도 순)
+
+명시적 findings 없음 (버그·회귀·설계 위반·컨벤션 위반 없음). 아래는 남은 리스크/관찰.
+
+- (low) **당월 미완성 월봉 포함**: 실측 마지막 포인트가 2026-07-24(진행 중인 7월) — KIS가 진행 월의 부분 봉을 반환함. 라인 차트 특성상 시각적 문제는 없으나 "완성 월"만 원하면 후속 조정 여지.
+- (low) **KIS 미가동 시간/휴장일**: KIS 장애 시 어댑터 graceful degrade(부분/빈 리스트) → 프론트 "주가 데이터가 없습니다." 문구로 처리됨. 재시도 UI는 없음(리포트 재진입 시 재조회).
+- (low) **Port 시그니처 변경**: `getDailyHistory` → `getPriceHistory`. 기존 호출처 0곳 grep 확인 — 파급 없음. 캐시 키에 period 포함으로 D/M 충돌 방지.
+- (info) **위저드 즉시 재진입 렌더**: `Chart.getChart` 가드로 step 5 재진입 시 중복 생성 방지. 차트 파기는 기존 `_crDestroyCharts` 흐름(뷰 전환·preview 재로드·refresh)에 편입.
+- (info) 상세 차트는 "6. 주가지표" 섹션(`priceMetrics` 존재 시) 내부에 위치 — priceMetrics 없는 리포트는 차트도 미표시(승인된 위치 결정에 따름).
+
+## Open Questions / Assumptions
+
+- 가정: KIS 기간별시세는 호출당 최대 100건, 종료일 기준 최신 반환(실측 확인).
+- 가정: from=1960-01-01이면 KIS가 상장 이후 구간만 반환(삼성전자 1985-01-31 실측 확인).
+
+## Change Summary
+
+- 백엔드 7파일(신규 2: ChartPeriod, PriceHistoryResponse) — KIS 기간별시세 주기 파라미터화 + `/api/stocks/{stockCode}/price-history` 신설.
+- 프론트 3파일 — 위저드 5단계·상세 주가지표 섹션에 월봉 종가 라인 차트.
+- Entity/DB/스냅샷 스키마/companyreport 백엔드 무변경.

--- a/docs/validations/2026-07-16-company-report-monthly-price-chart-validation.md
+++ b/docs/validations/2026-07-16-company-report-monthly-price-chart-validation.md
@@ -1,0 +1,31 @@
+# 기업분석리포트 월봉 주가 차트 검증
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## 실행 명령 / 결과
+
+- `./gradlew compileJava` → pass (기존 realestate deprecated 경고만).
+- 잔여 참조 grep(`getDailyHistory`/`getDomesticDailyChart`/`DAILY_CHUNK_*`) → 0건.
+- HTML 태그 균형(python): div 337/337, template 90/90, canvas 4/4 등 전 태그 일치 → pass.
+- JS 괄호 균형: 추가 구간 38/38·24/24·3/3 균형. 파일 전체 `()` 1건 차이는 base(HEAD)부터 동일(문자열 내 괄호) → 무관.
+- curl (worktree 앱, dev 프로파일):
+  - `GET /api/stocks/005930/price-history` → 200, **period=M, 499포인트, 1985-01-31 ~ 2026-07-24 (41년), 0.5s**.
+  - `GET .../price-history?period=D&from=2026-06-01` → 38포인트 (짧은 구간 정상).
+  - `period=X` → 400, 종목코드 `12345` → 400 (검증 동작).
+  - 미인증(prod 프로파일 시) → 401 (보안 유지).
+- 라이브 브라우저(dev, 삼성전자):
+  - 상세 뷰 "6. 주가지표" 섹션: "주가 추이 (월봉)" 카드 + 41년 종가 라인 차트 렌더 확인(스크린샷).
+  - 위저드 5단계(기업가치): 동일 차트 렌더 확인. 종목 데이터 재사용(상세→위저드 중복 호출 없음) — 차트 인스턴스 검사로 499포인트 데이터 확인.
+  - 기존 실적 추이 차트(상세) 회귀 없음.
+  - 신규 콘솔 에러 0. (기존 `nextScheduledAt` 에러 1건은 realestate 파티션 소속, 본 변경 파일 아님 — 무관 확인)
+
+## 검증 환경 메모
+
+- 검증은 worktree 앱(dev 프로파일, permitAll)에서 수행. UI 접근용으로 `.env` JWT 시크릿으로 로컬 dev 검증 토큰을 발급해 사용 후 브라우저에서 제거함.
+- 검증용으로 생성한 리포트(id 10)는 검증 후 DELETE(204) — dev DB 리포트 0건 복원.
+
+## 미검증 / 리스크
+
+- 테스트 코드 없음(명시 요청 없음) — 수동 검증으로 대체.
+- KIS 미가동 시간대의 실제 장애 폴백(부분 반환)은 코드 경로 검토로만 확인(강제 재현 안 함).
+- prod 프로파일 실행 시 인증 헤더 포함 호출은 로그인 세션에서 자동 처리(기존 api.js 공통 헤더) — 별도 미검증 항목 없음.

--- a/docs/works/2026-07-16-company-report-monthly-price-chart-work.md
+++ b/docs/works/2026-07-16-company-report-monthly-price-chart-work.md
@@ -1,0 +1,31 @@
+# 기업분석리포트 월봉 주가 차트 Work 기록
+
+gate: docs/gates/2026-07-16-company-report-monthly-price-chart-gates.md
+
+## 변경 파일
+
+### 백엔드 (stock 모듈 — companyreport 백엔드 무변경)
+- `stock/domain/model/ChartPeriod.java` [신규] — D("D",140) / W("W",690) / M("M",3000). KIS FID_PERIOD_DIV_CODE + 주기별 페이징 창(캘린더일). `fromCode` 파싱.
+- `stock/infrastructure/stock/kis/KisStockPriceClient.java` — `getDomesticDailyChart` → `getDomesticPeriodChart(+ChartPeriod)`. `FID_PERIOD_DIV_CODE="D"` 하드코딩 제거.
+- `stock/domain/service/StockPricePort.java` — `getDailyHistory` → `getPriceHistory(+ChartPeriod)` 일반화 (기존 메서드 호출처 0곳 확인 후 대체).
+- `stock/infrastructure/stock/kis/KisStockPriceAdapter.java` — `getPriceHistory`: 주기별 창 크기(`period.getChunkCalendarDays()`), 캐시 키 `stockCode:period:from:to`, 슬라이딩 페이징/dedup/graceful degrade 유지. 가드 상수 `MAX_CHUNK_ITERATIONS=10`(월봉 기준 ≈82년).
+- `stock/application/StockPriceService.java` — `getPriceHistory(stockCode, period, from, to)`. from 기본 1960-01-01(상장일 조회 없이 전구간 — KIS가 실데이터 구간만 반환), to 기본 오늘. 국내(KOSPI/KRX) 고정.
+- `stock/application/dto/PriceHistoryResponse.java` [신규] — `{stockCode, period, points[{date, open, high, low, close, volume}]}`.
+- `stock/presentation/StockController.java` — `GET /api/stocks/{stockCode}/price-history?period=M&from=&to=`. 종목코드 6자리·period·날짜(yyyy-MM-dd) 검증(400).
+
+### 프론트엔드
+- `static/js/api.js` — `getStockPriceHistory(stockCode, period='M')` (timeoutMs 30s).
+- `static/js/components/company-report.js` —
+  - 상태 `companyReport.priceHistory { stockCode, points, loading, error, _gen }`.
+  - `_crLoadPriceHistory(stockCode)`: 같은 종목 1회 로드 후 재사용, 세대 카운터 레이스 가드, 완료 시 현재 뷰에 렌더.
+  - `_crRenderPriceHistoryChart(canvasId)`: 월봉 종가 라인(Chart.js), `Chart.getChart` 중복 렌더 가드, `_charts` push(기존 파기 흐름 편입).
+  - 트리거: `_crRenderStepChart`(step 5 진입), `companyReportOpenDetail`, `companyReportRefresh`, `companyReportOnEnter`(detail 재진입).
+- `static/partials/company-report.html` —
+  - 위저드 5단계(기업가치) 상단: "주가 추이 (월봉)" 카드 + `report-wizard-price-history` canvas + 로딩/빈 상태.
+  - 상세 "6. 주가지표" 섹션 내: 동일 구성 `report-detail-price-history` canvas.
+
+## 설계 포인트
+- 상장일 별도 조회 없음: from=1960-01-01 → KIS가 실데이터 존재 구간만 반환(첫 포인트 = 상장 시점). 실측 삼성전자 1985-01-31부터.
+- 주가는 스냅샷 미저장(실시간 조회) + 서버 캐시 12h(dailyHistoryCacheManager).
+- 페이징: 월봉 창 3000일 ≈ 98개월/호출 → 41년 = 5~6회 KIS 호출. 실측 총 0.5초.
+- Port 시그니처 변경은 기존 호출처 0곳(미노출 상태였음) — plan 승인에 포함.

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/application/StockPriceService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/application/StockPriceService.java
@@ -1,8 +1,10 @@
 package com.thlee.stock.market.stockmarket.stock.application;
 
 import com.thlee.stock.market.stockmarket.stock.application.dto.BulkStockPriceResponse;
+import com.thlee.stock.market.stockmarket.stock.application.dto.PriceHistoryResponse;
 import com.thlee.stock.market.stockmarket.stock.application.dto.StockPriceResponse;
 import com.thlee.stock.market.stockmarket.stock.domain.model.CachedStockPrice;
+import com.thlee.stock.market.stockmarket.stock.domain.model.ChartPeriod;
 import com.thlee.stock.market.stockmarket.stock.domain.model.DailyPrice;
 import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
 import com.thlee.stock.market.stockmarket.stock.domain.model.MarketType;
@@ -83,12 +85,22 @@ public class StockPriceService {
         return new BulkStockPriceResponse(prices);
     }
 
+    /** 상장일 조회 없이 전구간을 커버하기 위한 기본 시작일 — KIS는 실데이터 존재 구간만 반환한다. */
+    private static final LocalDate PRICE_HISTORY_DEFAULT_FROM = LocalDate.of(1960, 1, 1);
+
     /**
-     * 일봉 히스토리 조회. 현재 포트 기본 구현은 빈 리스트 반환 — 실제 KIS
-     * inquire-daily-itemchartprice 연동은 후속.
+     * 기간별(일/주/월봉) 가격 히스토리 조회. 국내(KRX) 전용.
+     *
+     * @param period 봉 주기
+     * @param from   시작일 (null이면 1960-01-01 — 상장 이후 전구간)
+     * @param to     종료일 (null이면 오늘)
      */
-    public List<DailyPrice> getDailyHistory(String stockCode, MarketType marketType, ExchangeCode exchangeCode,
-                                            LocalDate from, LocalDate to) {
-        return stockPricePort.getDailyHistory(stockCode, marketType, exchangeCode, from, to);
+    public PriceHistoryResponse getPriceHistory(String stockCode, ChartPeriod period,
+                                                LocalDate from, LocalDate to) {
+        LocalDate effectiveFrom = from != null ? from : PRICE_HISTORY_DEFAULT_FROM;
+        LocalDate effectiveTo = to != null ? to : LocalDate.now();
+        List<DailyPrice> prices = stockPricePort.getPriceHistory(
+            stockCode, MarketType.KOSPI, ExchangeCode.KRX, period, effectiveFrom, effectiveTo);
+        return PriceHistoryResponse.from(stockCode, period, prices);
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/application/dto/PriceHistoryResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/application/dto/PriceHistoryResponse.java
@@ -1,0 +1,50 @@
+package com.thlee.stock.market.stockmarket.stock.application.dto;
+
+import com.thlee.stock.market.stockmarket.stock.domain.model.ChartPeriod;
+import com.thlee.stock.market.stockmarket.stock.domain.model.DailyPrice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 기간별(일/주/월봉) 가격 히스토리 응답.
+ * points는 date ASC 정렬. 값은 도메인 {@link DailyPrice}를 표시용으로 변환한 것.
+ */
+@Getter
+@Builder
+public class PriceHistoryResponse {
+
+    private final String stockCode;
+    private final String period;
+    private final List<PricePoint> points;
+
+    @Getter
+    @Builder
+    public static class PricePoint {
+        private final String date;    // yyyy-MM-dd
+        private final String open;
+        private final String high;
+        private final String low;
+        private final String close;
+        private final Long volume;
+    }
+
+    public static PriceHistoryResponse from(String stockCode, ChartPeriod period, List<DailyPrice> prices) {
+        List<PricePoint> points = prices.stream()
+            .map(p -> PricePoint.builder()
+                .date(p.date().toString())
+                .open(p.open() != null ? p.open().toPlainString() : null)
+                .high(p.high() != null ? p.high().toPlainString() : null)
+                .low(p.low() != null ? p.low().toPlainString() : null)
+                .close(p.close() != null ? p.close().toPlainString() : null)
+                .volume(p.volume())
+                .build())
+            .toList();
+        return PriceHistoryResponse.builder()
+            .stockCode(stockCode)
+            .period(period.getCode())
+            .points(points)
+            .build();
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/model/ChartPeriod.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/model/ChartPeriod.java
@@ -1,0 +1,40 @@
+package com.thlee.stock.market.stockmarket.stock.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+/**
+ * 기간별시세 봉 주기.
+ *
+ * <p>KIS inquire-daily-itemchartprice(FHKST03010100)의 {@code FID_PERIOD_DIV_CODE} 값과
+ * 페이징 창 크기(캘린더일)를 보유한다. KIS는 호출당 최대 100건(종료일 기준 최신)을 반환하므로,
+ * 창 크기는 "약 100봉"에 해당하는 캘린더일로 잡아 슬라이딩 페이징 횟수를 최소화한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ChartPeriod {
+
+    /** 일봉 — 100영업일 ≈ 140캘린더일 */
+    DAILY("D", 140),
+
+    /** 주봉 — 100주 ≈ 690캘린더일 */
+    WEEKLY("W", 690),
+
+    /** 월봉 — 100개월 ≈ 3000캘린더일 (40년치 ≈ 5회 호출) */
+    MONTHLY("M", 3000);
+
+    /** KIS FID_PERIOD_DIV_CODE 값. */
+    private final String code;
+
+    /** 페이징 슬라이딩 창 크기(캘린더일). */
+    private final int chunkCalendarDays;
+
+    public static ChartPeriod fromCode(String code) {
+        return Arrays.stream(values())
+            .filter(p -> p.code.equalsIgnoreCase(code))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 봉 주기: " + code));
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/service/StockPricePort.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/domain/service/StockPricePort.java
@@ -1,6 +1,7 @@
 package com.thlee.stock.market.stockmarket.stock.domain.service;
 
 import com.thlee.stock.market.stockmarket.stock.domain.model.CachedStockPrice;
+import com.thlee.stock.market.stockmarket.stock.domain.model.ChartPeriod;
 import com.thlee.stock.market.stockmarket.stock.domain.model.DailyPrice;
 import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
 import com.thlee.stock.market.stockmarket.stock.domain.model.MarketType;
@@ -30,16 +31,16 @@ public interface StockPricePort {
     Map<String, CachedStockPrice> getDomesticPricesWithCacheInfo(List<String> stockCodes);
 
     /**
-     * 일봉(Daily) 가격 히스토리 조회.
+     * 기간별(일/주/월봉) 가격 히스토리 조회.
      *
-     * <p>기본 구현은 빈 리스트 (포트 확장만 추가, 실제 어댑터 구현은 후속 작업). 구현체가
-     * 제공하는 경우 {@code date ASC} 정렬로 반환해야 한다.
+     * <p>기본 구현은 빈 리스트. 구현체가 제공하는 경우 {@code date ASC} 정렬로 반환해야 한다.
      *
-     * @param from 포함 시작일
-     * @param to 포함 종료일
+     * @param period 봉 주기 (일/주/월)
+     * @param from   포함 시작일
+     * @param to     포함 종료일
      */
-    default List<DailyPrice> getDailyHistory(String stockCode, MarketType marketType, ExchangeCode exchangeCode,
-                                             LocalDate from, LocalDate to) {
+    default List<DailyPrice> getPriceHistory(String stockCode, MarketType marketType, ExchangeCode exchangeCode,
+                                             ChartPeriod period, LocalDate from, LocalDate to) {
         return List.of();
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/stock/kis/KisStockPriceAdapter.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/stock/kis/KisStockPriceAdapter.java
@@ -1,6 +1,7 @@
 package com.thlee.stock.market.stockmarket.stock.infrastructure.stock.kis;
 
 import com.thlee.stock.market.stockmarket.stock.domain.model.CachedStockPrice;
+import com.thlee.stock.market.stockmarket.stock.domain.model.ChartPeriod;
 import com.thlee.stock.market.stockmarket.stock.domain.model.DailyPrice;
 import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
 import com.thlee.stock.market.stockmarket.stock.domain.model.MarketType;
@@ -34,11 +35,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class KisStockPriceAdapter implements StockPricePort {
 
-    /** KIS inquire-daily-itemchartprice 단일 호출 영업일 한계(~100). 캘린더 환산 안전 마진 포함. */
-    private static final int DAILY_CHUNK_CALENDAR_DAYS = 140;
-
-    /** 청크 루프 무한 가드 (365일 ÷ 100영업일 ≈ 3회면 충분). */
-    private static final int DAILY_MAX_CHUNK_ITERATIONS = 10;
+    /** 청크 루프 무한 가드 (주기별 창 크기가 ~100봉이므로 10회 ≈ 1000봉 — 월봉 기준 약 82년). */
+    private static final int MAX_CHUNK_ITERATIONS = 10;
 
     private final KisStockPriceClient priceClient;
     private final CacheManager stockPriceCacheManager;
@@ -108,8 +106,9 @@ public class KisStockPriceAdapter implements StockPricePort {
     }
 
     /**
-     * 국내 일봉 조회. KIS inquire-daily-itemchartprice 가 단일 호출 ~100영업일 한계라
+     * 국내 기간별(일/주/월봉) 조회. KIS inquire-daily-itemchartprice 가 단일 호출 ~100봉 한계라
      * 슬라이딩 윈도우(windowEnd 후방 이동) 로 청크 호출 + LinkedHashMap dedup 후 ASC 정렬 반환.
+     * 창 크기는 주기별 상수({@link ChartPeriod#getChunkCalendarDays()}).
      * 해외는 base 인터페이스의 default(빈 리스트)를 유지 — 별도 어댑터 도입 시 확장.
      *
      * <p>중간 청크 실패 시 이미 모은 부분 결과를 반환 (graceful degrade). 전체 실패면 빈 리스트.
@@ -118,24 +117,25 @@ public class KisStockPriceAdapter implements StockPricePort {
     @Cacheable(
             cacheNames = StockPriceCacheConfig.DAILY_HISTORY_CACHE,
             cacheManager = "dailyHistoryCacheManager",
-            key = "#stockCode + ':' + #from + ':' + #to",
+            key = "#stockCode + ':' + #period + ':' + #from + ':' + #to",
             unless = "#result.isEmpty()"
     )
-    public List<DailyPrice> getDailyHistory(String stockCode, MarketType marketType, ExchangeCode exchangeCode,
-                                            LocalDate from, LocalDate to) {
-        if (!marketType.isDomestic() || from == null || to == null || from.isAfter(to)) {
+    public List<DailyPrice> getPriceHistory(String stockCode, MarketType marketType, ExchangeCode exchangeCode,
+                                            ChartPeriod period, LocalDate from, LocalDate to) {
+        if (!marketType.isDomestic() || period == null || from == null || to == null || from.isAfter(to)) {
             return List.of();
         }
         Map<LocalDate, DailyPrice> dedup = new LinkedHashMap<>();
         LocalDate windowEnd = to;
         int iterations = 0;
         try {
-            while (!windowEnd.isBefore(from) && iterations++ < DAILY_MAX_CHUNK_ITERATIONS) {
-                LocalDate windowStart = windowEnd.minusDays(DAILY_CHUNK_CALENDAR_DAYS);
+            while (!windowEnd.isBefore(from) && iterations++ < MAX_CHUNK_ITERATIONS) {
+                LocalDate windowStart = windowEnd.minusDays(period.getChunkCalendarDays());
                 if (windowStart.isBefore(from)) {
                     windowStart = from;
                 }
-                KisDailyChartResponse response = priceClient.getDomesticDailyChart(stockCode, windowStart, windowEnd);
+                KisDailyChartResponse response =
+                        priceClient.getDomesticPeriodChart(stockCode, windowStart, windowEnd, period);
                 List<DailyPrice> chunk = KisStockPriceMapper.fromDailyChart(response.getItems());
                 if (chunk.isEmpty()) {
                     break;
@@ -150,8 +150,8 @@ public class KisStockPriceAdapter implements StockPricePort {
                 windowEnd = oldestInChunk.minusDays(1);
             }
         } catch (Exception e) {
-            log.warn("KIS 일봉 조회 실패 — degrade to partial/empty: stockCode={}, range={}~{}, collected={}, reason={}",
-                    stockCode, from, to, dedup.size(), e.getMessage());
+            log.warn("KIS 기간별시세 조회 실패 — degrade to partial/empty: stockCode={}, period={}, range={}~{}, collected={}, reason={}",
+                    stockCode, period, from, to, dedup.size(), e.getMessage());
         }
         return dedup.values().stream()
                 .sorted(Comparator.comparing(DailyPrice::date))

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/stock/kis/KisStockPriceClient.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/infrastructure/stock/kis/KisStockPriceClient.java
@@ -1,5 +1,6 @@
 package com.thlee.stock.market.stockmarket.stock.infrastructure.stock.kis;
 
+import com.thlee.stock.market.stockmarket.stock.domain.model.ChartPeriod;
 import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
 import com.thlee.stock.market.stockmarket.stock.infrastructure.stock.kis.dto.KisDailyChartResponse;
 import com.thlee.stock.market.stockmarket.stock.infrastructure.stock.kis.dto.KisDomesticMultiPriceOutput;
@@ -96,13 +97,15 @@ public class KisStockPriceClient {
     }
 
     /**
-     * 국내 주식 일봉(국내주식기간별시세) 조회. 한 번 호출로 최대 약 100 영업일치 반환.
+     * 국내 주식 기간별시세(일/주/월봉) 조회. 한 번 호출로 종료일 기준 최신 최대 100봉 반환.
      *
      * @param stockCode 종목코드 6자리
      * @param from      시작일 (포함)
      * @param to        종료일 (포함)
+     * @param period    봉 주기 (일/주/월)
      */
-    public KisDailyChartResponse getDomesticDailyChart(String stockCode, LocalDate from, LocalDate to) {
+    public KisDailyChartResponse getDomesticPeriodChart(String stockCode, LocalDate from, LocalDate to,
+                                                        ChartPeriod period) {
         KisDailyChartResponse response = kisApiClient.getRaw(
             DOMESTIC_DAILY_CHART_PATH,
             DOMESTIC_DAILY_CHART_TR_ID,
@@ -111,14 +114,14 @@ public class KisStockPriceClient {
                 .queryParam("FID_INPUT_ISCD", stockCode)
                 .queryParam("FID_INPUT_DATE_1", from.format(KIS_DATE_FORMAT))
                 .queryParam("FID_INPUT_DATE_2", to.format(KIS_DATE_FORMAT))
-                .queryParam("FID_PERIOD_DIV_CODE", "D")
+                .queryParam("FID_PERIOD_DIV_CODE", period.getCode())
                 .queryParam("FID_ORG_ADJ_PRC", "0")
                 .build(),
             new ParameterizedTypeReference<>() {},
-            "국내 일봉 조회 [" + stockCode + " " + from + "~" + to + "]"
+            "국내 기간별시세 조회 [" + stockCode + " " + period + " " + from + "~" + to + "]"
         );
         if (!response.isSuccess()) {
-            throw new KisApiException("국내 일봉 조회 실패 [" + stockCode + "]: " + response.getMessage());
+            throw new KisApiException("국내 기간별시세 조회 실패 [" + stockCode + "]: " + response.getMessage());
         }
         return response;
     }

--- a/src/main/java/com/thlee/stock/market/stockmarket/stock/presentation/StockController.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/stock/presentation/StockController.java
@@ -3,8 +3,10 @@ package com.thlee.stock.market.stockmarket.stock.presentation;
 import com.thlee.stock.market.stockmarket.stock.application.StockPriceService;
 import com.thlee.stock.market.stockmarket.stock.application.StockSearchService;
 import com.thlee.stock.market.stockmarket.stock.application.dto.BulkStockPriceResponse;
+import com.thlee.stock.market.stockmarket.stock.application.dto.PriceHistoryResponse;
 import com.thlee.stock.market.stockmarket.stock.application.dto.StockPriceResponse;
 import com.thlee.stock.market.stockmarket.stock.application.dto.StockResponse;
+import com.thlee.stock.market.stockmarket.stock.domain.model.ChartPeriod;
 import com.thlee.stock.market.stockmarket.stock.domain.model.ExchangeCode;
 import com.thlee.stock.market.stockmarket.stock.domain.model.MarketType;
 import com.thlee.stock.market.stockmarket.stock.presentation.dto.BulkStockPriceRequest;
@@ -18,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @RestController
@@ -56,5 +60,39 @@ public class StockController {
             @RequestBody BulkStockPriceRequest request) {
         BulkStockPriceResponse response = stockPriceService.getPrices(request.getStocks());
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 국내 주식 기간별(일/주/월봉) 가격 히스토리 조회.
+     *
+     * @param stockCode 종목코드 (KRX 6자리)
+     * @param period    봉 주기 D|W|M (기본 M)
+     * @param from      시작일 yyyy-MM-dd (미지정 시 1960-01-01 — 상장 이후 전구간)
+     * @param to        종료일 yyyy-MM-dd (미지정 시 오늘)
+     */
+    @GetMapping("/{stockCode}/price-history")
+    public ResponseEntity<PriceHistoryResponse> getPriceHistory(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "M") String period,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to) {
+        if (stockCode == null || !stockCode.matches("\\d{6}")) {
+            throw new IllegalArgumentException("유효하지 않은 종목코드: " + stockCode);
+        }
+        ChartPeriod chartPeriod = ChartPeriod.fromCode(period);
+        PriceHistoryResponse response = stockPriceService.getPriceHistory(
+            stockCode, chartPeriod, parseDate(from), parseDate(to));
+        return ResponseEntity.ok(response);
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("유효하지 않은 날짜 형식(yyyy-MM-dd): " + value);
+        }
     }
 }

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -368,6 +368,13 @@ const API = {
         return this.request('POST', '/api/stocks/prices', { stocks });
     },
 
+    // 기간별(일/주/월봉) 가격 히스토리. 전구간 월봉은 KIS 페이징(~5회)으로 다소 걸릴 수 있음
+    getStockPriceHistory(stockCode, period = 'M') {
+        return this.request('GET',
+            `/api/stocks/${stockCode}/price-history?period=${encodeURIComponent(period)}`,
+            null, { timeoutMs: 30000 });
+    },
+
     // ==================== Stock Financial ====================
 
     getFinancialOptions() {

--- a/src/main/resources/static/js/components/company-report.js
+++ b/src/main/resources/static/js/components/company-report.js
@@ -72,6 +72,9 @@ const CompanyReportComponent = {
         disclosures: { open: false, loading: false, error: null, stockCode: null, items: [] },
         _disclosureGen: 0,
 
+        // ==== 월봉 주가 히스토리 (위저드 5단계 + 상세 주가지표) — 상장 이후 전구간, 실시간 조회 ====
+        priceHistory: { stockCode: '', points: [], loading: false, error: null, _gen: 0 },
+
         _charts: [],
 
         // 정적 설정
@@ -162,6 +165,7 @@ const CompanyReportComponent = {
         const cr = this.companyReport;
         if (cr.view === 'detail' && cr.detail?.snapshot) {
             this.$nextTick(() => this._crRenderPerfChart(cr.detail.snapshot, 'report-detail-perf', cr.detail.manual));
+            this._crLoadPriceHistory(cr.detail.stockCode);
             return;
         }
         if (cr.view === 'form') {
@@ -337,12 +341,92 @@ const CompanyReportComponent = {
         this.companyReportGoStep(this.companyReport.step - 1);
     },
 
-    // 3단계(실적 추이) 진입 시에만 차트 렌더 (1회)
+    // 3단계(실적 추이) 진입 시에만 차트 렌더 (1회). 5단계(기업가치) 진입 시 월봉 주가 로드/렌더.
     _crRenderStepChart() {
         const cr = this.companyReport;
+        if (cr.step === 5 && cr.selected) {
+            this._crLoadPriceHistory(cr.selected.stockCode);
+        }
         if (cr.step !== 3 || !cr.preview?.snapshot || cr._previewChartRendered) return;
         cr._previewChartRendered = true;
         this.$nextTick(() => this._crRenderPerfChart(cr.preview.snapshot, 'report-preview-perf', cr.form.manual));
+    },
+
+    // ==================== 월봉 주가 히스토리 (상장 이후 전구간) ====================
+    // 같은 종목은 1회만 로드해 위저드/상세 양쪽 canvas에 재사용. 종목이 바뀌면 새로 로드.
+    async _crLoadPriceHistory(stockCode) {
+        const cr = this.companyReport;
+        if (!stockCode) return;
+        const ph = cr.priceHistory;
+        if (ph.stockCode === stockCode && (ph.loading || ph.points.length > 0)) {
+            this._crRenderPriceChartsForCurrentView(); // 이미 로드됨 → 렌더만
+            return;
+        }
+        const gen = ++ph._gen;
+        ph.stockCode = stockCode;
+        ph.loading = true;
+        ph.error = null;
+        ph.points = [];
+        try {
+            const res = await API.getStockPriceHistory(stockCode, 'M');
+            if (gen !== ph._gen) return;
+            ph.points = res?.points || [];
+            if (ph.points.length === 0) {
+                ph.error = '주가 데이터가 없습니다.';
+            }
+        } catch (e) {
+            if (gen !== ph._gen) return;
+            ph.error = '주가 데이터를 불러오지 못했습니다.';
+        } finally {
+            if (gen === ph._gen) {
+                ph.loading = false;
+                this._crRenderPriceChartsForCurrentView();
+            }
+        }
+    },
+
+    _crRenderPriceChartsForCurrentView() {
+        const cr = this.companyReport;
+        if (cr.view === 'form' && cr.step === 5) {
+            this.$nextTick(() => this._crRenderPriceHistoryChart('report-wizard-price-history'));
+        } else if (cr.view === 'detail') {
+            this.$nextTick(() => this._crRenderPriceHistoryChart('report-detail-price-history'));
+        }
+    },
+
+    // 월봉 종가 라인 차트. 이미 그려진 canvas(Chart.getChart)는 재렌더하지 않는다.
+    _crRenderPriceHistoryChart(canvasId) {
+        const ph = this.companyReport.priceHistory;
+        if (!ph.points.length || typeof Chart === 'undefined') return;
+        const canvas = document.getElementById(canvasId);
+        if (!canvas || Chart.getChart(canvas)) return;
+        const labels = ph.points.map(p => (p.date || '').slice(0, 7)); // YYYY-MM
+        const data = ph.points.map(p => {
+            const n = parseFloat(p.close);
+            return isNaN(n) ? null : n;
+        });
+        const chart = new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels,
+                datasets: [{
+                    label: '월봉 종가(원)', data,
+                    borderColor: '#2563eb', backgroundColor: 'rgba(37,99,235,0.08)',
+                    fill: true, pointRadius: 0, borderWidth: 1.5, tension: 0.1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: { legend: { display: false } },
+                scales: {
+                    x: { ticks: { maxTicksLimit: 12, maxRotation: 0 } },
+                    y: { title: { display: true, text: '원' } }
+                }
+            }
+        });
+        this.companyReport._charts.push(chart);
     },
 
     // ==================== 작성 시작 / 수정 / 재개 ====================
@@ -470,6 +554,7 @@ const CompanyReportComponent = {
         try {
             cr.detail = await API.getCompanyReport(id);
             this.companyReportLoadDisclosures(cr.detail?.stockCode);
+            this._crLoadPriceHistory(cr.detail?.stockCode);
             this.$nextTick(() => this._crRenderPerfChart(cr.detail?.snapshot, 'report-detail-perf', cr.detail?.manual));
         } catch (e) {
             cr.detailError = e?.message || '리포트 조회에 실패했습니다.';
@@ -487,6 +572,7 @@ const CompanyReportComponent = {
             const refreshed = await API.refreshCompanyReport(cr.detail.id);
             this._crDestroyCharts();
             cr.detail = refreshed;
+            this._crLoadPriceHistory(cr.detail?.stockCode);
             this.$nextTick(() => this._crRenderPerfChart(cr.detail?.snapshot, 'report-detail-perf', cr.detail?.manual));
         } catch (e) {
             cr.detailError = e?.message || '데이터 새로고침에 실패했습니다.';

--- a/src/main/resources/static/partials/company-report.html
+++ b/src/main/resources/static/partials/company-report.html
@@ -508,6 +508,16 @@
 
         <!-- ===== 5단계: 기업가치 ===== -->
         <div x-show="companyReport.step === 5" class="space-y-4">
+            <!-- 주가 추이 (월봉, 상장 이후 전구간, 실시간 조회) -->
+            <div class="bg-white border border-gray-200 rounded p-4">
+                <div class="flex items-center gap-2 mb-3">
+                    <div class="text-sm font-semibold text-gray-700">주가 추이 (월봉)</div>
+                    <span class="text-xs text-gray-400">상장 이후 전구간 · 종가 기준 · 실시간 조회(스냅샷 미저장)</span>
+                </div>
+                <div x-show="companyReport.priceHistory.loading" class="text-sm text-gray-400 text-center py-6">주가 데이터를 불러오는 중...</div>
+                <div x-show="!companyReport.priceHistory.loading && companyReport.priceHistory.error" class="text-sm text-gray-400 text-center py-6" x-text="companyReport.priceHistory.error"></div>
+                <div x-show="!companyReport.priceHistory.loading && !companyReport.priceHistory.error && companyReport.priceHistory.points.length > 0" class="relative h-64"><canvas id="report-wizard-price-history"></canvas></div>
+            </div>
             <!-- 주가지표: 자동값 기본 표시 + 재료 인라인 편집 통합 (자동/내 계산 단일화) -->
             <div class="bg-white border border-gray-200 rounded p-4">
                 <div class="flex items-center gap-2 mb-1">
@@ -1286,6 +1296,16 @@
                             <span class="text-xs text-gray-400">기준가: <span x-text="crNum(companyReport.detail.snapshot.priceMetrics.referencePrice, 0)"></span>원 (<span x-text="companyReport.detail.snapshot.priceMetrics.referencePriceDate || '—'"></span>)</span>
                         </div>
                         <p class="text-xs text-gray-400 mb-3">재료에 직접 입력한 값이 있으면 그 값으로, 없으면 자동 산출값으로 파생 지표를 계산합니다(가운데 열은 자동값 참고). EV/EBITDA·ROIC·발생액은 자동 전용(스냅샷값).</p>
+                        <!-- 주가 추이 (월봉, 상장 이후 전구간, 실시간 조회 — 스냅샷 미저장) -->
+                        <div class="mb-4">
+                            <div class="flex items-center gap-2 mb-2">
+                                <div class="text-xs font-semibold text-gray-600">주가 추이 (월봉)</div>
+                                <span class="text-[11px] text-gray-400">상장 이후 전구간 · 종가 기준 · 실시간 조회</span>
+                            </div>
+                            <div x-show="companyReport.priceHistory.loading" class="text-sm text-gray-400 text-center py-6">주가 데이터를 불러오는 중...</div>
+                            <div x-show="!companyReport.priceHistory.loading && companyReport.priceHistory.error" class="text-sm text-gray-400 text-center py-6" x-text="companyReport.priceHistory.error"></div>
+                            <div x-show="!companyReport.priceHistory.loading && !companyReport.priceHistory.error && companyReport.priceHistory.points.length > 0" class="relative h-64"><canvas id="report-detail-price-history"></canvas></div>
+                        </div>
                         <table class="w-full text-xs border border-gray-100 rounded">
                             <thead>
                                 <tr class="text-gray-500 border-b border-gray-100 text-left">


### PR DESCRIPTION
## 개요
기업 분석 리포트(작성 위저드 5단계 + 상세 "6. 주가지표" 섹션)에
**상장일~현재 전구간 월봉 종가 라인 차트**를 추가한다.

Closes #95

## 변경
### 백엔드 (stock 모듈 — companyreport 백엔드 무변경)
- 신규 API: `GET /api/stocks/{stockCode}/price-history?period=D|W|M` (기본 M, from 기본 1960-01-01 → KIS가 실데이터 구간만 반환해 상장 이후 전구간)
- `ChartPeriod` enum 신설, KIS 기간별시세(FHKST03010100) `FID_PERIOD_DIV_CODE` 파라미터화
- 어댑터 페이징 일반화: 주기별 창 크기(M=3000일≈98개월/호출), 캐시 키에 period 포함, 호출당 100건 한계 대응
- `StockPricePort.getDailyHistory` → `getPriceHistory(+period)` (기존 호출처 0곳 — 미노출 상태였음)

### 프론트
- 위저드 5단계·상세 주가지표 섹션에 월봉 종가 라인 차트(Chart.js, 기존 `_charts` 파기 흐름 편입)
- 종목별 1회 로드 재사용(상세↔위저드 중복 호출 없음), `Chart.getChart` 중복 렌더 가드
- 주가는 스냅샷 미저장(실시간 조회 + 서버 캐시 12h)

## 검증
- curl 실측: 삼성전자 **499포인트, 1985-01-31 ~ 2026-07-24 (41년), 0.5s** / 오류 케이스 400 / 미인증 401
- 라이브(dev): 위저드·상세 차트 렌더, 기존 실적 추이 차트 회귀 없음, 신규 콘솔 에러 0
- compileJava pass, documented workflow 하네스 `--through push` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
