### PR TITLE
fix(portfolio): 납입 리마인더 — 당일 항목 표시·이력 0건 판정 누락 수정 (#111)

### DIFF
--- a/docs/brainstorms/2026-08-10-deposit-reminder-due-today-brainstorm.md
+++ b/docs/brainstorms/2026-08-10-deposit-reminder-due-today-brainstorm.md
@@ -1,0 +1,38 @@
+# 납입 리마인더 당일 미표시 + 이력 0건 판정 누락 Brainstorm
+
+- Status: Decided (2026-08-10)
+- gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+
+## 문제 정의
+
+태형님 보고(2026-08-10): "10일 적금을 해놓은게 있는데 납입 알림이 안 떠서. 당일날부터 떠야 하는 거 아냐?"
+
+조사 결과 원인 2건 확인.
+
+### 1. 납입일 당일 팝업 미표시
+
+- #99 확정 스펙의 팝업 대상은 "당일 + 미납"인데, #100 구현이 기존 `depositOverdue`를 그대로 재사용.
+- `PortfolioService.isDepositOverdue`는 `!referenceDate.isAfter(depositDueDate)`이면 false — **납입일 다음날부터** 미납 판정.
+- 결과: 납입일 당일(예: 8/10, 납입일 10일)에는 리마인더 팝업이 뜨지 않음.
+
+### 2. 납입 이력 0건 항목 판정 누락
+
+- `PortfolioService.getItems`의 depositMap은 `findByPortfolioItemIdIn` 결과를 groupingBy — 이력이 1건 이상인 항목만 키 생성.
+- `deposits == null`이면 `isDepositOverdue` 호출 자체를 건너뛰어 `depositOverdue`가 null로 남음.
+- 결과: 납입 기록을 한 번도 남기지 않은 예금/적금/펀드는 납입일이 지나도 미납 배지·리마인더에 잡히지 않음.
+- 같은 가드에 묶인 만기 예상 금액(`expectedMaturityAmount`)도 이력 0건 항목에서 미계산.
+
+## 선택지와 결정
+
+당일 반영 방식 (태형님 확정, 2026-08-10):
+
+- (A) **팝업만 당일 포함** — 백엔드에 `depositDueToday` 플래그 추가, 팝업 필터를 `depositOverdue || depositDueToday`로 확장. 포트폴리오 목록의 미납 배지는 기존대로 다음날부터 유지(당일은 아직 미납이 아니므로 의미 보존). ← **채택**
+- (B) 미납 판정 자체를 당일부터로 변경 — 코드 최소지만 당일에 "미납" 배지가 붙어 의미가 어긋남. 기각.
+
+null 가드 버그는 `getOrDefault(itemId, List.of())`로 이력 0건 항목도 판정 수행 (`isDepositOverdue`는 빈 리스트에서 이미 올바르게 true 반환).
+
+## 범위
+
+- 백엔드: `PortfolioService.getItems` 판정 가드 수정 + `isDepositDueToday` 신설 + `PortfolioItemResponse.depositDueToday` 필드 추가.
+- 프런트: 리마인더 필터 확장 + 항목별 미납/오늘 납입일 구분 배지.
+- 메일 알림(#99 요구 1)·알림 설정(#99 요구 3)은 본 건 범위 아님 — #99에서 계속 진행.

--- a/docs/commits/2026-08-10-deposit-reminder-due-today-commit.md
+++ b/docs/commits/2026-08-10-deposit-reminder-due-today-commit.md
@@ -1,0 +1,40 @@
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 Commit 기록
+
+**Date:** 2026-08-10
+**Issue:** #111
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+
+## 태형님 승인
+
+- 2026-08-10 "진행해" — commit → push(PR 생성·main 병합) 일괄 승인
+
+## 포함 파일
+
+- src/main/java/.../portfolio/application/PortfolioService.java
+- src/main/java/.../portfolio/application/dto/PortfolioItemResponse.java
+- src/main/resources/static/js/components/portfolio.js
+- src/main/resources/static/partials/portfolio-deposit-financial.html
+- docs/brainstorms/2026-08-10-deposit-reminder-due-today-brainstorm.md
+- docs/issues/2026-08-10-deposit-reminder-due-today-issue.md
+- docs/plans/2026-08-10-001-fix-deposit-reminder-due-today-plan.md
+- docs/works/2026-08-10-deposit-reminder-due-today-work.md
+- docs/reviews/2026-08-10-deposit-reminder-due-today-review.md
+- docs/validations/2026-08-10-deposit-reminder-due-today-validation.md
+- docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+- docs/commits/2026-08-10-deposit-reminder-due-today-commit.md
+- docs/pushes/2026-08-10-deposit-reminder-due-today-push.md
+
+## 제외 파일
+
+- 없음 (worktree 내 기타 변경 없음. 하네스는 scratchpad, launch.json 항목은 primary worktree 로컬 설정으로 커밋 대상 아님)
+
+## 커밋 메시지
+
+```
+fix(portfolio): #111 납입 리마인더 — 당일 항목 표시·이력 0건 판정 누락 수정
+
+- isDepositDueToday 신설: 오늘==납입일(말일 보정)·당월 기록 없음 → 팝업 대상 (#99 스펙 "당일+미납")
+- getItems null 가드 수정: 납입 이력 0건 항목도 getOrDefault(빈 리스트)로 판정 수행
+- PortfolioItemResponse.depositDueToday additive 추가, 미납 배지는 기존(다음날부터) 유지
+- 팝업: 당일/미납 상태 배지 구분, 헤더·문구 조정
+```

--- a/docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+++ b/docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
@@ -1,0 +1,36 @@
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 게이트 로그
+
+## 원칙
+
+- 각 단계 시작 전 태형님에게 작업 내용을 제시한다.
+- 다음 단계로 넘어갈지에 대한 판단은 태형님에게 넘긴다.
+- 단계별 산출물은 이 게이트 로그를 `gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md`로 참조한다.
+
+## Stage Decisions
+
+- start: approved
+- brainstorm: approved (2026-08-10, 태형님 — 당일 처리 방식 "팝업만 당일 포함" 선택)
+- issue: approved (2026-08-10, 태형님 "이슈 등록 + 수정 진행" — GitHub #111 등록)
+- plan: approved (2026-08-10, "이슈 등록 + 수정 진행" 승인에 수정 작업 포함)
+- work: done (2026-08-10)
+- review: done (2026-08-10, 셀프 리뷰 — 명시적 findings 없음)
+- validation: done (2026-08-10 — gradlew test 117/117, 브라우저 하네스 전 시나리오 PASS)
+- commit: approved (2026-08-10, 태형님 "진행해" — docs/commits 기록)
+- push: approved (2026-08-10, 태형님 "진행해" — PR 생성·main 병합 포함, docs/pushes 기록)
+
+## Stage Log
+
+- start: 2026-08-10, 태형님 "자동 납입 기능이랑 납입 안되어있으면 리마인더 하는 기능... 실제로 동작을 안하네??" — 원인 조사 착수
+- brainstorm: 완료 (2026-08-10, docs/brainstorms/2026-08-10-deposit-reminder-due-today-brainstorm.md)
+  - 원인 2건: 당일 미판정(#100이 depositOverdue 재사용, #99 스펙은 당일+미납) + 이력 0건 null 가드
+  - 선택지 A(팝업만 당일 포함) vs B(미납 판정 당일부터) → 태형님 A 확정
+- issue: 완료 (2026-08-10, GitHub #111 — docs/issues/2026-08-10-deposit-reminder-due-today-issue.md)
+- plan: 완료 (2026-08-10, docs/plans/2026-08-10-001-fix-deposit-reminder-due-today-plan.md)
+- work: 진행 중
+
+## Approval Gate 항목
+
+- public API 변경: `PortfolioItemResponse`에 `depositDueToday` 필드 additive 추가 — 태형님 선택지 답변으로 승인됨
+- Entity·DB 변경 없음
+- 미납 배지 의미(납입일 다음날부터) 불변 — 확정안에 명시
+- worktree: fix/issue-111-deposit-reminder-due-today (scripts/create-worktree.sh --issue 111)

--- a/docs/issues/2026-08-10-deposit-reminder-due-today-issue.md
+++ b/docs/issues/2026-08-10-deposit-reminder-due-today-issue.md
@@ -1,0 +1,23 @@
+# 납입 리마인더 당일 미표시 + 이력 0건 판정 누락 Issue 기록
+
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+
+## GitHub Issue
+
+- status: created
+- issue_number: 111
+- issue_url: https://github.com/osnet-th/stock-market/issues/111
+- title: [bug] 납입 리마인더 팝업 — 납입일 당일 미표시 + 납입 이력 없는 항목 판정 누락
+- label: bug
+
+## 근거
+
+- brainstorm: docs/brainstorms/2026-08-10-deposit-reminder-due-today-brainstorm.md (Status: Decided)
+- 태형님 보고(2026-08-10): 납입일 10일 적금이 당일 리마인더에 안 뜸 — "당일날부터 떠야하는거아냐??"
+- 방식 확정: 팝업만 당일 포함(depositDueToday 추가), 미납 배지는 다음날부터 유지, null 가드 수정 포함
+
+## Branch
+
+- branch: fix/issue-111-deposit-reminder-due-today
+- base: main
+- worktree: /Users/tang/Documents/workspace/wt-issue-111-fix-issue-111-deposit-reminder-due-today (scripts/create-worktree.sh --issue 111)

--- a/docs/plans/2026-08-10-001-fix-deposit-reminder-due-today-plan.md
+++ b/docs/plans/2026-08-10-001-fix-deposit-reminder-due-today-plan.md
@@ -1,0 +1,58 @@
+---
+title: 납입 리마인더 당일 표시 + 이력 0건 판정 누락 수정
+type: fix
+status: active
+date: 2026-08-10
+issue: https://github.com/osnet-th/stock-market/issues/111
+origin: docs/brainstorms/2026-08-10-deposit-reminder-due-today-brainstorm.md
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+---
+
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 수정 (#111)
+
+## Overview
+
+리마인더 팝업 대상을 #99 스펙대로 "당일 + 미납"으로 확장하고, 납입 이력 0건 항목이 판정에서 빠지는 null 가드 버그를 수정한다. 포트폴리오 목록의 미납 배지는 기존 의미(납입일 다음날부터) 유지.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `portfolio/application/PortfolioService.java` | `getItems` 판정 가드 수정(getOrDefault), `isDepositDueToday` 신설, 공통 helper(`resolveDepositDay`/`hasNoDepositThisMonth`) 추출 |
+| `portfolio/application/dto/PortfolioItemResponse.java` | `depositDueToday` 필드·생성자 파라미터·`from` 확장 (기존 호출부는 null 유지) |
+| `static/js/components/portfolio.js` | `checkDepositReminder` 필터를 `depositOverdue \|\| depositDueToday`로 확장 |
+| `static/partials/portfolio-deposit-financial.html` | 항목별 미납/오늘 납입일 구분 배지, 헤더·안내 문구 조정 |
+
+Entity·DB 변경 없음. 미납 배지·납입 모달·스누즈 로직 불변.
+
+## Implementation Steps
+
+### 1. 백엔드 — 판정 로직
+
+- [x] `isDepositOverdue`에서 depositDay 해석을 `resolveDepositDay(item)` helper로 추출
+- [x] 당월 납입 기록 부재 검사를 `hasNoDepositThisMonth(histories, referenceDate)` helper로 추출
+- [x] `isDepositDueToday(item, histories, referenceDate)` 신설 — 오늘 == effectiveDay(말일 보정 동일) && 당월 기록 없음
+- [x] `getItems`: CASH/FUND 항목은 `finalDepositMap.getOrDefault(id, List.of())`로 항상 판정 수행 (이력 0건 포함), `depositDueToday` 계산 추가, 만기 예상 금액도 동일 가드 해제
+
+### 2. 백엔드 — 응답 DTO
+
+- [x] `PortfolioItemResponse`에 `depositDueToday` 추가 (depositOverdue 옆), 전체 `from` 오버로드 시그니처 확장, 축약 오버로드는 null 위임
+
+### 3. 프런트
+
+- [x] `checkDepositReminder`: 필터 `i.depositOverdue === true || i.depositDueToday === true`
+- [x] 팝업 항목에 상태 배지 — `depositOverdue`면 "미납", 아니면 "오늘 납입일"
+- [x] 헤더 "납입 확인 안내" / 안내 문구를 당일 포함으로 조정
+
+## Technical Considerations
+
+- **미납 배지 불변**: 목록 배지는 `depositOverdue`만 사용하므로 당일 항목에 배지가 붙지 않음 — 확정안 (A) 유지.
+- **null 가드 해제의 부수 효과**: 이력 0건 + 납입일 경과 항목이 이제 미납 배지에 정상 노출 — 버그 수정 의도 그 자체.
+- **만기 예상 금액**: 기존에도 이력 0건이면 미계산이던 것을 동일 수정으로 해제 — `calculateMaturityAmount`는 필수값 없으면 null 반환하므로 안전.
+- **API**: 응답 필드 additive 추가만 — 기존 클라이언트 영향 없음.
+
+## Validation
+
+- [x] `./gradlew compileJava` / `./gradlew test` — 117/117 PASS (로컬 PostgreSQL 가동으로 contextLoads 포함)
+- [x] JS 문법 — 브라우저 하네스 전체 로드로 확인 (node 미설치로 `node --check` 대체)
+- [x] 판정 로직 시나리오 검증 — 브라우저 목 하네스 (당일 배지/미납 배지/제외/납입 클릭/스누즈 재노출)

--- a/docs/pushes/2026-08-10-deposit-reminder-due-today-push.md
+++ b/docs/pushes/2026-08-10-deposit-reminder-due-today-push.md
@@ -1,0 +1,19 @@
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 Push 기록
+
+**Date:** 2026-08-10
+**Issue:** #111
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+
+## 태형님 승인
+
+- 2026-08-10 "진행해" — push·PR 생성·main 병합 일괄 승인
+
+## Push 내용
+
+- remote: origin (osnet-th/stock-market)
+- branch: fix/issue-111-deposit-reminder-due-today
+- 의도: PR 생성 → main 병합 (Closes #111)
+
+## 결과
+
+- push/PR/병합 결과는 최종 응답에 기록

--- a/docs/reviews/2026-08-10-deposit-reminder-due-today-review.md
+++ b/docs/reviews/2026-08-10-deposit-reminder-due-today-review.md
@@ -1,0 +1,26 @@
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 Review 기록
+
+**Date:** 2026-08-10
+**Issue:** #111
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+
+## Findings (심각도 순)
+
+명시적 findings 없음.
+
+셀프 리뷰(diff 라인 단위) 확인 사항:
+
+- 판정 기준 불변 검증: `isDepositOverdue`의 guard 순서·말일 보정·당월 기록 검사 로직은 helper 추출 전후 동일. 기존 호출부(공개 시그니처) 변경 없음.
+- `depositOverdue`/`depositDueToday` 상호 배타: 당일이면 overdue false(다음날부터), 다음날부터는 dueToday false(일자 불일치) — 배지 ternary 안전.
+- `from` 4-인자 오버로드 확장: 호출부는 `getItems` 1곳뿐 — 컴파일로 확인.
+- `@JsonInclude(NON_NULL)` 유지 — 신규 필드는 CASH/FUND에만 세팅, 기존 클라이언트 영향 없음(additive).
+- code-convention: helper 추출로 메서드 5~10줄 유지, guard clause 우선, 중첩 1단계.
+
+## Open Questions / Assumptions
+
+- 이력 0건 CASH 항목의 만기 예상 금액이 함께 표시되기 시작함 — 같은 null 가드에 묶여 있던 부수 버그로 판단, 의도 수정에 포함 (plan 명시).
+- `depositDay`는 entity 검증상 1 이상 가정 (기존 로직과 동일 가정).
+
+## Change Summary
+
+리마인더 팝업 대상을 #99 스펙("당일 + 미납")으로 확장 — 백엔드 `depositDueToday` 플래그 신설(+null 가드 버그 수정), 프런트 필터·배지 반영. 미납 배지 의미 불변. 4파일, +62/-26.

--- a/docs/validations/2026-08-10-deposit-reminder-due-today-validation.md
+++ b/docs/validations/2026-08-10-deposit-reminder-due-today-validation.md
@@ -1,0 +1,33 @@
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 Validation 기록
+
+**Date:** 2026-08-10
+**Issue:** #111
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+
+## 실행한 검증
+
+| 검증 | 명령/방법 | 결과 |
+|------|-----------|------|
+| 백엔드 컴파일 | `./gradlew compileJava` (worktree) | 통과 |
+| 백엔드 테스트 | `./gradlew test` (worktree, 로컬 PostgreSQL 가동 중) | **117/117 PASS** (contextLoads 포함) |
+| JS 문법 | 브라우저 하네스에서 portfolio.js 전체 로드 — 콘솔 에러 0 | 통과 (node 미설치로 `node --check` 대체) |
+| 브라우저 기능 | 브라우저 목 하네스 (scratchpad/harness111 — 실제 portfolio.js·format.js·리마인더 마크업 추출 + Alpine CDN, launch.json `harness111` 정적 서버) | **전 시나리오 PASS** |
+
+### 하네스 검증 시나리오
+
+- 당일 항목(depositDueToday=true) 팝업 노출 + "오늘 납입일" 배지(emerald) — **핵심 수정 확인**
+- 미납 항목(depositOverdue=true) 노출 + "미납" 배지(red), 유형 배지(현금성/펀드)·월납입액·납입일 meta 정상
+- 비대상(플래그 없음 CASH·STOCK) 제외 — 2건만 표시
+- [납입] 클릭: 팝업 닫힘 → navigateTo('portfolio') → openDepositModal(해당 item) 호출 순서 정확
+- [오늘 하루 보지 않기]+닫기 → localStorage `2026-08-10` 저장 → 재확인 시 API 미호출·미노출 / 스누즈 해제 후 재노출(2건) / 대상 0건 미노출
+- 스크린샷 확보 (팝업 렌더링 — 당일·미납 배지 구분 표시)
+
+## 미검증 항목 (운영 배포 후 태형님 확인)
+
+1. 실서버 전체 부트 경로(실 API + 카카오 로그인)에서 당일 항목 팝업 노출 — 하네스는 리마인더 조각 격리 검증
+2. 실데이터 기준 `depositDueToday` 값 (백엔드 판정은 신규 로직 — 오늘 납입일인 실제 적금으로 확인 가능)
+3. 이력 0건 항목의 미납 배지·만기 예상 금액 표시 (실데이터 의존)
+
+## 판단
+
+이 환경에서 가능한 검증 전부 통과. 미검증 항목은 배포 후 확인 성격 — commit/push 승인 대기.

--- a/docs/works/2026-08-10-deposit-reminder-due-today-work.md
+++ b/docs/works/2026-08-10-deposit-reminder-due-today-work.md
@@ -1,0 +1,37 @@
+# 납입 리마인더 당일 표시 + 이력 0건 판정 누락 Work 기록
+
+**Date:** 2026-08-10
+**Issue:** #111
+gate: docs/gates/2026-08-10-deposit-reminder-due-today-gates.md
+plan: docs/plans/2026-08-10-001-fix-deposit-reminder-due-today-plan.md
+
+## 변경 내용
+
+### 백엔드
+
+- `PortfolioService.getItems`
+  - CASH/FUND 항목은 `finalDepositMap.getOrDefault(id, List.of())`로 **이력 0건이어도 항상 판정** (기존: 이력 ≥1건일 때만 판정 → null 가드 버그)
+  - `depositDueToday` 계산 추가, 만기 예상 금액도 동일 가드 해제
+- `PortfolioService.isDepositDueToday` 신설 — 기준일 == 당월 유효 납입일(말일 보정 동일) && 당월 납입 기록 없음
+- 공통 helper 추출: `resolveDepositDay` / `effectiveDepositDay` / `hasNoDepositThisMonth` (`isDepositOverdue`와 공유, 판정 기준 불변)
+- `isDepositOverdue`의 중복 javadoc 블록 1개 제거 (기존 파일 중복)
+- `PortfolioItemResponse`: `depositDueToday` 필드·생성자 파라미터 추가, 전체 `from` 오버로드 시그니처 확장(축약 오버로드는 null 위임) — additive, `@JsonInclude(NON_NULL)` 유지
+
+### 프런트
+
+- `portfolio.js` `checkDepositReminder`: 필터 `depositOverdue === true || depositDueToday === true` (#99 스펙 "당일 + 미납")
+- `portfolio-deposit-financial.html`: 항목별 상태 배지("미납" red / "오늘 납입일" emerald), 헤더 "납입 확인 안내"·안내 문구 당일 포함으로 조정
+
+## 변경 파일
+
+- src/main/java/.../portfolio/application/PortfolioService.java
+- src/main/java/.../portfolio/application/dto/PortfolioItemResponse.java
+- src/main/resources/static/js/components/portfolio.js
+- src/main/resources/static/partials/portfolio-deposit-financial.html
+
+## 동작 변경 (의도된 것)
+
+1. 납입일 당일 + 당월 기록 없음 → 리마인더 팝업에 "오늘 납입일"로 노출 (기존: 미노출)
+2. 이력 0건 + 납입일 경과 → 미납 배지·리마인더 정상 노출 (기존: 절대 미노출)
+3. 이력 0건 CASH 항목의 만기 예상 금액 표시 (기존: 미계산 — 같은 null 가드에 묶여 있던 부수 버그)
+4. 포트폴리오 목록 미납 배지는 기존대로 납입일 다음날부터 (불변)

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/PortfolioService.java
@@ -335,18 +335,21 @@ public class PortfolioService {
         return items.stream()
                 .map(item -> {
                     Long linkedId = finalLinkMap.get(item.getId());
-                    List<DepositHistory> deposits = finalDepositMap.get(item.getId());
                     Boolean overdue = null;
+                    Boolean dueToday = null;
                     BigDecimal maturityAmount = null;
 
-                    if (deposits != null) {
+                    // 이력 0건 항목도 판정 대상 — 빈 리스트로 폴백 (#111)
+                    if (item.getAssetType() == AssetType.CASH || item.getAssetType() == AssetType.FUND) {
+                        List<DepositHistory> deposits = finalDepositMap.getOrDefault(item.getId(), List.of());
                         overdue = isDepositOverdue(item, deposits, today);
+                        dueToday = isDepositDueToday(item, deposits, today);
                         if (item.getAssetType() == AssetType.CASH && item.getCashDetail() != null) {
                             maturityAmount = calculateMaturityAmount(item);
                         }
                     }
 
-                    return PortfolioItemResponse.from(item, linkedId, overdue, maturityAmount);
+                    return PortfolioItemResponse.from(item, linkedId, overdue, dueToday, maturityAmount);
                 })
                 .collect(Collectors.toList());
     }
@@ -1121,33 +1124,57 @@ public class PortfolioService {
 
     /**
      * 미납 여부 판정
-     * 자동납입 설정이 있고, 당월 납입일이 지났는데 당월 납입 기록이 없으면 미납
-     */
-    /**
-     * 미납 여부 판정
      * 자동납입 설정이 있고, 기준일 기준 당월 납입일이 지났는데 당월 납입 기록이 없으면 미납
      */
     public boolean isDepositOverdue(PortfolioItem item, List<DepositHistory> histories, LocalDate referenceDate) {
-        Integer depositDay = null;
-        if (item.getAssetType() == AssetType.CASH && item.getCashDetail() != null) {
-            depositDay = item.getCashDetail().getDepositDay();
-        } else if (item.getAssetType() == AssetType.FUND && item.getFundDetail() != null) {
-            depositDay = item.getFundDetail().getDepositDay();
-        }
-
+        Integer depositDay = resolveDepositDay(item);
         if (depositDay == null) {
             return false;
         }
 
-        int lastDayOfMonth = referenceDate.lengthOfMonth();
-        int effectiveDay = Math.min(depositDay, lastDayOfMonth);
-        LocalDate depositDueDate = referenceDate.withDayOfMonth(effectiveDay);
+        LocalDate depositDueDate = referenceDate.withDayOfMonth(effectiveDepositDay(depositDay, referenceDate));
 
         // 납입일 다음날부터 미납 처리
         if (!referenceDate.isAfter(depositDueDate)) {
             return false;
         }
 
+        return hasNoDepositThisMonth(histories, referenceDate);
+    }
+
+    /**
+     * 납입일 당일 여부 판정 (#111)
+     * 자동납입 설정이 있고, 기준일이 당월 납입일 당일인데 당월 납입 기록이 없으면 true — 리마인더 팝업 당일 안내용
+     */
+    public boolean isDepositDueToday(PortfolioItem item, List<DepositHistory> histories, LocalDate referenceDate) {
+        Integer depositDay = resolveDepositDay(item);
+        if (depositDay == null) {
+            return false;
+        }
+
+        if (referenceDate.getDayOfMonth() != effectiveDepositDay(depositDay, referenceDate)) {
+            return false;
+        }
+
+        return hasNoDepositThisMonth(histories, referenceDate);
+    }
+
+    private Integer resolveDepositDay(PortfolioItem item) {
+        if (item.getAssetType() == AssetType.CASH && item.getCashDetail() != null) {
+            return item.getCashDetail().getDepositDay();
+        }
+        if (item.getAssetType() == AssetType.FUND && item.getFundDetail() != null) {
+            return item.getFundDetail().getDepositDay();
+        }
+        return null;
+    }
+
+    // 말일 보정: 설정 납입일이 해당 월 일수보다 크면 말일로 당김
+    private int effectiveDepositDay(int depositDay, LocalDate referenceDate) {
+        return Math.min(depositDay, referenceDate.lengthOfMonth());
+    }
+
+    private boolean hasNoDepositThisMonth(List<DepositHistory> histories, LocalDate referenceDate) {
         LocalDate monthStart = referenceDate.withDayOfMonth(1);
         return histories.stream()
                 .noneMatch(h -> !h.getDepositDate().isBefore(monthStart)

--- a/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/PortfolioItemResponse.java
+++ b/src/main/java/com/thlee/stock/market/stockmarket/portfolio/application/dto/PortfolioItemResponse.java
@@ -28,6 +28,7 @@ public class PortfolioItemResponse {
     private final GoldDetailResponse goldDetail;
     private final Long linkedCashItemId;
     private final Boolean depositOverdue;
+    private final Boolean depositDueToday;
     private final BigDecimal expectedMaturityAmount;
 
     private PortfolioItemResponse(Long id, String assetType, String itemName,
@@ -42,6 +43,7 @@ public class PortfolioItemResponse {
                                   GoldDetailResponse goldDetail,
                                   Long linkedCashItemId,
                                   Boolean depositOverdue,
+                                  Boolean depositDueToday,
                                   BigDecimal expectedMaturityAmount) {
         this.id = id;
         this.assetType = assetType;
@@ -61,19 +63,21 @@ public class PortfolioItemResponse {
         this.goldDetail = goldDetail;
         this.linkedCashItemId = linkedCashItemId;
         this.depositOverdue = depositOverdue;
+        this.depositDueToday = depositDueToday;
         this.expectedMaturityAmount = expectedMaturityAmount;
     }
 
     public static PortfolioItemResponse from(PortfolioItem item) {
-        return from(item, null, null, null);
+        return from(item, null, null, null, null);
     }
 
     public static PortfolioItemResponse from(PortfolioItem item, Long linkedCashItemId) {
-        return from(item, linkedCashItemId, null, null);
+        return from(item, linkedCashItemId, null, null, null);
     }
 
     public static PortfolioItemResponse from(PortfolioItem item, Long linkedCashItemId,
-                                              Boolean depositOverdue, BigDecimal expectedMaturityAmount) {
+                                              Boolean depositOverdue, Boolean depositDueToday,
+                                              BigDecimal expectedMaturityAmount) {
         return new PortfolioItemResponse(
                 item.getId(),
                 item.getAssetType().name(),
@@ -93,6 +97,7 @@ public class PortfolioItemResponse {
                 item.getGoldDetail() != null ? GoldDetailResponse.from(item.getGoldDetail()) : null,
                 linkedCashItemId,
                 depositOverdue,
+                depositDueToday,
                 expectedMaturityAmount
         );
     }

--- a/src/main/resources/static/js/components/portfolio.js
+++ b/src/main/resources/static/js/components/portfolio.js
@@ -1918,9 +1918,10 @@ const PortfolioComponent = {
         try {
             if (this._depositReminderSnoozedToday()) return;
             const items = await API.getPortfolioItems(this.auth.userId) || [];
-            const overdue = items.filter((i) => i.depositOverdue === true);
-            if (overdue.length === 0) return;
-            this.portfolio.depositReminder.items = overdue;
+            // 당일(depositDueToday) + 미납(depositOverdue) 모두 안내 (#99 스펙, #111)
+            const targets = items.filter((i) => i.depositOverdue === true || i.depositDueToday === true);
+            if (targets.length === 0) return;
+            this.portfolio.depositReminder.items = targets;
             this.portfolio.depositReminder.snoozeChecked = false;
             this.portfolio.depositReminder.show = true;
         } catch (e) {

--- a/src/main/resources/static/partials/portfolio-deposit-financial.html
+++ b/src/main/resources/static/partials/portfolio-deposit-financial.html
@@ -139,18 +139,18 @@
                 </div>
             </div>
 
-            <!-- 미납 납입 리마인더 (#100) — 로그인 시 미납 항목 안내, 납입 모달(z-50)보다 아래 -->
+            <!-- 납입 확인 리마인더 (#100, #111) — 로그인 시 당일·미납 항목 안내, 납입 모달(z-50)보다 아래 -->
             <div x-show="portfolio.depositReminder.show" x-cloak
                 class="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
                 <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6"
                     @click.outside="closeDepositReminder()">
 
                     <div class="flex items-start justify-between mb-1">
-                        <h3 class="text-lg font-bold text-gray-900">미납 납입 안내</h3>
+                        <h3 class="text-lg font-bold text-gray-900">납입 확인 안내</h3>
                         <button @click="closeDepositReminder()"
                             class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
                     </div>
-                    <p class="text-sm text-gray-500 mb-4">이번 달 납입이 처리되지 않은 항목이 있습니다.</p>
+                    <p class="text-sm text-gray-500 mb-4">오늘이 납입일이거나 이번 달 납입이 처리되지 않은 항목이 있습니다.</p>
 
                     <div class="space-y-2 max-h-72 overflow-y-auto">
                         <template x-for="item in portfolio.depositReminder.items" :key="item.id">
@@ -160,6 +160,9 @@
                                         <span class="text-sm font-medium text-gray-900 truncate" x-text="item.itemName"></span>
                                         <span class="text-[11px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 shrink-0"
                                             x-text="item.assetType === 'FUND' ? '펀드' : '현금성'"></span>
+                                        <span class="text-[11px] px-1.5 py-0.5 rounded shrink-0"
+                                            :class="item.depositOverdue === true ? 'bg-red-100 text-red-600' : 'bg-emerald-100 text-emerald-700'"
+                                            x-text="item.depositOverdue === true ? '미납' : '오늘 납입일'"></span>
                                     </div>
                                     <div class="text-xs text-gray-500 mt-0.5" x-text="depositReminderMeta(item)"></div>
                                 </div>


### PR DESCRIPTION
Closes #111

## 요약

리마인더 팝업 대상을 #99 확정 스펙 **"당일 + 미납"**으로 확장한다. 오늘이 납입일인 항목(당월 기록 없음)이 팝업에 "오늘 납입일" 배지로 노출되고, 납입 이력이 0건인 항목이 미납 판정에서 아예 빠지던 null 가드 버그를 수정한다. 포트폴리오 목록의 미납 배지는 기존 의미(납입일 다음날부터) 유지.

## 주요 변경

### 백엔드
- `PortfolioService.isDepositDueToday` 신설 — 기준일 == 당월 유효 납입일(말일 보정 동일) && 당월 납입 기록 없음
- `getItems`: CASH/FUND 항목은 `getOrDefault(빈 리스트)`로 이력 0건이어도 항상 판정 (기존: 이력 ≥1건만) — 만기 예상 금액도 동일 가드 해제
- 공통 helper 추출(`resolveDepositDay`/`effectiveDepositDay`/`hasNoDepositThisMonth`) — 미납 판정 기준 불변
- `PortfolioItemResponse.depositDueToday` additive 추가

### 프런트
- `checkDepositReminder` 필터: `depositOverdue || depositDueToday`
- 팝업 항목별 상태 배지("미납" red / "오늘 납입일" emerald), 헤더 "납입 확인 안내"·문구 조정

## 검증

- `./gradlew test` **117/117 PASS** (로컬 PostgreSQL 가동, contextLoads 포함)
- 브라우저 목 하네스(실제 portfolio.js·리마인더 마크업 + Alpine): 당일 배지·미납 배지·비대상 제외·[납입] 클릭 흐름·스누즈 저장/재노출 전 시나리오 PASS
- 미검증(배포 후 확인): 실서버 로그인 경로 노출, 실데이터 기준 당일 판정·이력 0건 배지

## 문서

- docs/{brainstorms,issues,plans,works,reviews,validations,commits,pushes,gates}/2026-08-10-deposit-reminder-due-today-*

🤖 Generated with [Claude Code](https://claude.com/claude-code)