### PR TITLE
feat(portfolio): 현금성 자산 예금/적금/CMA 서브 카테고리 표시

### DIFF
--- a/src/main/resources/static/js/components/portfolio.js
+++ b/src/main/resources/static/js/components/portfolio.js
@@ -466,6 +466,35 @@ const PortfolioComponent = {
         return this.portfolio.items.filter((item) => item.assetType === 'STOCK' && item.stockDetail && item.stockDetail.country !== 'KR');
     },
 
+    getCashSubTypeKey(item) {
+        return item.cashDetail?.subType || 'ETC';
+    },
+
+    getCashItemsSorted() {
+        const order = ['DEPOSIT', 'SAVINGS', 'CMA'];
+        return this.getItemsByType('CASH').slice().sort((a, b) => {
+            const aIdx = order.indexOf(this.getCashSubTypeKey(a));
+            const bIdx = order.indexOf(this.getCashSubTypeKey(b));
+            return (aIdx === -1 ? order.length : aIdx) - (bIdx === -1 ? order.length : bIdx);
+        });
+    },
+
+    isCashGroupStart(item) {
+        const sorted = this.getCashItemsSorted();
+        const idx = sorted.findIndex((i) => i.id === item.id);
+        if (idx < 0) return false;
+        if (idx === 0) return true;
+        return this.getCashSubTypeKey(sorted[idx - 1]) !== this.getCashSubTypeKey(item);
+    },
+
+    getCashGroupSummary(item) {
+        const key = this.getCashSubTypeKey(item);
+        const labels = { DEPOSIT: '🏦 예금', SAVINGS: '💰 적금', CMA: '💳 CMA' };
+        const groupItems = this.getItemsByType('CASH').filter((i) => this.getCashSubTypeKey(i) === key);
+        const total = groupItems.reduce((sum, i) => sum + this.getEvalAmount(i), 0);
+        return (labels[key] || '📦 기타') + ' ' + groupItems.length + '건 · ' + Format.number(total, 0) + '원';
+    },
+
     getTotalInvested() {
         return this.portfolio.items.reduce((sum, item) => sum + this.getInvestedAmountKrw(item), 0);
     },

--- a/src/main/resources/static/partials/portfolio.html
+++ b/src/main/resources/static/partials/portfolio.html
@@ -228,7 +228,12 @@
                                                 <template x-if="alloc.assetType === 'STOCK' && getDomesticStocks().length > 0">
                                                     <div class="text-xs font-medium text-gray-500 px-1 pt-1">🇰🇷 국내 주식</div>
                                                 </template>
-                                                <template x-for="item in alloc.assetType === 'STOCK' ? getDomesticStocks() : getItemsByType(alloc.assetType)" :key="item.id">
+                                                <template x-for="item in alloc.assetType === 'STOCK' ? getDomesticStocks() : (alloc.assetType === 'CASH' ? getCashItemsSorted() : getItemsByType(alloc.assetType))" :key="item.id">
+                                                    <div>
+                                                    <!-- CASH: 서브 카테고리(예금/적금/CMA) 헤더 -->
+                                                    <template x-if="alloc.assetType === 'CASH' && isCashGroupStart(item)">
+                                                        <div class="text-xs font-medium text-gray-500 px-1 pt-1 pb-2" x-text="getCashGroupSummary(item)"></div>
+                                                    </template>
                                                     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden shadow-sm">
                                                         <div @click="item.newsEnabled ? selectPortfolioNewsItem(item) : null"
                                                             class="px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 transition"
@@ -329,6 +334,7 @@
                                                                     class="text-xs px-2 py-1 rounded text-gray-500 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed">다음</button>
                                                             </div>
                                                         </div>
+                                                    </div>
                                                     </div>
                                                 </template>
                                                 <!-- STOCK: 해외 주식 서브 헤더 + 루프 -->


### PR DESCRIPTION
## 요약
- 포트폴리오 현금성 자산 섹션에서 예금/적금이 한 목록에 섞여 구분이 어려운 문제 해결
- CASH 섹션 항목을 예금→적금→CMA→기타 순으로 정렬하고, 각 그룹 시작에 서브 헤더(라벨·건수·소계 금액) 표시
- 주식 섹션의 국내/해외 서브 헤더와 동일한 UI 패턴, 프론트엔드 2개 파일만 변경 (백엔드·API·Entity 변경 없음)

## 변경 파일
- `static/js/components/portfolio.js` — getCashSubTypeKey / getCashItemsSorted / isCashGroupStart / getCashGroupSummary 헬퍼 추가
- `static/partials/portfolio.html` — CASH 루프 소스를 정렬 목록으로 교체, 그룹 시작 지점에 서브 헤더 삽입

## 검증
- 목 하네스(실제 파셜+컴포넌트 JS 로드, API 목 대체)로 렌더링 순서 확인: 예금(2건·소계) → 적금 → CMA → 기타(subType 미지정)
- 다른 자산 섹션(금)에 서브 헤더 미표시 확인, 콘솔 에러 없음
- 미검증: 실제 dev 서버(bootRun) 구동 확인, 모바일 뷰 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)