### PR TITLE
fix(economics): 글로벌 지표 히스토리 보강 — 지표 단위 트랜잭션·시간순 정렬·조건부 catch-up·1포인트 표시 (#51)

### DIFF
--- a/docs/brainstorms/2026-08-02-global-indicator-history-hardening-brainstorm.md
+++ b/docs/brainstorms/2026-08-02-global-indicator-history-hardening-brainstorm.md
@@ -1,0 +1,51 @@
+# 글로벌 경제지표 히스토리 적재 보강 - Brainstorm
+
+**Date:** 2026-08-02
+**Status:** Decided (태형님 "한번에 처리하지 왜 이걸 나눠서 처리하는거야" — #51 전체 범위 일괄 진행 승인, 2026-08-02)
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+
+## 배경
+
+- 기존 open 이슈 #51 "global 경제 지표 히스토리 처리 불가" (2026-05-10 태형님 등록)
+- 직접 원인이던 스케줄러 전체 정지(#96, ES 클라이언트 행 → 풀 고갈)는 수정·병합 완료 (PR #98). cron 재개로 히스토리 적재 자체는 복구 경로에 있음
+- #96 진단 과정에서 확인된 글로벌 히스토리 파이프라인 자체의 잔여 결함 4가지가 #51 범위로 남아 있었음:
+  1. **배치 전체 단일 트랜잭션** — PostgreSQL 은 트랜잭션 내 SQL 에러 1건이면 전체 abort. 지표별 try-catch 가 있어도 하루치 저장 전체가 롤백될 수 있어 "부분 성공 허용"이 실제로 동작하지 않음
+  2. **그래프 시간순 정렬 버그** — 히스토리 조회가 `ORDER BY cycle`(문자열 사전순). cycle 이 "10월 2026" 같은 텍스트라 데이터가 쌓이는 즉시 x축이 뒤섞여 보임
+  3. **catch-up 부재** — 배치 시각(07:30 UTC)에 앱이 내려가 있으면 그날 수집을 건너뜀. ECOS 는 warmup 이 있어 재시작마다 보충되는 것과 비대칭. 또한 "마지막 수집 시각"을 알 방법이 없어 #96 진단 때 관측이 어려웠음
+  4. **1포인트 국가 미표시** — 차트가 2포인트부터 렌더링(`pointRadius: 0` 이라 1포인트는 그릴 수 없음). 시딩 직후 상태에서는 그래프 탭 전체가 "데이터 부족"
+
+## What We're Building (전체 일괄)
+
+1. **지표 단위 독립 트랜잭션**: 클래스 레벨 `@Transactional` 제거. HTTP 수집은 트랜잭션 밖, 저장은 신규 `GlobalIndicatorSnapshotWriter`(@Transactional, 지표 단위)로 분리. 한 지표의 DB 실패가 다른 지표를 롤백시키지 않음. 배치 요약 로그(성공/실패/전체 지표 수) 추가
+2. **시간순 정렬**: `ORDER BY t.country_name, t.cycle` → `ORDER BY t.country_name, t.snapshot_date, t.id` (cycle 은 겹치지 않고 순차 등장하므로 대표 snapshot 의 관측 시각 오름차순 = 시간순)
+3. **조건부 catch-up + 수집 시각 컬럼**: `global_indicator_latest`에 `last_collected_at` 추가(nullable — 기존 행 호환). cycle 변경 여부와 무관하게 수집 성공마다 갱신. 앱 시작 시 `GlobalIndicatorWarmupListener`가 max(last_collected_at)이 없거나 20시간 이상 경과 시에만 fetchAndSave 실행 — 전용 daemon 스레드(ECOS warmup 등 다른 리스너 블로킹 방지)
+4. **1포인트 표시**: 히스토리 1포인트 국가도 차트 렌더링(점 pointRadius 3). "데이터 부족"은 0포인트일 때만
+
+## 확정된 결정
+
+| 항목 | 결정 |
+|------|------|
+| 범위 | 위 4개 전부 일괄 (태형님 "한번에 처리" 지시) |
+| catch-up 방식 | 조건부(20h) + `last_collected_at` 컬럼 — 이전 질의에서 Recommended 로 제시했던 안. **Entity 수정 승인 게이트 항목**: 태형님 일괄 진행 지시를 포괄 승인으로 기록, 최종 보고에 명시 |
+| 트랜잭션 분리 방식 | 별도 @Transactional 빈(`GlobalIndicatorSnapshotWriter`) — 자기 호출 프록시 우회 문제 없음, 기존 initialSeed/saveChanged/isCycleChanged 로직은 그대로 이동 |
+| 1포인트 UI | 포함 (이전 질의 Recommended, 태형님 no preference → 일괄 지시로 포함) |
+| 놓친 중간 cycle | 소급 불가 수용 (스크래핑은 현재값만 제공 — 기존 설계 한계 유지) |
+
+## 검토한 대안 (채택 안 함)
+
+- **무조건 시작 시 warmup (ECOS 방식)** — 재배포마다 TradingEconomics 41회 순차 스크래핑(약 2분) 발생. 배포가 잦아 차단 위험
+- **catch-up 없이 cron만** — 배치 시각에 앱이 꺼져 있던 날 복구 불가, "마지막 수집 시각" 관측 공백 지속
+- **TransactionTemplate 로 단일 클래스 유지** — 별도 빈이 Spring 관례에 부합하고 저장 로직 책임 분리가 명확
+
+## Edge Cases
+
+- 기존 latest 행의 `last_collected_at` NULL → max NULL → 첫 기동 시 catch-up 실행 → 이후 전부 스탬프 (자연 부트스트랩)
+- catch-up 과 정규 배치가 드물게 겹치면 동일 cycle 히스토리 중복 INSERT 가능 → 조회의 cycle 단위 dedup(ROW_NUMBER)이 흡수, 저장도 지표 단위 트랜잭션이라 무해
+- #25 로 추가된 10개 지표(시딩 누락): latestMap 에 없으므로 첫 정상 수집에서 자동 시딩 (별도 코드 불필요)
+- 시딩일(04-11) 동일 snapshot_date 다수 행: 국가당 cycle 1개뿐이라 정렬 동률 없음, id 보조 정렬로 안정화
+
+## 범위 밖 (하지 않음)
+
+- 놓친 중간 cycle 소급 수집 (원천 데이터가 현재값뿐)
+- ECOS 쪽 동일 패턴 적용 (ECOS 는 단일 API 호출로 이미 짧은 트랜잭션)
+- 수집 주기 변경, TradingEconomics 외 소스 추가

--- a/docs/commits/2026-08-02-global-indicator-history-hardening-commit.md
+++ b/docs/commits/2026-08-02-global-indicator-history-hardening-commit.md
@@ -1,0 +1,24 @@
+# 글로벌 경제지표 히스토리 적재 보강 Commit 기록
+
+**Date:** 2026-08-02
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+
+## 포함 파일
+
+- 백엔드 8파일 (SaveService 재구성, SnapshotWriter·WarmupListener 신규, Latest 도메인/Entity/매퍼/리포지토리 3종, 히스토리 조회 정렬)
+- 프론트 2파일 (global.js, global.html)
+- workflow 문서 9종 (brainstorm/issue/plan/gates/work/review/validation/commit/push)
+
+## 제외 파일
+
+- 없음 (작업 외 변경 없음 — git status 확인)
+
+## 커밋 메시지
+
+```
+fix(economics): 글로벌 지표 히스토리 보강 — 지표 단위 트랜잭션·시간순 정렬·조건부 catch-up·1포인트 표시 (#51)
+```
+
+## 승인
+
+- 태형님 "한번에 처리하지 왜 이걸 나눠서 처리하는거야" (2026-08-02) — 전체 범위·전 단계 일괄 승인 (Entity nullable 컬럼 추가 포함, 최종 보고에 명시)

--- a/docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+++ b/docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
@@ -1,0 +1,38 @@
+# 글로벌 경제지표 히스토리 적재 보강 게이트 로그
+
+## 원칙
+- 각 단계 시작 전 태형님에게 작업 내용을 제시한다.
+- 다음 단계로 넘어갈지에 대한 판단은 태형님에게 넘긴다.
+- 단계별 산출물은 이 게이트 로그를 `gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md`로 참조한다.
+
+## Stage Decisions
+- start: approved
+- brainstorm: approved (일괄 지시)
+- issue: approved (기존 #51 재사용)
+- plan: approved (일괄 지시)
+- work: approved (일괄 지시)
+- review: approved (셀프 리뷰 — #100 선례)
+- validation: approved (일괄 지시)
+- commit: approved (일괄 지시)
+- push: approved (일괄 지시 — PR 생성·main 병합 포함, #98·#101 선례)
+
+## Stage Log
+- start: 세션 최초 문의(글로벌 그래프 히스토리 미표시, 2026-07-26)에서 분리된 후속. #96 해결·병합 후 "#51 진행할까요?" 제안 → 태형님 "진행해"(2026-08-02) → 맥락 재확인 문답 → **"한번에 처리하지 왜 이걸 나눠서 처리하는거야"** — 전체 범위 일괄 진행 지시로 게이트 포괄 승인 처리
+- brainstorm: 완료 (2026-08-02, docs/brainstorms/2026-08-02-global-indicator-history-hardening-brainstorm.md — 결함 4건 일괄: 트랜잭션 분리·정렬·조건부 catch-up·1포인트 UI)
+- issue: 완료 (기존 open #51 재사용 — docs/issues/2026-08-02-global-indicator-history-hardening-issue.md)
+- plan: 완료 (2026-08-02, docs/plans/2026-08-02-001-fix-global-indicator-history-hardening-plan.md)
+- work: 완료 (2026-08-02, docs/works/2026-08-02-global-indicator-history-hardening-work.md — 10파일, compileJava·node --check 통과)
+- review: 완료 (2026-08-02, 셀프 리뷰 — docs/reviews/2026-08-02-global-indicator-history-hardening-review.md)
+- validation: 완료 (2026-08-02, docs/validations/2026-08-02-global-indicator-history-hardening-validation.md — 배포 후 확인 항목 명시)
+- commit/push: 완료 (2026-08-02, docs/commits·docs/pushes 기록 — PR·main 병합 결과는 최종 응답 보고)
+
+## Approval Gate 항목
+- **Entity 수정**: `GlobalIndicatorLatestEntity`에 nullable `last_collected_at` 컬럼 추가 — catch-up 판단 + 수집 관측성. 태형님 "한번에 처리" 일괄 지시를 포괄 승인으로 기록하되 **최종 보고에 명시하여 이견 시 정정 가능하게 함**
+- 신규 클래스 2건: `GlobalIndicatorSnapshotWriter`(지표 단위 트랜잭션 — 범위 내 필수), `GlobalIndicatorWarmupListener`(catch-up)
+- 비즈니스 로직 변경: 배치 트랜잭션 경계 (저장 의미·cycle 감지 로직은 무변경 이동)
+- 공개 API 시그니처 변경 없음 (히스토리 응답 정렬 순서만 시간순으로 교정)
+- worktree: 세션 지정 브랜치 `claude/global-economic-indicator-history-bug-dnjci5` (main 9579dea에서 재시작)
+
+## Notes
+- 선행: #96 (docs/gates/2026-07-26-scheduler-pool-es-hang-gates.md) — cron 정지 근본 원인 해결
+- #25 추가 10개 지표는 첫 정상 수집에서 자동 시딩 예상 (latestMap 부재 → 전건 INSERT)

--- a/docs/issues/2026-08-02-global-indicator-history-hardening-issue.md
+++ b/docs/issues/2026-08-02-global-indicator-history-hardening-issue.md
@@ -1,0 +1,18 @@
+# 글로벌 경제지표 히스토리 적재 보강 Issue 기록
+
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+
+## GitHub Issue
+- status: 기존 open 이슈 재사용 (신규 등록 없음)
+- issue_number: 51
+- issue_url: https://github.com/osnet-th/stock-market/issues/51
+- title: global 경제 지표 히스토리 처리 불가 (2026-05-10 태형님 등록)
+
+## 근거
+- brainstorm: docs/brainstorms/2026-08-02-global-indicator-history-hardening-brainstorm.md (Status: Decided)
+- 태형님 지시(2026-08-02): "한번에 처리하지 왜 이걸 나눠서 처리하는거야" — #51 전체 범위 일괄 진행
+- 선행: #96(스케줄러 전체 정지, PR #98 병합)이 #51 증상의 직접 원인이었고, 본 작업은 글로벌 히스토리 파이프라인 자체의 잔여 결함 4건(트랜잭션·정렬·catch-up·1포인트 UI) 보강
+
+## Branch
+- branch: claude/global-economic-indicator-history-bug-dnjci5 (원격 세션 지정 브랜치 — PR #101 병합 후 main 9579dea에서 재시작)
+- base: main (9579dea)

--- a/docs/plans/2026-08-02-001-fix-global-indicator-history-hardening-plan.md
+++ b/docs/plans/2026-08-02-001-fix-global-indicator-history-hardening-plan.md
@@ -1,0 +1,67 @@
+---
+title: 글로벌 경제지표 히스토리 적재 보강
+type: fix
+status: active
+date: 2026-08-02
+issue: https://github.com/osnet-th/stock-market/issues/51
+origin: docs/brainstorms/2026-08-02-global-indicator-history-hardening-brainstorm.md
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+---
+
+# 글로벌 경제지표 히스토리 적재 보강 (#51)
+
+## Overview
+
+#96(스케줄러 정지) 해결 후 남은 글로벌 히스토리 파이프라인 결함 4건을 일괄 보강한다: 지표 단위 독립 트랜잭션(부분 성공 실제 보장), 그래프 시간순 정렬, 조건부 catch-up(+수집 시각 컬럼), 1포인트 표시.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `application/GlobalIndicatorSaveService.java` | 클래스 @Transactional 제거, 수집(트랜잭션 밖)→writer 위임, 성공/실패 카운트 요약 로그 |
+| `application/GlobalIndicatorSnapshotWriter.java` | **신규** — 지표 단위 @Transactional 저장 (initialSeed/saveChanged/isCycleChanged 이동) |
+| `infrastructure/scheduler/GlobalIndicatorWarmupListener.java` | **신규** — 시작 시 조건부 catch-up (20h, 전용 daemon 스레드, LoggingContext) |
+| `domain/model/GlobalIndicatorLatest.java` | `lastCollectedAt` 필드 추가 (fromSnapshot 에서 now 스탬프) |
+| `infrastructure/persistence/GlobalIndicatorLatestEntity.java` | `last_collected_at` nullable 컬럼 + 생성자/update 파라미터 (**Entity 수정 — 게이트 항목**) |
+| `infrastructure/persistence/mapper/GlobalIndicatorLatestMapper.java` | 필드 매핑 추가 |
+| `domain/repository/GlobalIndicatorLatestRepository.java` + `Impl` + `JpaRepository` | `findMaxLastCollectedAt()` 추가, saveAll 에서 스탬프 반영 |
+| `infrastructure/persistence/GlobalIndicatorJpaRepository.java` | 히스토리 조회 `ORDER BY cycle`(사전순) → `snapshot_date, id`(시간순) |
+| `static/js/components/global.js` | 1포인트 렌더링 허용 + 단일 포인트 시 pointRadius 3 |
+| `static/partials/global.html` | 차트/데이터 부족 분기 2포인트 → 1포인트 기준 |
+
+공개 API 시그니처·응답 형식 변경 없음 (히스토리 응답 구조 동일, 정렬 순서만 시간순으로 교정).
+
+## Implementation Steps
+
+- [x] `GlobalIndicatorLatest` 도메인에 `lastCollectedAt` 추가, `fromSnapshot` now 스탬프
+- [x] `GlobalIndicatorLatestEntity` nullable `last_collected_at` 컬럼 + update 반영 (ddl-auto=update 로 자동 생성)
+- [x] 매퍼·RepositoryImpl.saveAll·도메인 리포지토리·JpaRepository(`select max`) 반영
+- [x] `GlobalIndicatorSnapshotWriter` 신규 — 지표 단위 @Transactional, 기존 저장 로직 무변경 이동
+- [x] `GlobalIndicatorSaveService` 재구성 — @Transactional 제거, fetch→writer, 요약 로그
+- [x] `GlobalIndicatorWarmupListener` 신규 — max(last_collected_at) null 또는 20h+ 경과 시에만 catch-up, 전용 daemon 스레드
+- [x] 히스토리 조회 정렬 수정 (`snapshot_date, id`)
+- [x] 프론트 1포인트 표시 (global.js / global.html)
+
+## Technical Considerations
+
+- **트랜잭션 경계**: 자기 호출 프록시 우회를 피하려 별도 빈으로 분리. HTTP 수집이 트랜잭션 밖으로 나가면서 DB 커넥션 점유도 지표당 저장 순간으로 최소화 (#96 계열 위험 추가 감소)
+- **historyExists 1회 판정 유지**: 지표 단위 커밋이어도 시딩 런에서 의미 동일 (각 지표는 자기 데이터만 시딩)
+- **latestMap 일관성**: writer 가 커밋 성공 경로에서만 latestMap 갱신 — 실패 지표는 다음 실행에서 재시도됨
+- **정렬 근거**: cycle 은 국가별로 겹치지 않고 순차 등장 → rn=1 대표 행의 snapshot_date 오름차순이 시간순과 일치. 동일 날짜 다중 cycle(이론상)만 id 로 안정화
+- **catch-up 임계 20h**: 하루 1회 배치(24h 간격)보다 짧고, 같은 날 재배포(수 시간 간격)보다 길어 중복 수집 방지
+- **Entity 수정**: nullable 컬럼 추가만 — 기존 행·코드 경로와 완전 호환, 데이터 마이그레이션 불필요
+
+## Validation
+
+- `./gradlew compileJava` + `node --check global.js`
+- 지표 단위 트랜잭션·catch-up 은 운영 환경 재현 불가 — 코드 리뷰 검증, 배포 후 로그("catch-up 시작/불필요", 요약 로그)로 확인
+- 정렬·1포인트는 배포 후 그래프 탭 육안 확인 (시딩 상태에서 점 표시, 데이터 누적 후 시간순)
+
+## Risks
+
+- Entity 컬럼 추가는 ddl-auto=update 환경에서 자동 반영 — 실패 시 앱 기동 로그로 즉시 드러남
+- catch-up 과 정규 배치 동시 실행 창(시작 직후 배치 시각) — cycle dedup 조회가 흡수, 무해
+
+## Out of Scope
+
+- 놓친 중간 cycle 소급, ECOS 동일 패턴 적용, 수집 주기 변경

--- a/docs/pushes/2026-08-02-global-indicator-history-hardening-push.md
+++ b/docs/pushes/2026-08-02-global-indicator-history-hardening-push.md
@@ -1,0 +1,21 @@
+# 글로벌 경제지표 히스토리 적재 보강 Push 기록
+
+**Date:** 2026-08-02
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+
+## 대상
+
+- remote: origin (github.com/osnet-th/stock-market)
+- branch: `claude/global-economic-indicator-history-bug-dnjci5` (main 9579dea 기반 재시작)
+
+## 의도
+
+- #51 보강(코드 10파일) + workflow 문서 push → PR 생성 → main 병합 (merge commit, #98·#101 선례). PR 에 `Closes #51` 로 이슈 종료
+
+## 승인
+
+- 태형님 "한번에 처리하지 왜 이걸 나눠서 처리하는거야" (2026-08-02) — PR·main 병합 포함 일괄
+
+## 결과
+
+- PR 생성·병합 결과는 최종 응답에 보고

--- a/docs/reviews/2026-08-02-global-indicator-history-hardening-review.md
+++ b/docs/reviews/2026-08-02-global-indicator-history-hardening-review.md
@@ -1,0 +1,32 @@
+# 글로벌 경제지표 히스토리 적재 보강 Review 기록
+
+**Date:** 2026-08-02
+**Issue:** #51
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+**방식:** 셀프 리뷰 (#100 선례 — 태형님 일괄 진행 지시)
+
+## Findings
+
+명시적 findings 없음. 검토 경로:
+
+- **트랜잭션 경계**: writer 가 별도 빈이라 프록시 정상 적용 (자기 호출 아님). HTTP 수집·sleep 은 트랜잭션 밖 — 커넥션 점유가 지표당 저장 순간으로 축소. 저장 로직(initialSeed/saveChanged/isCycleChanged)은 diff 대조로 무변경 이동 확인
+- **부분 성공**: 지표 A 커밋 성공 후 지표 B 가 DB 예외를 던져도 A 는 유지 — PostgreSQL abort 가 트랜잭션 단위로 격리됨. SaveService 의 지표별 try-catch 가 이제 실제로 의미를 가짐
+- **latestMap 정합**: 커밋 실패 지표의 latestMap 선반영은 run-로컬이며 지표 간 키 불겹침(compareKey 에 indicatorType 포함) — 다른 지표 판정에 영향 없음, 다음 실행에서 DB 기준 재구성
+- **정렬**: cycle 은 (국가, 지표) 안에서 순차 등장하므로 rn=1 행의 snapshot_date 오름차순 = 시간순. 동률은 id 안정화. 응답 구조 불변 — 프론트 수정 불필요 확인
+- **catch-up 조건**: NULL(기존 행)·20h+ 만 실행 — 부트스트랩과 재배포 중복 방지 양립. daemon 스레드라 ECOS warmup 등 다른 리스너 비블로킹, 앱 종료도 안 막음. LoggingContext 로 requestId 부여 (#96 스케줄러 관례)
+- **Entity 수정 안전성**: nullable 컬럼 추가만 — 기존 행·기존 쿼리 경로 완전 호환, ddl-auto=update 자동 반영
+- **프론트**: 1포인트 시 pointRadius 3 (기존 0이라 렌더해도 안 보이는 문제까지 함께 처리), countries 그룹핑 특성상 0포인트 카드는 실제로 발생하지 않으나 가드 유지
+
+남은 리스크 (결함 아님):
+
+- [nit] catch-up·정규 배치 동시 실행 창에서 동일 cycle 히스토리 중복 행 가능 — 조회 dedup 흡수, 저장량 미미 (문서화됨)
+- [nit] 놓친 중간 cycle 은 여전히 소급 불가 (원천이 현재값만 제공 — 설계 한계 유지, 범위 밖)
+
+## Open Questions / Assumptions
+
+- catch-up 임계 20h 는 하루 1회 배치 전제 — 배치 주기를 바꾸면 함께 조정 필요
+- Entity 컬럼 추가는 태형님 "한번에 처리" 일괄 지시를 포괄 승인으로 처리 — 최종 보고에 명시, 이견 시 정정
+
+## Change Summary
+
+#51 잔여 결함 4건을 일괄 보강: 지표 단위 독립 트랜잭션(부분 성공 실제 보장 + 요약 로그), 히스토리 시간순 정렬, `last_collected_at` 기반 조건부 catch-up(수집 관측성 확보), 1포인트 점 표시. 저장 규칙·API 응답 구조는 불변이며 compileJava·node --check 통과.

--- a/docs/validations/2026-08-02-global-indicator-history-hardening-validation.md
+++ b/docs/validations/2026-08-02-global-indicator-history-hardening-validation.md
@@ -1,0 +1,25 @@
+# 글로벌 경제지표 히스토리 적재 보강 Validation 기록
+
+**Date:** 2026-08-02
+**Issue:** #51
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+
+## 실행한 검증
+
+| 검증 | 명령/방법 | 결과 |
+|------|-----------|------|
+| Java 컴파일 | `./gradlew compileJava -q` | 통과 (exit 0) |
+| JS 문법 | `node --check global.js` | 통과 |
+| 셀프 리뷰 | 트랜잭션 경계·latestMap 정합·정렬 근거·catch-up 조건 라인 검토 | 명시적 findings 없음 |
+
+## 미검증 항목 (운영 배포 후 확인)
+
+1. **`last_collected_at` 컬럼 자동 생성** — 기동 로그에 DDL 에러 없는지 (ddl-auto=update)
+2. **첫 기동 catch-up** — `docker logs hubth-app | grep "catch-up"` 에 "catch-up 시작"(첫 기동, NULL 부트스트랩) 후 "완료: N건", 이후 재시작에서는 "catch-up 불필요"
+3. **배치 요약 로그** — 16:30(KST) 이후 "글로벌 경제지표 저장 완료: 히스토리 N건 (지표 성공 a / 실패 b / 전체 41)" — #25 추가 10개 지표의 자동 시딩 포함 여부
+4. **그래프 확인** — 글로벌 탭 그래프 보기: 1포인트 국가는 점 표시, 데이터 누적 후 x축 시간순 (사전순 뒤섞임 해소)
+5. 지표 단위 트랜잭션의 부분 성공은 실운영 실패 상황에서만 관측 가능 — 요약 로그의 실패 카운트와 저장 건수 병존으로 간접 확인
+
+## 판단
+
+이 환경에서 가능한 검증 전부 통과. 미검증 항목은 배포 후 확인 성격 — commit/push 진행.

--- a/docs/works/2026-08-02-global-indicator-history-hardening-work.md
+++ b/docs/works/2026-08-02-global-indicator-history-hardening-work.md
@@ -1,0 +1,39 @@
+# 글로벌 경제지표 히스토리 적재 보강 Work 기록
+
+**Date:** 2026-08-02
+**Issue:** #51
+gate: docs/gates/2026-08-02-global-indicator-history-hardening-gates.md
+**Plan:** docs/plans/2026-08-02-001-fix-global-indicator-history-hardening-plan.md
+
+## 변경 파일 (백엔드 8 + 프론트 2)
+
+- `application/GlobalIndicatorSaveService.java` — 클래스 @Transactional 제거. 수집·필터는 트랜잭션 밖, 저장은 `snapshotWriter.persistIndicator` 위임. 지표별 성공/실패 카운트 + 종료 시 요약 로그("히스토리 N건 (지표 성공 a / 실패 b / 전체 c)")
+- `application/GlobalIndicatorSnapshotWriter.java` **신규** — 지표 단위 `@Transactional` 저장. `initialSeedIndicator` / `saveChangedIndicator` / `isCycleChanged` 를 기존 로직 그대로 이동, latest upsert + latestMap 갱신은 `upsertLatest` 로 공통화
+- `infrastructure/scheduler/GlobalIndicatorWarmupListener.java` **신규** — ApplicationReadyEvent 시 `max(last_collected_at)` 이 없거나 20시간+ 경과 시에만 catch-up. 전용 daemon 스레드(`global-indicator-warmup`) + `LoggingContext.forScheduler`
+- `domain/model/GlobalIndicatorLatest.java` — `lastCollectedAt` 필드 (fromSnapshot 에서 updatedAt 과 동일 시각 스탬프)
+- `infrastructure/persistence/GlobalIndicatorLatestEntity.java` — nullable `last_collected_at` 컬럼, 생성자·`update()` 파라미터 추가 (**Entity 수정** — ddl-auto=update 로 자동 반영)
+- `infrastructure/persistence/mapper/GlobalIndicatorLatestMapper.java` — 양방향 매핑 추가
+- `domain/repository/GlobalIndicatorLatestRepository.java` / `...RepositoryImpl.java` / `...LatestJpaRepository.java` — `findMaxLastCollectedAt()`(JPQL select max) 추가, saveAll 갱신 경로에 lastCollectedAt 반영
+- `infrastructure/persistence/GlobalIndicatorJpaRepository.java` — 히스토리 조회 정렬 `ORDER BY t.country_name, t.cycle` → `t.snapshot_date, t.id` (시간순)
+- `static/js/components/global.js` — 1포인트 렌더링 허용, 단일 포인트 시 `pointRadius: 3` (기존 0이라 점이 안 보였음)
+- `static/partials/global.html` — 차트/"데이터 부족" 분기 기준 2포인트 → 1포인트
+
+## 동작 의미 변화
+
+- 배치 저장: 하루치 전체 단일 트랜잭션 → **지표 단위 커밋** (한 지표의 DB 에러가 다른 지표를 롤백시키지 않음). cycle 감지·저장 규칙 자체는 무변경
+- 히스토리 조회 응답: 구조 동일, 정렬만 사전순 → 시간순 교정
+- 앱 시작: 마지막 수집 20시간+ 경과 시 백그라운드 catch-up (약 2분, 다른 리스너 비블로킹)
+
+## work 단계 자체 검증
+
+- `./gradlew compileJava` 통과, `node --check global.js` 통과
+
+## 특이사항
+
+- 기존 latest 행의 `last_collected_at` NULL → 배포 후 첫 기동에서 catch-up 1회 실행되며 자연 부트스트랩
+- catch-up·정규 배치 동시 실행 창(시작 직후 배치 시각): 동일 cycle 중복 히스토리 가능 → 조회 dedup(ROW_NUMBER)이 흡수 (brainstorm Edge Case)
+- 지표 커밋 실패 시 latestMap 은 이미 갱신된 상태로 남으나 run-로컬 맵이며 지표 간 키가 겹치지 않아 무해, 다음 실행에서 DB 기준 재적재
+
+## 미검증 항목 (validation 단계 과제)
+
+- 운영 배포 후: 기동 로그("catch-up 시작/불필요"), 배치 요약 로그, `last_collected_at` 컬럼 자동 생성, 그래프 시간순·1포인트 표시 육안 확인

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/application/GlobalIndicatorSaveService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/application/GlobalIndicatorSaveService.java
@@ -2,7 +2,6 @@ package com.thlee.stock.market.stockmarket.economics.application;
 
 import com.thlee.stock.market.stockmarket.economics.domain.model.CountryIndicatorSnapshot;
 import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalEconomicIndicatorType;
-import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalIndicator;
 import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalIndicatorLatest;
 import com.thlee.stock.market.stockmarket.economics.domain.repository.GlobalIndicatorLatestRepository;
 import com.thlee.stock.market.stockmarket.economics.domain.repository.GlobalIndicatorRepository;
@@ -10,7 +9,6 @@ import com.thlee.stock.market.stockmarket.economics.domain.service.GlobalIndicat
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -19,13 +17,14 @@ import java.util.Map;
 
 /**
  * 글로벌 경제지표 배치 저장 서비스
- * - 55개 지표를 순차 수집 → (국가, 지표)별 cycle 변경 감지 → 변경분만 히스토리 INSERT
+ * - 41개 지표를 순차 수집 → (국가, 지표)별 cycle 변경 감지 → 변경분만 히스토리 INSERT
  * - 지표 사이에 1.5초 딜레이로 TradingEconomics 차단 위험 최소화
- * - 단일 트랜잭션 + 지표별 try-catch로 부분 성공 허용
+ * - 지표 단위 독립 트랜잭션(#51, {@link GlobalIndicatorSnapshotWriter}):
+ *   한 지표의 실패가 다른 지표의 저장을 롤백시키지 않는다 (부분 성공 실제 보장).
+ *   HTTP 수집은 트랜잭션 밖에서 수행해 커넥션 점유를 최소화한다.
  */
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class GlobalIndicatorSaveService {
 
@@ -34,9 +33,10 @@ public class GlobalIndicatorSaveService {
     private final GlobalIndicatorPort globalIndicatorPort;
     private final GlobalIndicatorRepository globalIndicatorRepository;
     private final GlobalIndicatorLatestRepository globalIndicatorLatestRepository;
+    private final GlobalIndicatorSnapshotWriter snapshotWriter;
 
     /**
-     * 55개 지표 순차 수집 → cycle 변경분만 히스토리 + latest 전건 갱신
+     * 전체 지표 순차 수집 → cycle 변경분만 히스토리 + latest 전건 갱신
      *
      * @return 저장된 히스토리 레코드 수
      */
@@ -53,6 +53,8 @@ public class GlobalIndicatorSaveService {
         }
 
         int totalSaved = 0;
+        int successCount = 0;
+        int failCount = 0;
         int indicatorIndex = 0;
 
         for (GlobalEconomicIndicatorType type : GlobalEconomicIndicatorType.values()) {
@@ -63,35 +65,27 @@ public class GlobalIndicatorSaveService {
             indicatorIndex++;
 
             try {
-                totalSaved += saveOneIndicator(type, today, historyExists, latestMap);
+                totalSaved += fetchAndPersistOne(type, today, historyExists, latestMap);
+                successCount++;
             } catch (Exception e) {
+                failCount++;
                 log.error("글로벌 지표 수집 실패: type={}", type, e);
-                // 다음 지표로 계속 진행 (부분 성공 허용)
+                // 다음 지표로 계속 진행 (지표 단위 트랜잭션이라 이전 저장분은 유지됨)
             }
         }
 
-        log.info("글로벌 경제지표 저장 완료: 총 {}건", totalSaved);
+        log.info("글로벌 경제지표 저장 완료: 히스토리 {}건 (지표 성공 {} / 실패 {} / 전체 {})",
+                totalSaved, successCount, failCount, GlobalEconomicIndicatorType.values().length);
         return totalSaved;
     }
 
-    private boolean sleepBetweenRequests() {
-        try {
-            Thread.sleep(REQUEST_DELAY_MS);
-            return true;
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            log.warn("글로벌 지표 배치 인터럽트, 루프 중단");
-            return false;
-        }
-    }
-
     /**
-     * 단일 지표 처리: 수집 → 필터링 → (초기 시딩 또는 변경분 저장)
+     * 단일 지표 처리: 수집(트랜잭션 밖) → 유효성 필터 → 지표 단위 트랜잭션 저장
      */
-    private int saveOneIndicator(GlobalEconomicIndicatorType type,
-                                  LocalDate today,
-                                  boolean historyExists,
-                                  Map<String, GlobalIndicatorLatest> latestMap) {
+    private int fetchAndPersistOne(GlobalEconomicIndicatorType type,
+                                    LocalDate today,
+                                    boolean historyExists,
+                                    Map<String, GlobalIndicatorLatest> latestMap) {
         List<CountryIndicatorSnapshot> snapshots = globalIndicatorPort.fetchByIndicator(type);
 
         // referenceText(=cycle) 및 lastValue 유효성 필터
@@ -105,83 +99,17 @@ public class GlobalIndicatorSaveService {
             return 0;
         }
 
-        if (!historyExists) {
-            return initialSeedIndicator(type, valid, today, latestMap);
-        }
-
-        return saveChangedIndicator(type, valid, today, latestMap);
+        return snapshotWriter.persistIndicator(type, valid, today, historyExists, latestMap);
     }
 
-    /**
-     * 초기 시딩 (지표 단위): 수집된 전체 snapshot → history + latest
-     */
-    private int initialSeedIndicator(GlobalEconomicIndicatorType type,
-                                      List<CountryIndicatorSnapshot> snapshots,
-                                      LocalDate today,
-                                      Map<String, GlobalIndicatorLatest> latestMap) {
-        List<GlobalIndicator> histories = snapshots.stream()
-            .map(s -> GlobalIndicator.fromSnapshot(s, today))
-            .toList();
-        globalIndicatorRepository.saveAll(histories);
-
-        List<GlobalIndicatorLatest> latestList = snapshots.stream()
-            .map(GlobalIndicatorLatest::fromSnapshot)
-            .toList();
-        globalIndicatorLatestRepository.saveAll(latestList);
-
-        // 배치 내 일관성: latestMap 즉시 갱신
-        for (GlobalIndicatorLatest latest : latestList) {
-            latestMap.put(latest.toCompareKey(), latest);
+    private boolean sleepBetweenRequests() {
+        try {
+            Thread.sleep(REQUEST_DELAY_MS);
+            return true;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            log.warn("글로벌 지표 배치 인터럽트, 루프 중단");
+            return false;
         }
-
-        log.info("글로벌 지표 초기 시딩: type={}, count={}", type, histories.size());
-        return histories.size();
-    }
-
-    /**
-     * cycle 변경분만 history INSERT + latest 전건 갱신 (previous_data_value 보존)
-     */
-    private int saveChangedIndicator(GlobalEconomicIndicatorType type,
-                                      List<CountryIndicatorSnapshot> snapshots,
-                                      LocalDate today,
-                                      Map<String, GlobalIndicatorLatest> latestMap) {
-        List<GlobalIndicator> changed = snapshots.stream()
-            .filter(s -> isCycleChanged(s, latestMap))
-            .map(s -> GlobalIndicator.fromSnapshot(s, today))
-            .toList();
-
-        if (!changed.isEmpty()) {
-            globalIndicatorRepository.saveAll(changed);
-            log.info("글로벌 지표 히스토리 저장: type={}, count={}", type, changed.size());
-        } else {
-            log.info("글로벌 지표 변경 없음: type={}", type);
-        }
-
-        // latest 전건 갱신 (previous_data_value 는 LatestRepositoryImpl 에서 보존)
-        List<GlobalIndicatorLatest> latestList = snapshots.stream()
-            .map(GlobalIndicatorLatest::fromSnapshot)
-            .toList();
-        globalIndicatorLatestRepository.saveAll(latestList);
-
-        // 배치 내 일관성: latestMap 즉시 갱신
-        for (GlobalIndicatorLatest latest : latestList) {
-            latestMap.put(latest.toCompareKey(), latest);
-        }
-
-        return changed.size();
-    }
-
-    /**
-     * latestMap 과 비교하여 cycle 변경 여부 판단
-     */
-    private boolean isCycleChanged(CountryIndicatorSnapshot snapshot,
-                                    Map<String, GlobalIndicatorLatest> latestMap) {
-        String newCycle = snapshot.getReferenceText();
-        String key = snapshot.getCountryName() + "::" + snapshot.getIndicatorType().name();
-        GlobalIndicatorLatest existing = latestMap.get(key);
-
-        // latestMap 에 없으면 신규 → 저장 대상
-        // cycle 이 다르면 → 저장 대상
-        return existing == null || !newCycle.equals(existing.getCycle());
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/application/GlobalIndicatorSnapshotWriter.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/application/GlobalIndicatorSnapshotWriter.java
@@ -1,0 +1,121 @@
+package com.thlee.stock.market.stockmarket.economics.application;
+
+import com.thlee.stock.market.stockmarket.economics.domain.model.CountryIndicatorSnapshot;
+import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalEconomicIndicatorType;
+import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalIndicator;
+import com.thlee.stock.market.stockmarket.economics.domain.model.GlobalIndicatorLatest;
+import com.thlee.stock.market.stockmarket.economics.domain.repository.GlobalIndicatorLatestRepository;
+import com.thlee.stock.market.stockmarket.economics.domain.repository.GlobalIndicatorRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 글로벌 경제지표 지표 단위 저장 (#51)
+ *
+ * 지표별 독립 트랜잭션으로 저장해 한 지표의 DB 실패가 같은 배치의 다른 지표를
+ * 롤백시키지 않도록 한다 — PostgreSQL 은 트랜잭션 내 SQL 에러 1건이면 트랜잭션
+ * 전체가 abort 되므로, 배치 전체 단일 트랜잭션 구조에서는 "부분 성공 허용"이
+ * 실제로 동작하지 않았다 (히스토리가 2026-04-11 시딩 이후 동결된 원인 계열).
+ * HTTP 수집은 트랜잭션 밖({@link GlobalIndicatorSaveService})에서 수행한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GlobalIndicatorSnapshotWriter {
+
+    private final GlobalIndicatorRepository globalIndicatorRepository;
+    private final GlobalIndicatorLatestRepository globalIndicatorLatestRepository;
+
+    /**
+     * 단일 지표 저장: 초기 시딩 또는 cycle 변경분 INSERT + latest 전건 갱신
+     */
+    @Transactional
+    public int persistIndicator(GlobalEconomicIndicatorType type,
+                                List<CountryIndicatorSnapshot> snapshots,
+                                LocalDate today,
+                                boolean historyExists,
+                                Map<String, GlobalIndicatorLatest> latestMap) {
+        if (!historyExists) {
+            return initialSeedIndicator(type, snapshots, today, latestMap);
+        }
+        return saveChangedIndicator(type, snapshots, today, latestMap);
+    }
+
+    /**
+     * 초기 시딩 (지표 단위): 수집된 전체 snapshot → history + latest
+     */
+    private int initialSeedIndicator(GlobalEconomicIndicatorType type,
+                                      List<CountryIndicatorSnapshot> snapshots,
+                                      LocalDate today,
+                                      Map<String, GlobalIndicatorLatest> latestMap) {
+        List<GlobalIndicator> histories = snapshots.stream()
+            .map(s -> GlobalIndicator.fromSnapshot(s, today))
+            .toList();
+        globalIndicatorRepository.saveAll(histories);
+
+        upsertLatest(snapshots, latestMap);
+
+        log.info("글로벌 지표 초기 시딩: type={}, count={}", type, histories.size());
+        return histories.size();
+    }
+
+    /**
+     * cycle 변경분만 history INSERT + latest 전건 갱신 (previous_data_value 보존)
+     */
+    private int saveChangedIndicator(GlobalEconomicIndicatorType type,
+                                      List<CountryIndicatorSnapshot> snapshots,
+                                      LocalDate today,
+                                      Map<String, GlobalIndicatorLatest> latestMap) {
+        List<GlobalIndicator> changed = snapshots.stream()
+            .filter(s -> isCycleChanged(s, latestMap))
+            .map(s -> GlobalIndicator.fromSnapshot(s, today))
+            .toList();
+
+        if (!changed.isEmpty()) {
+            globalIndicatorRepository.saveAll(changed);
+            log.info("글로벌 지표 히스토리 저장: type={}, count={}", type, changed.size());
+        } else {
+            log.info("글로벌 지표 변경 없음: type={}", type);
+        }
+
+        upsertLatest(snapshots, latestMap);
+
+        return changed.size();
+    }
+
+    /**
+     * latest 전건 갱신 (previous_data_value 는 LatestRepositoryImpl 에서 보존)
+     * + 배치 내 일관성을 위해 latestMap 즉시 갱신
+     */
+    private void upsertLatest(List<CountryIndicatorSnapshot> snapshots,
+                              Map<String, GlobalIndicatorLatest> latestMap) {
+        List<GlobalIndicatorLatest> latestList = snapshots.stream()
+            .map(GlobalIndicatorLatest::fromSnapshot)
+            .toList();
+        globalIndicatorLatestRepository.saveAll(latestList);
+
+        for (GlobalIndicatorLatest latest : latestList) {
+            latestMap.put(latest.toCompareKey(), latest);
+        }
+    }
+
+    /**
+     * latestMap 과 비교하여 cycle 변경 여부 판단
+     */
+    private boolean isCycleChanged(CountryIndicatorSnapshot snapshot,
+                                    Map<String, GlobalIndicatorLatest> latestMap) {
+        String newCycle = snapshot.getReferenceText();
+        String key = snapshot.getCountryName() + "::" + snapshot.getIndicatorType().name();
+        GlobalIndicatorLatest existing = latestMap.get(key);
+
+        // latestMap 에 없으면 신규 → 저장 대상
+        // cycle 이 다르면 → 저장 대상
+        return existing == null || !newCycle.equals(existing.getCycle());
+    }
+}

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/model/GlobalIndicatorLatest.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/model/GlobalIndicatorLatest.java
@@ -17,6 +17,8 @@ public class GlobalIndicatorLatest {
     private final String cycle;
     private final String unit;
     private final LocalDateTime updatedAt;
+    // 마지막 수집 시각 — cycle 변경 여부와 무관하게 수집 성공마다 갱신 (#51 catch-up 판단 기준)
+    private final LocalDateTime lastCollectedAt;
 
     public GlobalIndicatorLatest(String countryName,
                                   GlobalEconomicIndicatorType indicatorType,
@@ -24,7 +26,8 @@ public class GlobalIndicatorLatest {
                                   String previousDataValue,
                                   String cycle,
                                   String unit,
-                                  LocalDateTime updatedAt) {
+                                  LocalDateTime updatedAt,
+                                  LocalDateTime lastCollectedAt) {
         this.countryName = countryName;
         this.indicatorType = indicatorType;
         this.dataValue = dataValue;
@@ -32,6 +35,7 @@ public class GlobalIndicatorLatest {
         this.cycle = cycle;
         this.unit = unit;
         this.updatedAt = updatedAt;
+        this.lastCollectedAt = lastCollectedAt;
     }
 
     /**
@@ -39,6 +43,7 @@ public class GlobalIndicatorLatest {
      */
     public static GlobalIndicatorLatest fromSnapshot(CountryIndicatorSnapshot snapshot) {
         IndicatorValue lastValue = snapshot.getLastValue();
+        LocalDateTime now = LocalDateTime.now();
         return new GlobalIndicatorLatest(
             snapshot.getCountryName(),
             snapshot.getIndicatorType(),
@@ -46,7 +51,8 @@ public class GlobalIndicatorLatest {
             null,
             snapshot.getReferenceText(),
             lastValue != null ? lastValue.getUnit() : null,
-            LocalDateTime.now()
+            now,
+            now
         );
     }
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/repository/GlobalIndicatorLatestRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/domain/repository/GlobalIndicatorLatestRepository.java
@@ -23,4 +23,9 @@ public interface GlobalIndicatorLatestRepository {
      * 최근 업데이트된 지표 조회 (updatedAt 기준, 최신순)
      */
     List<GlobalIndicatorLatest> findRecentlyUpdated(java.time.LocalDateTime after);
+
+    /**
+     * 전체 지표 중 가장 최근 수집 시각 (#51 catch-up 판단용, 수집 이력 없으면 empty)
+     */
+    java.util.Optional<java.time.LocalDateTime> findMaxLastCollectedAt();
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorJpaRepository.java
@@ -22,7 +22,7 @@ public interface GlobalIndicatorJpaRepository extends JpaRepository<GlobalIndica
                 WHERE e.indicator_type = :indicatorType
             ) t
             WHERE t.rn = 1
-            ORDER BY t.country_name, t.cycle
+            ORDER BY t.country_name, t.snapshot_date, t.id
             """, nativeQuery = true)
     List<GlobalIndicatorEntity> findLatestHistoryByIndicatorType(@Param("indicatorType") String indicatorType);
 

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorLatestEntity.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorLatestEntity.java
@@ -41,6 +41,10 @@ public class GlobalIndicatorLatestEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    // 마지막 수집 시각 — cycle 변경 없어도 수집 성공마다 갱신 (#51 catch-up 판단, 기존 행 호환 위해 nullable)
+    @Column(name = "last_collected_at")
+    private LocalDateTime lastCollectedAt;
+
     protected GlobalIndicatorLatestEntity() {
     }
 
@@ -50,7 +54,8 @@ public class GlobalIndicatorLatestEntity {
                                         String previousDataValue,
                                         String cycle,
                                         String unit,
-                                        LocalDateTime updatedAt) {
+                                        LocalDateTime updatedAt,
+                                        LocalDateTime lastCollectedAt) {
         this.countryName = countryName;
         this.indicatorType = indicatorType;
         this.dataValue = dataValue;
@@ -58,6 +63,7 @@ public class GlobalIndicatorLatestEntity {
         this.cycle = cycle;
         this.unit = unit;
         this.updatedAt = updatedAt;
+        this.lastCollectedAt = lastCollectedAt;
     }
 
     /**
@@ -67,7 +73,8 @@ public class GlobalIndicatorLatestEntity {
                        String newCycle,
                        String newUnit,
                        boolean cycleChanged,
-                       LocalDateTime updatedAt) {
+                       LocalDateTime updatedAt,
+                       LocalDateTime lastCollectedAt) {
         if (cycleChanged) {
             this.previousDataValue = this.dataValue;
         }
@@ -75,6 +82,7 @@ public class GlobalIndicatorLatestEntity {
         this.cycle = newCycle;
         this.unit = newUnit;
         this.updatedAt = updatedAt;
+        this.lastCollectedAt = lastCollectedAt;
     }
 
     /**

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorLatestJpaRepository.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorLatestJpaRepository.java
@@ -1,12 +1,17 @@
 package com.thlee.stock.market.stockmarket.economics.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface GlobalIndicatorLatestJpaRepository
     extends JpaRepository<GlobalIndicatorLatestEntity, GlobalIndicatorLatestEntity.LatestId> {
 
     List<GlobalIndicatorLatestEntity> findByUpdatedAtAfterOrderByUpdatedAtDesc(LocalDateTime after);
+
+    @Query("select max(e.lastCollectedAt) from GlobalIndicatorLatestEntity e")
+    Optional<LocalDateTime> findMaxLastCollectedAt();
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorLatestRepositoryImpl.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/GlobalIndicatorLatestRepositoryImpl.java
@@ -32,6 +32,11 @@ public class GlobalIndicatorLatestRepositoryImpl implements GlobalIndicatorLates
     }
 
     @Override
+    public Optional<LocalDateTime> findMaxLastCollectedAt() {
+        return jpaRepository.findMaxLastCollectedAt();
+    }
+
+    @Override
     public void saveAll(List<GlobalIndicatorLatest> latestList) {
         for (GlobalIndicatorLatest latest : latestList) {
             GlobalIndicatorLatestEntity.LatestId id =
@@ -51,7 +56,8 @@ public class GlobalIndicatorLatestRepositoryImpl implements GlobalIndicatorLates
                     latest.getCycle(),
                     latest.getUnit(),
                     cycleChanged,
-                    updatedAt
+                    updatedAt,
+                    latest.getLastCollectedAt()
                 );
             } else {
                 jpaRepository.save(mapper.toEntity(latest));

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/mapper/GlobalIndicatorLatestMapper.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/persistence/mapper/GlobalIndicatorLatestMapper.java
@@ -15,7 +15,8 @@ public class GlobalIndicatorLatestMapper {
             domain.getPreviousDataValue(),
             domain.getCycle(),
             domain.getUnit(),
-            domain.getUpdatedAt()
+            domain.getUpdatedAt(),
+            domain.getLastCollectedAt()
         );
     }
 
@@ -27,7 +28,8 @@ public class GlobalIndicatorLatestMapper {
             entity.getPreviousDataValue(),
             entity.getCycle(),
             entity.getUnit(),
-            entity.getUpdatedAt()
+            entity.getUpdatedAt(),
+            entity.getLastCollectedAt()
         );
     }
 }

--- a/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/scheduler/GlobalIndicatorWarmupListener.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/economics/infrastructure/scheduler/GlobalIndicatorWarmupListener.java
@@ -1,0 +1,64 @@
+package com.thlee.stock.market.stockmarket.economics.infrastructure.scheduler;
+
+import com.thlee.stock.market.stockmarket.economics.application.GlobalIndicatorSaveService;
+import com.thlee.stock.market.stockmarket.economics.domain.repository.GlobalIndicatorLatestRepository;
+import com.thlee.stock.market.stockmarket.logging.application.LoggingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * 앱 시작 시 글로벌 경제지표 조건부 catch-up (#51)
+ *
+ * 마지막 수집(last_collected_at)이 없거나 {@link #CATCH_UP_THRESHOLD} 이상 경과한
+ * 경우에만 수집을 보충한다 — 배치 시각에 앱이 내려가 있던 날을 복구하되,
+ * 잦은 재배포 시 TradingEconomics 중복 스크래핑(41개 지표 × 1.5초)은 피한다.
+ *
+ * 수집은 약 2분 소요되므로 다른 ApplicationReadyEvent 리스너(ECOS warmup 등)를
+ * 막지 않도록 전용 daemon 스레드에서 실행한다. 시작 직후 정규 배치 시각과 겹치면
+ * 드물게 동시 수집될 수 있으나, cycle 중복 행은 히스토리 조회의 cycle 단위
+ * dedup(ROW_NUMBER) 이 흡수한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GlobalIndicatorWarmupListener {
+
+    private static final Duration CATCH_UP_THRESHOLD = Duration.ofHours(20);
+
+    private final GlobalIndicatorSaveService globalIndicatorSaveService;
+    private final GlobalIndicatorLatestRepository globalIndicatorLatestRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        LocalDateTime lastCollectedAt =
+            globalIndicatorLatestRepository.findMaxLastCollectedAt().orElse(null);
+
+        if (lastCollectedAt != null
+                && Duration.between(lastCollectedAt, LocalDateTime.now()).compareTo(CATCH_UP_THRESHOLD) < 0) {
+            log.info("글로벌 경제지표 catch-up 불필요: 마지막 수집 {}", lastCollectedAt);
+            return;
+        }
+
+        Thread worker = new Thread(() -> runCatchUp(lastCollectedAt), "global-indicator-warmup");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private void runCatchUp(LocalDateTime lastCollectedAt) {
+        try (var ctx = LoggingContext.forScheduler("global-indicator-warmup")) {
+            log.info("글로벌 경제지표 catch-up 시작 (마지막 수집: {})", lastCollectedAt);
+            try {
+                int savedCount = globalIndicatorSaveService.fetchAndSave();
+                log.info("글로벌 경제지표 catch-up 완료: {}건", savedCount);
+            } catch (Exception e) {
+                log.error("글로벌 경제지표 catch-up 실패", e);
+            }
+        }
+    }
+}

--- a/src/main/resources/static/js/components/global.js
+++ b/src/main/resources/static/js/components/global.js
@@ -191,7 +191,7 @@ const GlobalComponent = {
         if (!data || !data.countries || data.countries.length === 0) return;
 
         data.countries.forEach((country, idx) => {
-            if (country.history.length < 2) return;
+            if (country.history.length < 1) return;
 
             const canvasId = 'global-chart-' + country.countryName.replace(/[^a-zA-Z0-9가-힣]/g, '_');
             const canvas = document.getElementById(canvasId);
@@ -209,7 +209,8 @@ const GlobalComponent = {
                         }),
                         borderColor: COUNTRY_COLORS[idx % COUNTRY_COLORS.length],
                         borderWidth: 1.5,
-                        pointRadius: 0,
+                        // 1포인트뿐이면 선을 그릴 수 없으므로 점을 보이게 (#51)
+                        pointRadius: country.history.length === 1 ? 3 : 0,
                         pointHoverRadius: 4,
                         tension: 0.3,
                         fill: false,

--- a/src/main/resources/static/partials/global.html
+++ b/src/main/resources/static/partials/global.html
@@ -95,12 +95,12 @@
                                                     <h3 class="text-sm font-semibold text-gray-800" x-text="country.countryName"></h3>
                                                     <span class="text-xs text-gray-400 ml-2 shrink-0" x-text="globalData.historyData.unit"></span>
                                                 </div>
-                                                <template x-if="country.history.length >= 2">
+                                                <template x-if="country.history.length >= 1">
                                                     <div class="h-48">
                                                         <canvas :id="'global-chart-' + country.countryName.replace(/[^a-zA-Z0-9가-힣]/g, '_')"></canvas>
                                                     </div>
                                                 </template>
-                                                <template x-if="country.history.length < 2">
+                                                <template x-if="country.history.length < 1">
                                                     <div class="h-48 flex items-center justify-center text-sm text-gray-400">
                                                         데이터 부족
                                                     </div>


### PR DESCRIPTION
## 배경 (#51)

히스토리 미적재의 직접 원인(스케줄러 전체 정지)은 #96/PR #98에서 해결됐다. 본 PR은 #96 진단에서 확인된 글로벌 히스토리 파이프라인 자체의 잔여 결함 4건을 일괄 보강한다.

## 변경 내용

1. **지표 단위 독립 트랜잭션** — 배치 전체 단일 `@Transactional` 제거. 저장은 신규 `GlobalIndicatorSnapshotWriter`(지표별 트랜잭션)로 분리, HTTP 수집은 트랜잭션 밖. PostgreSQL은 트랜잭션 내 SQL 에러 1건이면 전체 abort되므로 기존 구조에서는 지표별 try-catch에도 하루치 전체가 롤백될 수 있었다 — 이제 한 지표의 실패가 다른 지표를 롤백시키지 않는다. 종료 시 요약 로그(히스토리 건수 + 지표 성공/실패/전체) 추가
2. **그래프 시간순 정렬** — 히스토리 조회 `ORDER BY cycle`(문자열 사전순 — 데이터가 쌓이면 x축이 뒤섞임) → `ORDER BY snapshot_date, id`(시간순). 응답 구조 불변
3. **조건부 catch-up + 수집 시각 관측성** — `global_indicator_latest.last_collected_at`(nullable 컬럼 추가, ddl-auto 자동 반영). cycle 변경과 무관하게 수집 성공마다 스탬프. 신규 `GlobalIndicatorWarmupListener`가 앱 시작 시 마지막 수집이 없거나 20h+ 경과한 경우에만 백그라운드 catch-up(전용 daemon 스레드) — 배치 시각(KST 16:30)에 앱이 꺼져 있던 날을 복구하되 잦은 재배포 시 중복 스크래핑은 방지
4. **1포인트 표시** — 히스토리 1포인트 국가도 점(pointRadius 3)으로 렌더링. 시딩 직후 상태에서 그래프 탭 전체가 "데이터 부족"이던 문제 해소

부수 효과: #25로 추가됐던 미시딩 10개 지표는 첫 정상 수집에서 자동 시딩된다 (latestMap 부재 → 전건 INSERT).

## 검증

- `./gradlew compileJava` + `node --check` 통과, 셀프 리뷰 명시적 findings 없음 (`docs/reviews/2026-08-02-...`)
- 배포 후 확인: 첫 기동 "catch-up 시작/완료" 로그(기존 행 NULL 부트스트랩), 이후 재시작 "catch-up 불필요", 16:30 배치 요약 로그, 그래프 점 표시·시간순 (`docs/validations/2026-08-02-...`)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMHYkZpyuMDRNqQGYtHe9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMHYkZpyuMDRNqQGYtHe9R)_