### PR TITLE
feat(portfolio): 로그인 시 미납 납입 리마인더 팝업 — 미납 목록·바로 납입·스누즈 (#100)

### DIFF
--- a/docs/brainstorms/2026-07-27-deposit-overdue-login-reminder-brainstorm.md
+++ b/docs/brainstorms/2026-07-27-deposit-overdue-login-reminder-brainstorm.md
@@ -1,0 +1,61 @@
+# 로그인 시 미납 납입 리마인더 팝업 - Brainstorm
+
+**Date:** 2026-07-27
+**Status:** Decided (태형님 요청 + 노출 빈도/동작 선택 확정, 2026-07-27)
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+
+## 배경
+
+- 태형님 요청: "로그인시 미처리된 납입 내역 있으면 재 팝업으로 해줄래"
+- 기존 구조 (이미 있는 것):
+  - 펀드/현금성 항목의 월 납입 설정: `monthlyDepositAmount` / `depositDay` (FundDetail·CashDetail)
+  - 미납 판정: `PortfolioService.isDepositOverdue` — 당월 납입일 경과 + 당월 납입 기록 없음 (`PortfolioService.java:1113`)
+  - 포트폴리오 목록 API(`GET /api/portfolio/items`)가 항목별 `depositOverdue` 반환, 포트폴리오 페이지에서 "⚠ 미납" 배지 표시
+  - 납입 처리 모달: `portfolio-deposit-financial.html` (`showDepositModal`, 전역 mount 오버레이) + `openDepositModal(item)`
+- 문제: 미납 여부를 포트폴리오 페이지에 들어가야만 인지할 수 있음 → 로그인 시점에 리마인더 필요
+
+## What We're Building
+
+로그인(대시보드 부트 완료) 시 포트폴리오 항목을 조회해 `depositOverdue` 항목이 있으면 리마인더 팝업을 띄운다.
+
+- 팝업 내용: 미납 항목 목록 — 항목명, 자산 유형, 월 납입액, 납입일(매월 N일)
+- 항목별 **[납입]** 버튼 → 포트폴리오 페이지로 이동 + 해당 항목의 기존 납입 모달 오픈
+- **[오늘 하루 보지 않기]** 체크 후 닫으면 당일 재노출 안 함 (localStorage, 날짜 기반)
+- 닫기(X/오버레이): 이번 세션에서만 닫힘 — 다음 로그인/새로고침 시 미납이 남아 있으면 다시 노출
+
+## 확정된 결정 (태형님 선택, 2026-07-27)
+
+| 항목 | 결정 |
+|------|------|
+| 노출 빈도 | 기본 매 로그인/새로고침 노출 + "오늘 하루 보지 않기" 체크 옵션 (localStorage `depositReminderSnoozeDate` = YYYY-MM-DD) |
+| 팝업 동작 | 미납 목록 + 항목별 [납입] 버튼 (포트폴리오 이동 + 기존 납입 모달 오픈) |
+| 백엔드 | **변경 없음** — 기존 `getPortfolioItems` 응답의 `depositOverdue` 재사용. API·Entity·DB 불변 |
+| 미납 판정 | 기존 `isDepositOverdue` 로직 그대로 (변경 없음) |
+
+## 구현 방향
+
+- `app.js init()`: 부트 완료 후(프로필 로드·SIGNING_USER 분기 통과 뒤) `checkDepositReminder()` 호출 — 홈 로드와 병렬, 실패 시 조용히 스킵
+- `portfolio.js`(PortfolioComponent): 리마인더 상태(`depositReminder: { show, items }`) + `checkDepositReminder()` / `openDepositFromReminder(item)` / `closeDepositReminder(snooze)` 메서드
+- 팝업 마크업: `portfolio-deposit-financial.html`에 추가 (납입 도메인 + 전역 mount라 어느 페이지에서든 표시 가능)
+- 납입 완료(`submitDeposit` 성공) 시 리마인더 목록에서 해당 항목 제거, 목록이 비면 리마인더 자동 종료
+
+## 검토한 대안 (채택 안 함)
+
+- **하루 1회 고정 노출** — "재 팝업" 요청 취지(미납이 남아 있는 동안 계속 상기)와 어긋남. 스누즈 옵션으로 사용자가 선택하게 함
+- **납입 모달 즉시 오픈** — 미납이 여러 개일 때 순차 진행 UX가 복잡. 목록형이 전체 현황 파악에 유리
+- **전용 백엔드 API(`/deposits/overdue`) 신설** — 기존 목록 API로 충분 (YAGNI, 승인 게이트 대상 회피)
+
+## Edge Cases
+
+- 미납 항목 0개 → 팝업 미노출 (조회 실패 포함 — 콘솔 로그만)
+- 스누즈 당일 재로그인 → 미노출, 다음날 미납 지속 시 재노출
+- [납입] 클릭 → 포트폴리오 페이지 이동 후 납입 모달 오픈 — 리마인더 팝업은 닫음 (모달 겹침 방지)
+- 납입 처리 후 미납 항목이 남아 있으면 리마인더 재표시하지 않음 (이번 세션에서는 이미 인지) — 다음 로그인 시 재노출
+- SIGNING_USER(가입 중)·비로그인 → 체크 자체를 하지 않음 (init 분기 이후에만 호출)
+- localStorage 접근 불가 환경 → 스누즈 없이 매번 노출 (try-catch)
+
+## 범위 밖 (하지 않음)
+
+- 백엔드 API·Entity·DB·미납 판정 로직 변경
+- 메일/푸시 알림 (기존 장마감 알림과 별개)
+- 포트폴리오 페이지 기존 "⚠ 미납" 배지·납입 모달 변경

--- a/docs/commits/2026-07-27-deposit-overdue-login-reminder-commit.md
+++ b/docs/commits/2026-07-27-deposit-overdue-login-reminder-commit.md
@@ -1,0 +1,27 @@
+# 로그인 시 미납 납입 리마인더 팝업 Commit 기록
+
+**Date:** 2026-07-27
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+
+## 커밋 구성 (원격 세션 증분 커밋)
+
+| 커밋 | 내용 |
+|------|------|
+| `a23f318` | docs: brainstorm·issue·plan·gate (#100) |
+| `0029995` | feat(portfolio): 리마인더 팝업 구현 — 코드 3파일 + work 문서 |
+| `2a5340d` | docs: plan 체크리스트 완료 갱신 |
+| `8c505d2` | docs: 셀프 리뷰 기록 |
+| (본 커밋) | docs: validation·commit·push 게이트 기록 |
+
+## 포함 파일
+
+- 코드 3파일: `static/js/components/portfolio.js`, `static/partials/portfolio-deposit-financial.html`, `static/js/app.js`
+- workflow 문서 (brainstorm/issue/plan/gates/work/review/validation/commit/push)
+
+## 제외 파일
+
+- 없음 (작업 외 변경 없음). 하네스(scratchpad/harness100)는 저장소 외부 — 커밋 대상 아님
+
+## 승인
+
+- plan→work: 태형님 "진행해" / review: "셀프 리뷰로 진행해" / validation→commit/push→PR→병합: "한번에 진행해" (2026-07-27)

--- a/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+++ b/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
@@ -12,9 +12,9 @@
 - plan: approved
 - work: approved
 - review: approved (2026-07-27, 태형님 "셀프 리뷰로 진행해" — 명시적 findings 없음, nit 2)
-- validation: pending
-- commit: pending
-- push: pending
+- validation: approved (2026-07-27, "한번에 진행해" — 결과 기록, 미검증 3건은 배포 후 확인으로 명시)
+- commit: approved (2026-07-27, "한번에 진행해")
+- push: approved (2026-07-27, "한번에 진행해" — PR 생성·main 병합 포함)
 
 ## Stage Log
 - start: 2026-07-27, 태형님 "로그인시 미처리된 납입 내역 있으면 재 팝업으로 해줄래" — 기능 요청 접수, 기존 구조(isDepositOverdue·depositOverdue 배지·납입 모달) 탐색
@@ -25,6 +25,8 @@
 - plan: 완료 (2026-07-27, docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md — 태형님 "진행해" 승인)
 - work: 완료 (2026-07-27, docs/works/2026-07-27-deposit-overdue-login-reminder-work.md — 3파일 수정, node --check + Playwright 하네스 14/14 PASS)
 - review: 완료 (2026-07-27, 태형님 "셀프 리뷰로 진행해" — docs/reviews/2026-07-27-deposit-overdue-login-reminder-review.md. 명시적 findings 없음, nit 2(메서드 길이 관행·Escape 미지원 일관) 미반영 수용)
+- validation: 완료 (2026-07-27, docs/validations/2026-07-27-deposit-overdue-login-reminder-validation.md — node --check + 하네스 14/14 PASS. 배포 후 확인 3건 명시)
+- commit/push: 완료 (2026-07-27, 태형님 "한번에 진행해" — docs/commits·docs/pushes 기록, PR 생성·main 병합 결과는 최종 응답 보고)
 
 ## Approval Gate 항목
 - 백엔드·API·Entity·DB 변경 없음 — 프런트 3파일(app.js / portfolio.js / portfolio-deposit-financial.html)만 additive 수정

--- a/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+++ b/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
@@ -1,0 +1,33 @@
+# 로그인 시 미납 납입 리마인더 팝업 게이트 로그
+
+## 원칙
+- 각 단계 시작 전 태형님에게 작업 내용을 제시한다.
+- 다음 단계로 넘어갈지에 대한 판단은 태형님에게 넘긴다.
+- 단계별 산출물은 이 게이트 로그를 `gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md`로 참조한다.
+
+## Stage Decisions
+- start: approved
+- brainstorm: approved
+- issue: approved
+- plan: pending
+- work: pending
+- review: pending
+- validation: pending
+- commit: pending
+- push: pending
+
+## Stage Log
+- start: 2026-07-27, 태형님 "로그인시 미처리된 납입 내역 있으면 재 팝업으로 해줄래" — 기능 요청 접수, 기존 구조(isDepositOverdue·depositOverdue 배지·납입 모달) 탐색
+- brainstorm: 완료 (2026-07-27, docs/brainstorms/2026-07-27-deposit-overdue-login-reminder-brainstorm.md)
+  - 노출 빈도/팝업 동작 2개 선택지 질의 → 태형님 확정: "오늘 하루 보지 않기 옵션 포함" + "미납 목록 + 항목별 [납입] 버튼"
+  - 백엔드 무변경(기존 depositOverdue 재사용), 프론트 3파일 additive
+- issue: 완료 (2026-07-27, GitHub Issue 등록 — docs/issues/2026-07-27-deposit-overdue-login-reminder-issue.md 참조)
+- plan: 작성 (2026-07-27, docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md) — 태형님 승인 대기
+
+## Approval Gate 항목
+- 백엔드·API·Entity·DB 변경 없음 — 프런트 3파일(app.js / portfolio.js / portfolio-deposit-financial.html)만 additive 수정
+- 기존 미납 판정·납입 모달·배지 UI 불변
+- worktree: 본 세션은 원격 실행 환경의 지정 브랜치 `claude/global-economic-indicator-history-bug-dnjci5` 사용 — PR #98(#96) 병합 후 main(92f3100)에서 재시작 (`scripts/create-worktree.sh` 대체, 세션 하네스 제약)
+
+## Notes
+- 선행 맥락: 같은 세션에서 #96(스케줄러 풀 고갈) 수정 → PR #98 main 병합 완료. 본 작업은 별개 기능.

--- a/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+++ b/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
@@ -11,7 +11,7 @@
 - issue: approved
 - plan: approved
 - work: approved
-- review: pending
+- review: approved (2026-07-27, 태형님 "셀프 리뷰로 진행해" — 명시적 findings 없음, nit 2)
 - validation: pending
 - commit: pending
 - push: pending
@@ -23,7 +23,8 @@
   - 백엔드 무변경(기존 depositOverdue 재사용), 프론트 3파일 additive
 - issue: 완료 (2026-07-27, GitHub Issue 등록 — docs/issues/2026-07-27-deposit-overdue-login-reminder-issue.md 참조)
 - plan: 완료 (2026-07-27, docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md — 태형님 "진행해" 승인)
-- work: 완료 (2026-07-27, docs/works/2026-07-27-deposit-overdue-login-reminder-work.md — 3파일 수정, node --check + Playwright 하네스 14/14 PASS. review·validation 게이트 대기)
+- work: 완료 (2026-07-27, docs/works/2026-07-27-deposit-overdue-login-reminder-work.md — 3파일 수정, node --check + Playwright 하네스 14/14 PASS)
+- review: 완료 (2026-07-27, 태형님 "셀프 리뷰로 진행해" — docs/reviews/2026-07-27-deposit-overdue-login-reminder-review.md. 명시적 findings 없음, nit 2(메서드 길이 관행·Escape 미지원 일관) 미반영 수용)
 
 ## Approval Gate 항목
 - 백엔드·API·Entity·DB 변경 없음 — 프런트 3파일(app.js / portfolio.js / portfolio-deposit-financial.html)만 additive 수정

--- a/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+++ b/docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
@@ -9,8 +9,8 @@
 - start: approved
 - brainstorm: approved
 - issue: approved
-- plan: pending
-- work: pending
+- plan: approved
+- work: approved
 - review: pending
 - validation: pending
 - commit: pending
@@ -22,7 +22,8 @@
   - 노출 빈도/팝업 동작 2개 선택지 질의 → 태형님 확정: "오늘 하루 보지 않기 옵션 포함" + "미납 목록 + 항목별 [납입] 버튼"
   - 백엔드 무변경(기존 depositOverdue 재사용), 프론트 3파일 additive
 - issue: 완료 (2026-07-27, GitHub Issue 등록 — docs/issues/2026-07-27-deposit-overdue-login-reminder-issue.md 참조)
-- plan: 작성 (2026-07-27, docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md) — 태형님 승인 대기
+- plan: 완료 (2026-07-27, docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md — 태형님 "진행해" 승인)
+- work: 완료 (2026-07-27, docs/works/2026-07-27-deposit-overdue-login-reminder-work.md — 3파일 수정, node --check + Playwright 하네스 14/14 PASS. review·validation 게이트 대기)
 
 ## Approval Gate 항목
 - 백엔드·API·Entity·DB 변경 없음 — 프런트 3파일(app.js / portfolio.js / portfolio-deposit-financial.html)만 additive 수정

--- a/docs/issues/2026-07-27-deposit-overdue-login-reminder-issue.md
+++ b/docs/issues/2026-07-27-deposit-overdue-login-reminder-issue.md
@@ -1,0 +1,19 @@
+# 로그인 시 미납 납입 리마인더 팝업 Issue 기록
+
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+
+## GitHub Issue
+- status: created
+- issue_number: 100
+- issue_url: https://github.com/osnet-th/stock-market/issues/100
+- title: [enhancement] 로그인 시 미납 납입 리마인더 팝업 — 미납 목록 + 바로 납입
+- label: enhancement
+
+## 근거
+- brainstorm: docs/brainstorms/2026-07-27-deposit-overdue-login-reminder-brainstorm.md (Status: Decided)
+- 태형님 요청(2026-07-27): "로그인시 미처리된 납입 내역 있으면 재 팝업으로 해줄래"
+- 노출 빈도/동작 선택 확정: "오늘 하루 보지 않기 옵션 포함" + "미납 목록 + 항목별 [납입] 버튼"
+
+## Branch
+- branch: claude/global-economic-indicator-history-bug-dnjci5 (원격 세션 지정 브랜치 — PR #98 병합 후 main 92f3100에서 재시작)
+- base: main (92f3100)

--- a/docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md
+++ b/docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md
@@ -1,0 +1,73 @@
+---
+title: 로그인 시 미납 납입 리마인더 팝업
+type: feat
+status: active
+date: 2026-07-27
+issue: https://github.com/osnet-th/stock-market/issues/100
+origin: docs/brainstorms/2026-07-27-deposit-overdue-login-reminder-brainstorm.md
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+---
+
+# 로그인 시 미납 납입 리마인더 팝업 (#100)
+
+## Overview
+
+로그인(대시보드 부트 완료) 시 `depositOverdue` 항목이 있으면 리마인더 팝업을 띄운다. 미납 목록 + 항목별 [납입] 버튼(포트폴리오 이동 + 기존 납입 모달 오픈) + [오늘 하루 보지 않기] 스누즈. 백엔드 무변경, 프런트 3파일 additive.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `static/js/components/portfolio.js` | 리마인더 상태 + `checkDepositReminder` / `openDepositFromReminder` / `closeDepositReminder` 메서드, `submitDeposit` 성공 시 리마인더 목록 갱신 |
+| `static/partials/portfolio-deposit-financial.html` | 리마인더 팝업 마크업 (전역 mount 오버레이, 기존 모달 패턴 재사용) |
+| `static/js/app.js` | `init()` 부트 완료 후 `checkDepositReminder()` 호출 1곳 |
+
+백엔드·API·Entity·DB 변경 없음. 기존 납입 모달·미납 배지·`isDepositOverdue` 불변.
+
+## Implementation Steps
+
+### 1. portfolio.js — 상태·메서드
+
+- [ ] `portfolio` 상태에 `depositReminder: { show: false, items: [], snoozeChecked: false }` 추가
+- [ ] `checkDepositReminder()`:
+  - localStorage `depositReminderSnoozeDate` === 오늘(YYYY-MM-DD)이면 skip (localStorage 접근은 try-catch — 실패 시 스누즈 무시하고 진행)
+  - `API.getPortfolioItems(this.auth.userId)` 호출 → `depositOverdue === true` 필터
+  - 1건 이상이면 `depositReminder.items` 세팅 + `show = true`; 0건/조회 실패 시 조용히 skip (console.error만)
+- [ ] `openDepositFromReminder(item)`: 리마인더 닫기(스누즈 저장 없음) → `navigateTo('portfolio')` → `openDepositModal(item)`
+- [ ] `closeDepositReminder()`: `snoozeChecked`면 localStorage에 오늘 날짜 저장 후 닫기, 아니면 그냥 닫기 (세션 내 재노출 없음)
+- [ ] `submitDeposit()` 성공 시: `depositReminder.items`에서 해당 항목 제거 (남은 목록이 비어도 팝업 재표시는 하지 않음 — 이미 닫힌 상태 유지)
+
+### 2. portfolio-deposit-financial.html — 팝업 마크업
+
+- [ ] 기존 모달 패턴(fixed 오버레이 + x-show + x-cloak) 재사용, `z-index`는 납입 모달보다 낮게 (겹침 시 납입 모달 우선)
+- [ ] 헤더: "미납 납입 안내" + 닫기(X)
+- [ ] 목록: 항목명, 자산 유형 라벨(펀드/현금성), 월 납입액(format), 납입일("매월 N일"), 항목별 [납입] 버튼
+- [ ] 하단: [오늘 하루 보지 않기] 체크박스 + [닫기] 버튼
+- [ ] 모바일: 기존 모달 반응형 패턴 따름
+
+### 3. app.js — init 훅
+
+- [ ] `init()`의 SIGNING_USER 분기 통과 후, 초기 페이지 로드와 병렬로 `this.checkDepositReminder()` 호출 (await 하지 않음 — 부트 블로킹 금지, 내부 catch로 실패 무해화)
+
+## Technical Considerations
+
+- **openDepositModal 재사용**: `openDepositModal(item)`은 전역 오버레이라 페이지 무관 동작하지만, 납입 후 목록 상태 일관성을 위해 포트폴리오 페이지로 이동 후 오픈한다 (`refreshDepositItem`이 `portfolio.items` 기준으로 동작).
+- **스누즈 키**: `depositReminderSnoozeDate` 단일 키(사용자 구분 없음) — 단일 사용자 앱 전제. 값은 `YYYY-MM-DD`.
+- **팝업 노출 시점**: 부트 직후 홈 로드와 병렬 — 홈 API 실패와 무관하게 동작.
+- **재노출 정책**: 세션 내 닫으면 그 세션에서는 재노출 없음. 스누즈는 당일 전체. 다음 로그인/새로고침 시 미납 잔존이면 재노출 (brainstorm 확정).
+- 기존 코드 리팩토링 없음 — additive만.
+
+## Validation
+
+- `jsc`(JavaScriptCore) `new Function(src)` 파싱으로 JS 문법 확인
+- 스크래치패드 목 데이터 하네스(#93 방식)로 브라우저 확인: 미납 있음/없음/스누즈/[납입] 이동/납입 후 목록 제거
+- 실서버 실데이터 확인은 태형님 확인 항목으로 validation 문서에 기록
+
+## Risks
+
+- app.js init 수정은 1곳 호출 추가뿐이나 부트 경로라 회귀 주의 (await 없는 fire-and-forget으로 격리)
+- localStorage 미지원/차단 환경에서는 스누즈가 동작하지 않고 매번 노출 (수용)
+
+## Out of Scope
+
+- 백엔드 변경 일체, 메일/푸시 알림, 미납 판정 로직·기존 UI 변경

--- a/docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md
+++ b/docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md
@@ -28,26 +28,26 @@ gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
 
 ### 1. portfolio.js — 상태·메서드
 
-- [ ] `portfolio` 상태에 `depositReminder: { show: false, items: [], snoozeChecked: false }` 추가
-- [ ] `checkDepositReminder()`:
+- [x] `portfolio` 상태에 `depositReminder: { show: false, items: [], snoozeChecked: false }` 추가
+- [x] `checkDepositReminder()`:
   - localStorage `depositReminderSnoozeDate` === 오늘(YYYY-MM-DD)이면 skip (localStorage 접근은 try-catch — 실패 시 스누즈 무시하고 진행)
   - `API.getPortfolioItems(this.auth.userId)` 호출 → `depositOverdue === true` 필터
   - 1건 이상이면 `depositReminder.items` 세팅 + `show = true`; 0건/조회 실패 시 조용히 skip (console.error만)
-- [ ] `openDepositFromReminder(item)`: 리마인더 닫기(스누즈 저장 없음) → `navigateTo('portfolio')` → `openDepositModal(item)`
-- [ ] `closeDepositReminder()`: `snoozeChecked`면 localStorage에 오늘 날짜 저장 후 닫기, 아니면 그냥 닫기 (세션 내 재노출 없음)
-- [ ] `submitDeposit()` 성공 시: `depositReminder.items`에서 해당 항목 제거 (남은 목록이 비어도 팝업 재표시는 하지 않음 — 이미 닫힌 상태 유지)
+- [x] `openDepositFromReminder(item)`: 리마인더 닫기(스누즈 저장 없음) → `navigateTo('portfolio')` → `openDepositModal(item)`
+- [x] `closeDepositReminder()`: `snoozeChecked`면 localStorage에 오늘 날짜 저장 후 닫기, 아니면 그냥 닫기 (세션 내 재노출 없음)
+- [x] `submitDeposit()` 성공 시: `depositReminder.items`에서 해당 항목 제거 (남은 목록이 비어도 팝업 재표시는 하지 않음 — 이미 닫힌 상태 유지)
 
 ### 2. portfolio-deposit-financial.html — 팝업 마크업
 
-- [ ] 기존 모달 패턴(fixed 오버레이 + x-show + x-cloak) 재사용, `z-index`는 납입 모달보다 낮게 (겹침 시 납입 모달 우선)
-- [ ] 헤더: "미납 납입 안내" + 닫기(X)
-- [ ] 목록: 항목명, 자산 유형 라벨(펀드/현금성), 월 납입액(format), 납입일("매월 N일"), 항목별 [납입] 버튼
-- [ ] 하단: [오늘 하루 보지 않기] 체크박스 + [닫기] 버튼
-- [ ] 모바일: 기존 모달 반응형 패턴 따름
+- [x] 기존 모달 패턴(fixed 오버레이 + x-show + x-cloak) 재사용, `z-index`는 납입 모달보다 낮게 (겹침 시 납입 모달 우선)
+- [x] 헤더: "미납 납입 안내" + 닫기(X)
+- [x] 목록: 항목명, 자산 유형 라벨(펀드/현금성), 월 납입액(format), 납입일("매월 N일"), 항목별 [납입] 버튼
+- [x] 하단: [오늘 하루 보지 않기] 체크박스 + [닫기] 버튼
+- [x] 모바일: 기존 모달 반응형 패턴 따름
 
 ### 3. app.js — init 훅
 
-- [ ] `init()`의 SIGNING_USER 분기 통과 후, 초기 페이지 로드와 병렬로 `this.checkDepositReminder()` 호출 (await 하지 않음 — 부트 블로킹 금지, 내부 catch로 실패 무해화)
+- [x] `init()`의 SIGNING_USER 분기 통과 후, 초기 페이지 로드와 병렬로 `this.checkDepositReminder()` 호출 (await 하지 않음 — 부트 블로킹 금지, 내부 catch로 실패 무해화)
 
 ## Technical Considerations
 

--- a/docs/pushes/2026-07-27-deposit-overdue-login-reminder-push.md
+++ b/docs/pushes/2026-07-27-deposit-overdue-login-reminder-push.md
@@ -1,0 +1,21 @@
+# 로그인 시 미납 납입 리마인더 팝업 Push 기록
+
+**Date:** 2026-07-27
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+
+## 대상
+
+- remote: origin (github.com/osnet-th/stock-market)
+- branch: `claude/global-economic-indicator-history-bug-dnjci5` (원격 세션 지정 브랜치, main 92f3100 기반)
+
+## 의도
+
+- #100 구현(코드 3파일)과 workflow 문서를 push 후 PR 생성 → main 병합 (merge commit — 저장소 관례)
+
+## 승인
+
+- 태형님 "한번에 진행해" (2026-07-27) — validation·commit/push·PR·main 병합 일괄 승인
+
+## 결과
+
+- PR 생성·병합 결과는 최종 응답에 보고 (Commit/Push Contract의 후속 기록 방식)

--- a/docs/reviews/2026-07-27-deposit-overdue-login-reminder-review.md
+++ b/docs/reviews/2026-07-27-deposit-overdue-login-reminder-review.md
@@ -1,0 +1,32 @@
+# 로그인 시 미납 납입 리마인더 팝업 Review 기록
+
+**Date:** 2026-07-27
+**Issue:** #100
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+**대상:** 커밋 0029995 (코드 3파일)
+**방식:** 셀프 리뷰 (태형님 지시, 2026-07-27 — 프런트 3파일 additive 소규모)
+
+## Findings
+
+명시적 findings 없음. 아래 경로를 라인 단위로 재검토했고 결함을 찾지 못했다:
+
+- **동작 경로**: `checkDepositReminder`의 스누즈 가드 → `getPortfolioItems` → `depositOverdue === true` 필터(STOCK의 null·false 제외) → 노출. `openDepositFromReminder`는 팝업을 닫은 뒤 `navigateTo('portfolio')`(→ `loadPortfolio()`로 items 적재 — app.js:270-272 확인) 후 `openDepositModal(item)` — 납입 후 `refreshDepositItem`이 id 기준으로 `portfolio.items`에서 재조회하므로 정합
+- **부트 안전성**: 호출 지점이 partial mount·로그인 확인·SIGNING_USER 분기 이후, await 없는 fire-and-forget이며 메서드 전체가 try-catch — 부트 블로킹·unhandled rejection 없음. `init()`은 `_mqlCleanup` 가드로 1회 실행이라 중복 노출 없음
+- **상태·마크업**: `depositReminder`는 Alpine 반응 프록시 하위라 중첩 변이 반영(하네스에서 실 Alpine으로 검증). x-cloak·오버레이·`@click.outside` 패턴은 같은 파일의 납입 모달과 동일, z-40으로 납입 모달(z-50) 아래. `@click.outside` 닫기도 `closeDepositReminder()`를 경유해 스누즈 체크가 유실되지 않음
+- **스누즈 날짜**: 로컬 날짜 헬퍼 사용 — `toISOString`(UTC)이면 KST 오전에 "오늘"이 어긋나는 문제를 회피
+- **동시성**: `#portfolio` 해시로 부트 시 `loadPortfolio`와 병렬 호출되나 리마인더는 `portfolio.items`를 건드리지 않아 상태 충돌 없음
+
+남은 리스크 (결함 아님):
+
+- [nit] `checkDepositReminder` 본문이 code-convention의 10줄 기준을 소폭 초과 — 기존 JS 컴포넌트 관행(`submitDeposit` 24줄 등) 범위 내이며 guard clause 단일 책임 흐름이라 유지
+- [nit] 리마인더에 Escape 닫기 없음 — 같은 파일의 납입 모달도 동일(일관), 필요 시 후속
+- 하네스는 리마인더 조각 격리 검증 — 실서버 전체 부트 경로는 validation 단계 확인 항목
+
+## Open Questions / Assumptions
+
+- 단일 사용자 앱 전제로 스누즈 키(`depositReminderSnoozeDate`)에 사용자 구분 없음 (plan 명시)
+- `depositOverdue` 판정 자체(백엔드)는 검증 범위 밖 — 기존 로직 재사용
+
+## Change Summary
+
+로그인 부트 후 미납(`depositOverdue`) 항목이 있으면 리마인더 팝업을 띄우는 프런트 전용 additive 변경 (3파일, +111줄). 목록 + 항목별 [납입](포트폴리오 이동·기존 납입 모달 오픈) + [오늘 하루 보지 않기] 로컬 날짜 스누즈, 납입 완료 시 목록 제거. Playwright 하네스 14/14 PASS로 주요 시나리오 검증 완료, plan 범위와 정확히 일치.

--- a/docs/validations/2026-07-27-deposit-overdue-login-reminder-validation.md
+++ b/docs/validations/2026-07-27-deposit-overdue-login-reminder-validation.md
@@ -1,0 +1,30 @@
+# 로그인 시 미납 납입 리마인더 팝업 Validation 기록
+
+**Date:** 2026-07-27
+**Issue:** #100
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+
+## 실행한 검증
+
+| 검증 | 명령/방법 | 결과 |
+|------|-----------|------|
+| JS 문법 | `node --check` (portfolio.js, app.js) | 통과 |
+| 브라우저 기능 | Playwright + 사전설치 chromium, 목 데이터 하네스 (scratchpad/harness100 — 실제 portfolio.js·format.js·리마인더 마크업 추출 + Alpine) | **14/14 PASS** |
+| 셀프 리뷰 | 커밋 0029995 라인 단위 재검토 | 명시적 findings 없음 (docs/reviews 참조) |
+
+### 하네스 검증 시나리오 (14건)
+
+- 미납 2건만 필터 표시 (depositOverdue=false·STOCK 제외), 항목명·유형 배지, 펀드/현금성 각각의 월납입액·납입일 meta
+- [납입] 클릭: 팝업 닫힘 → `navigateTo('portfolio')` → `openDepositModal(해당 item)` 호출 순서 정확
+- 스누즈 없이 새로고침 → 재노출 / [오늘 하루 보지 않기]+닫기 → 로컬 날짜 저장 → 당일 재노출 안 함
+- 미납 0건 → 미노출 / 목록 제거 반영 / 콘솔·페이지 에러 없음
+
+## 미검증 항목 (운영 배포 후 태형님 확인)
+
+1. 실서버 전체 부트 경로(전체 partial mount + 실 API + 카카오 로그인)에서 팝업 노출 — 하네스는 리마인더 조각 격리 검증
+2. 실데이터 기준 미납 판정 표시 (기존 `depositOverdue` 로직 재사용이므로 포트폴리오 "⚠ 미납" 배지와 동일하게 나오는지)
+3. 모바일 폭 실기기 확인
+
+## 판단
+
+이 환경에서 가능한 검증 전부 통과. 미검증 항목은 배포 후 확인 성격 — commit/push 진행 가능.

--- a/docs/works/2026-07-27-deposit-overdue-login-reminder-work.md
+++ b/docs/works/2026-07-27-deposit-overdue-login-reminder-work.md
@@ -1,0 +1,41 @@
+# 로그인 시 미납 납입 리마인더 팝업 Work 기록
+
+**Date:** 2026-07-27
+**Issue:** #100
+gate: docs/gates/2026-07-27-deposit-overdue-login-reminder-gates.md
+**Plan:** docs/plans/2026-07-27-001-feat-deposit-overdue-login-reminder-plan.md
+
+## 변경 파일
+
+- `src/main/resources/static/js/components/portfolio.js`
+  - 상태: `depositReminder: { show, items, snoozeChecked }`
+  - `checkDepositReminder()`: 스누즈 확인(localStorage `depositReminderSnoozeDate`) → `API.getPortfolioItems` → `depositOverdue === true` 필터 → 1건 이상이면 노출. 실패는 console.error 후 무해화
+  - `_depositReminderToday()`: 스누즈용 로컬 날짜 (toISOString 은 UTC 라 KST 오전에 날짜가 어긋나 별도 헬퍼 사용 — 기존 depositForm 의 toISOString 관례는 그대로 둠)
+  - `depositReminderMeta(item)`: 유형별 detail(fundDetail/cashDetail)에서 월 납입액·납입일 문자열 조립
+  - `openDepositFromReminder(item)`: 팝업 닫기 → 포트폴리오 아니면 `navigateTo('portfolio')` → `openDepositModal(item)`
+  - `closeDepositReminder()`: 스누즈 체크 시 오늘 날짜 저장(try-catch) 후 닫기
+  - `submitDeposit()` 성공 시 리마인더 목록에서 해당 항목 제거
+- `src/main/resources/static/partials/portfolio-deposit-financial.html`
+  - 납입 모달(1~140행) 뒤에 리마인더 팝업 추가 — 기존 오버레이 모달 패턴, z-40(납입 모달 z-50 아래), 목록 max-h-72 스크롤, [오늘 하루 보지 않기] 체크 + [닫기]
+- `src/main/resources/static/js/app.js`
+  - `init()` SIGNING_USER 분기 통과 직후 `this.checkDepositReminder()` fire-and-forget 1줄
+
+## 백엔드·API 변경
+
+없음 (plan 준수 — 기존 `depositOverdue`/`isDepositOverdue` 재사용).
+
+## work 단계 자체 검증 (하네스)
+
+- JS 문법: `node --check` portfolio.js·app.js 통과
+- 브라우저 검증: 스크래치패드 목 데이터 하네스(scratchpad/harness100 — 정적 서버 :8100, **실제 portfolio.js·format.js·리마인더 마크업**(partial 에서 추출) + Alpine(npm) + Playwright/사전설치 chromium) — **14/14 PASS**
+  - 미납 2건만 표시 (depositOverdue=false·STOCK 제외), 항목명·유형 배지·월납입액·납입일 meta
+  - [납입] 클릭 → 팝업 닫힘 + `navigateTo('portfolio')` + `openDepositModal(해당 item)` 호출 순서
+  - 스누즈 없이 새로고침 → 재노출 / [오늘 하루 보지 않기]+닫기 → 로컬 날짜 저장 + 당일 재노출 안 함
+  - 미납 0건 → 미노출 / 목록 제거 반영 / 콘솔·페이지 에러 없음
+- 하네스 경로: scratchpad/harness100 (저장소 외부, 커밋 대상 아님)
+
+## 미검증 항목 (validation 단계 과제)
+
+- 실서버 전체 부트 경로(app.js init 전체 partial mount + 실 API)에서의 동작 — 하네스는 리마인더 관련 조각만 격리 검증. 태형님 실데이터 확인 권장
+- 모바일 폭 실기기 확인
+- 납입 모달과의 z-index 겹침은 설계상 회피(리마인더 닫은 후 모달 오픈) — 실서버에서 육안 확인

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -179,6 +179,9 @@ function dashboard() {
                 return;
             }
 
+            // 미납 납입 리마인더 (#100) — 부트 블로킹 없이 병렬 확인 (내부 catch 로 실패 무해화)
+            this.checkDepositReminder();
+
             // hash 재읽기: bootstrap await 동안 사용자가 back/forward 눌러 hash 가 바뀐 경우 마지막 상태 honor
             const finalHash = location.hash.replace('#', '');
             const validPages = this.menus.map(m => m.key);

--- a/src/main/resources/static/js/components/portfolio.js
+++ b/src/main/resources/static/js/components/portfolio.js
@@ -36,6 +36,7 @@ const PortfolioComponent = {
         depositHistories: [],
         editingDeposit: null,
         editDepositForm: { depositDate: '', amount: '', units: '', memo: '' },
+        depositReminder: { show: false, items: [], snoozeChecked: false },
         // 매도 상태
         activeTab: 'items',
         showSaleModal: false,
@@ -1679,6 +1680,65 @@ const PortfolioComponent = {
         if (fresh) this.portfolio.depositItem = fresh;
     },
 
+    // ──────────────────────────────────────────────────────────────────
+    // 미납 납입 리마인더 (#100)
+    // ──────────────────────────────────────────────────────────────────
+
+    // 스누즈는 사용자 로컬 하루 기준 (toISOString 은 UTC 라 KST 오전에 날짜가 어긋남)
+    _depositReminderToday() {
+        const d = new Date();
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    },
+
+    _depositReminderSnoozedToday() {
+        try {
+            return localStorage.getItem('depositReminderSnoozeDate') === this._depositReminderToday();
+        } catch (e) {
+            return false;
+        }
+    },
+
+    async checkDepositReminder() {
+        try {
+            if (this._depositReminderSnoozedToday()) return;
+            const items = await API.getPortfolioItems(this.auth.userId) || [];
+            const overdue = items.filter((i) => i.depositOverdue === true);
+            if (overdue.length === 0) return;
+            this.portfolio.depositReminder.items = overdue;
+            this.portfolio.depositReminder.snoozeChecked = false;
+            this.portfolio.depositReminder.show = true;
+        } catch (e) {
+            console.error('미납 납입 리마인더 확인 실패:', e);
+        }
+    },
+
+    depositReminderMeta(item) {
+        const detail = item.assetType === 'FUND' ? item.fundDetail
+            : (item.assetType === 'CASH' ? item.cashDetail : null);
+        if (!detail) return '';
+        const parts = [];
+        if (detail.monthlyDepositAmount) parts.push('월 ' + Format.number(detail.monthlyDepositAmount, 0) + '원');
+        if (detail.depositDay) parts.push('매월 ' + detail.depositDay + '일');
+        return parts.join(' · ');
+    },
+
+    async openDepositFromReminder(item) {
+        this.portfolio.depositReminder.show = false;
+        if (this.currentPage !== 'portfolio') {
+            await this.navigateTo('portfolio');
+        }
+        await this.openDepositModal(item);
+    },
+
+    closeDepositReminder() {
+        if (this.portfolio.depositReminder.snoozeChecked) {
+            try {
+                localStorage.setItem('depositReminderSnoozeDate', this._depositReminderToday());
+            } catch (e) { /* localStorage 불가 시 스누즈 없이 매번 노출 */ }
+        }
+        this.portfolio.depositReminder.show = false;
+    },
+
     async submitDeposit() {
         const form = this.portfolio.depositForm;
         const item = this.portfolio.depositItem;
@@ -1699,6 +1759,9 @@ const PortfolioComponent = {
             await this.loadDepositHistories(item.id);
             await this.loadPortfolio();
             this.refreshDepositItem();
+            // 납입 처리된 항목은 리마인더 목록에서 제거 (#100)
+            this.portfolio.depositReminder.items =
+                this.portfolio.depositReminder.items.filter((r) => r.id !== item.id);
         } catch (e) {
             console.error('납입 추가 실패:', e);
             alert('납입 추가에 실패했습니다.');

--- a/src/main/resources/static/partials/portfolio-deposit-financial.html
+++ b/src/main/resources/static/partials/portfolio-deposit-financial.html
@@ -139,6 +139,52 @@
                 </div>
             </div>
 
+            <!-- 미납 납입 리마인더 (#100) — 로그인 시 미납 항목 안내, 납입 모달(z-50)보다 아래 -->
+            <div x-show="portfolio.depositReminder.show" x-cloak
+                class="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
+                <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6"
+                    @click.outside="closeDepositReminder()">
+
+                    <div class="flex items-start justify-between mb-1">
+                        <h3 class="text-lg font-bold text-gray-900">미납 납입 안내</h3>
+                        <button @click="closeDepositReminder()"
+                            class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+                    </div>
+                    <p class="text-sm text-gray-500 mb-4">이번 달 납입이 처리되지 않은 항목이 있습니다.</p>
+
+                    <div class="space-y-2 max-h-72 overflow-y-auto">
+                        <template x-for="item in portfolio.depositReminder.items" :key="item.id">
+                            <div class="flex items-center justify-between gap-3 border border-amber-200 bg-amber-50 rounded-lg px-3 py-2.5">
+                                <div class="min-w-0">
+                                    <div class="flex items-center gap-2">
+                                        <span class="text-sm font-medium text-gray-900 truncate" x-text="item.itemName"></span>
+                                        <span class="text-[11px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 shrink-0"
+                                            x-text="item.assetType === 'FUND' ? '펀드' : '현금성'"></span>
+                                    </div>
+                                    <div class="text-xs text-gray-500 mt-0.5" x-text="depositReminderMeta(item)"></div>
+                                </div>
+                                <button @click="openDepositFromReminder(item)"
+                                    class="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">
+                                    납입
+                                </button>
+                            </div>
+                        </template>
+                    </div>
+
+                    <div class="flex items-center justify-between mt-4">
+                        <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+                            <input type="checkbox" x-model="portfolio.depositReminder.snoozeChecked"
+                                class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500">
+                            오늘 하루 보지 않기
+                        </label>
+                        <button @click="closeDepositReminder()"
+                            class="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50">
+                            닫기
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             <!-- Payload 모달 -->
             <div x-show="adminLogs.modal.open" x-cloak
                  class="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center p-4"


### PR DESCRIPTION
## 배경 (#100)

납입일 설정이 있는 펀드/현금성 항목의 미납(`depositOverdue`)을 포트폴리오 페이지에 들어가야만 "⚠ 미납" 배지로 인지할 수 있었다. 로그인 시점에 리마인더 팝업으로 안내한다.

## 변경 내용 (프런트 3파일 additive, 백엔드 무변경)

- **portfolio.js**: `depositReminder` 상태 + `checkDepositReminder`(스누즈 확인 → `getPortfolioItems` → `depositOverdue` 필터) / `depositReminderMeta` / `openDepositFromReminder`(포트폴리오 이동 + 기존 납입 모달 오픈) / `closeDepositReminder`(스누즈 저장). `submitDeposit` 성공 시 리마인더 목록에서 제거
- **portfolio-deposit-financial.html**: 리마인더 팝업 마크업 — 미납 항목 목록(항목명·유형·월 납입액·납입일) + 항목별 [납입] 버튼 + [오늘 하루 보지 않기] 체크. 기존 모달 패턴, z-40(납입 모달 아래)
- **app.js**: `init()` 부트 완료 후 fire-and-forget 호출 1곳 (부트 블로킹 없음, 내부 try-catch)
- 스누즈는 localStorage `depositReminderSnoozeDate`(로컬 날짜) — 당일 재노출 안 함, 미납이 남아 있으면 다음 로그인마다 재노출
- workflow 문서 일체 (brainstorm/issue/plan/gates/work/review/validation/commit/push)

## 검증

- `node --check` 통과, Playwright 하네스(실제 컴포넌트 JS + 실제 마크업 + 목 API) **14/14 PASS** — 필터·meta·[납입] 핸드오프·스누즈·재노출·목록 제거·콘솔 에러 없음
- 셀프 리뷰: 명시적 findings 없음 (`docs/reviews/2026-07-27-deposit-overdue-login-reminder-review.md`)
- 배포 후 확인 3건: 실서버 부트 경로·실데이터 미납 표시·모바일 (`docs/validations/...`)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMHYkZpyuMDRNqQGYtHe9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMHYkZpyuMDRNqQGYtHe9R)_